### PR TITLE
feat: 给PySimpleGUI菜单追加是否闲置时关闭游戏的选项

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -184,6 +184,11 @@ def menu():
 
     start_automatically = sg.Checkbox('启动mower时自动开始任务', default=conf['start_automatically'],
                                       key='conf_start_automatically', enable_events=True)
+    
+    exit_game_when_idle = sg.Checkbox('距下次任务闲置超过5分钟时退出游戏', default=conf['exit_game_when_idle'],
+                                      key='conf_exit_game_when_idle', enable_events=True)
+    
+
     # --------外部调用设置页面
     # mail
     mail_enable_1 = sg.Radio('启用', 'mail_enable', default=conf['mail_enable'] == 1,
@@ -266,7 +271,7 @@ def menu():
                              [exhaust_require_title, exhaust_require],
                              [workaholic_title, workaholic],
                              [resting_priority_title, resting_priority],
-                             [start_automatically],
+                             [start_automatically, exit_game_when_idle],
                          ], pad=((10, 10), (10, 10)))
 
     other_tab = sg.Tab('  外部调用 ',


### PR DESCRIPTION
目前引入闲置时关闭游戏功能后，macOS上显示器休眠时mower无法按原计划执行任务（到原定下一次任务的时间后mower无输出也无反应，只有手动启动方舟后一段时间mower才开始继续工作，或者手动重启mower），疑似原因为无法正确启动方舟？仍在排查中，总之先加一个关闭的选项，关闭这个功能后可以恢复正常运行