### PR TITLE
修复了在蓝叠模拟器、逍遥模拟器等平台中运行程序时，在干员选择过程中可能出现的图像处理错误的问题

### DIFF
--- a/arknights_mower/utils/character_recognize.py
+++ b/arknights_mower/utils/character_recognize.py
@@ -141,8 +141,8 @@ def agent(img, draw=False):
         # 去除左侧干员详情
         x0 = left + 1
         while not (
-            img[height - 1, x0 - 1, 0] > img[height - 1, x0, 0] + 10
-            and abs(int(img[height - 1, x0, 0]) - int(img[height - 1, x0 + 1, 0])) < 5
+            img[height - 10, x0 - 1, 0] > img[height - 10, x0, 0] + 10
+            and abs(int(img[height - 10, x0, 0]) - int(img[height - 10, x0 + 1, 0])) < 5
         ):
             x0 += 1
 

--- a/arknights_mower/utils/segment.py
+++ b/arknights_mower/utils/segment.py
@@ -350,8 +350,8 @@ def agent(img, draw=False):
 
         # 去除左侧干员详情
         x0 = left + 1
-        while not (img[ height - 1, x0 - 1, 0 ] > img[ height - 1, x0, 0 ] + 10 and abs(
-                int(img[ height - 1, x0, 0 ]) - int(img[ height - 1, x0 + 1, 0 ])) < 5):
+        while not (img[ height - 10, x0 - 1, 0 ] > img[ height - 10, x0, 0 ] + 10 and abs(
+                int(img[ height - 10, x0, 0 ]) - int(img[ height - 10, x0 + 1, 0 ])) < 5):
             x0 += 1
 
         # ocr 初步识别干员名称
@@ -463,8 +463,8 @@ def free_agent(img, draw=False):
 
         # 去除左侧干员详情
         x0 = left + 1
-        while not (img[ height - 1, x0 - 1, 0 ] > img[ height - 1, x0, 0 ] + 10 and abs(
-                int(img[ height - 1, x0, 0 ]) - int(img[ height - 1, x0 + 1, 0 ])) < 5):
+        while not (img[ height - 10, x0 - 1, 0 ] > img[ height - 10, x0, 0 ] + 10 and abs(
+                int(img[ height - 10, x0, 0 ]) - int(img[ height - 10, x0 + 1, 0 ])) < 5):
             x0 += 1
 
         # 获取分割结果


### PR DESCRIPTION
个别平台中（如蓝叠模拟器、逍遥模拟器）的安卓截图输出最上一行的像素块为全黑，而选择干员时需要通过最上一行的像素进行判断，以对识别到的图像进行操作，进而出现错误。这一度成为Mower脚本兼容蓝叠模拟器和逍遥模拟器的核心问题，而通过这次的修改可以完全解决这一问题。