### PR TITLE
fix: a bug when choosing agents

### DIFF
--- a/arknights_mower/utils/segment.py
+++ b/arknights_mower/utils/segment.py
@@ -408,6 +408,10 @@ def agent(img, draw=False):
         gap = [y - x for x, y in zip(x_set[:-1], x_set[1:])]
         logger.debug(sorted(gap))
         gap = int(np.median(gap))  # 干员卡片宽度
+        
+        gap_max = 190 * (resolution / 1080)  # 卡片宽度上限, 防止存在将两个干员的名字拼在一起（例如“缄默德克萨斯"出现时）
+        gap = gap_max if gap > gap_max else gap
+        
         for x, y in zip(x_set[:-1], x_set[1:]):
             if y - x > gap:
                 gap_num = round((y - x) / gap)


### PR DESCRIPTION
There is a bug when choosing agents since we did not restrict the max width of agent name segmentation:
When "缄默德克萨斯" (an extremely long name) comes up, the system will combine it with the agent name in front of it. 
Then the system can not find the specified agent.

Given ```draw=True```, the image is generated by https://github.com/Konano/arknights-mower/blob/ae1b816781f641f7f52842c341a86859fffaa67e/arknights_mower/utils/segment.py#L339 
![6701670696938_ pic_hd](https://user-images.githubusercontent.com/79753202/206871799-f541ecc7-785a-4563-be71-aa94cc8dbcc1.jpg)
