### PR TITLE
优化日志输出

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -863,7 +863,7 @@ class BaseSchedulerSolver(BaseSolver):
                 img = cv2.vconcat([img, img])
         try:
             self.initialize_paddle()
-            rets = ocr.ocr(img, cls=True)
+            rets = ocr.ocr(img, cls=False)
             line_conf = []
             for idx in range(len(rets[0])):
                 res = rets[0][idx]


### PR DESCRIPTION
由于没有读取旋转过180°图片的需求，调用paddleocr时cls选择False，进而避免出现ppocr WARNING: Since the angle classifier is not initialized...的警告