### PR TITLE
纯跑单任务开始时先返回主页

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,7 @@ dmypy.json
 ###JetBrains Product###
 .idea/*
 
+### 命令行运行产生的/tmp/data.db
+/tmp/
+
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode

--- a/纯跑单.py
+++ b/纯跑单.py
@@ -59,7 +59,6 @@ Bilibili服务器 = 'com.hypergryph.arknights.bilibili'
 日志存储目录 = './log'
 截图存储目录 = './screenshot'
 每种截图的最大保存数量 = 10
-跑单前铃声提醒开关 = 开  # 跑单前铃声提醒开关，仅在 Windows 平台有效
 任务结束后退出游戏 = 开
 
 # 设置贸易站的房间以及跑单干员的具体位置

--- a/纯跑单.py
+++ b/纯跑单.py
@@ -283,7 +283,6 @@ class 基建求解器(BaseSolver):
         self.run_order_rooms = {}
 
     def run(self) -> None:
-        self.back_to_index()
         self.error = 关
         if len(self.任务列表) == 0:
             self.recog.update()
@@ -1299,6 +1298,8 @@ def 运行():
                         if sleep_time > 300:
                             基建状态.device.exit(基建状态.服务器)
                     time.sleep(sleep_time)
+                    if sleep_time > 300:
+                        基建状态.back_to_index()
 
             if len(基建状态.任务列表) > 0 and 基建状态.任务列表[0].type.split('_')[0] == 'maa':
                 基建状态.maa_plan_solver((基建状态.任务列表[0].type.split('_')[1]).split(','),

--- a/纯跑单.py
+++ b/纯跑单.py
@@ -1287,7 +1287,7 @@ def 运行():
                     logger.warning("※请注意手动换班后记得重新运行程序※")
                     for i in range(len(任务列表)):
                         logger.warning(任务列表[i].type + ' 开始跑单的时间为：' + 任务列表[i].time.strftime("%H:%M:%S"))
-                    logger.warning(f'休息{sleep_time // 60}分{sleep_time % 60:.0f}秒')
+                    logger.warning(f'休息{int(sleep_time / 60)}分{sleep_time % 60:.0f}秒')
 
                 # 如果有高强度重复任务,任务间隔时间超过10分钟则启动MAA
                 if (MAA设置['集成战略'] or MAA设置['生息演算']) and (sleep_time > 600):


### PR DESCRIPTION
修复了 #249 
在开始任务时先返回主页，重新进基建

对于 #250 
选择暂时回避
考虑到有ui接入纯跑单的计划
直接删除了铃声相关代码