### PR TITLE
仓库 页面改动

### DIFF
--- a/arknights_mower/utils/depot.py
+++ b/arknights_mower/utils/depot.py
@@ -7,29 +7,25 @@ import os
 from arknights_mower.data import key_mapping
 
 depot_file = os.path.join("tmp", "itemlist.csv")
-current_datetime = datetime.datetime.now()
-
 
 def process_itemlist(d):
-    itemlist = {"时间": current_datetime, "data": {key: 0 for key in key_mapping.keys()}}
+    itemlist = {"时间": datetime.datetime.now(), "data": {key: 0 for key in key_mapping.keys()}}
 
-    if d.get("what") == "DepotInfo" and d["details"].get("done") is True:
-        itemlist["data"] = json.loads(d["details"]["lolicon"]["data"])
+    itemlist["data"] = json.loads(d["details"]["lolicon"]["data"])
 
-        # Check if file exists, if not, create the file
-        if not os.path.exists(depot_file):
-            with open(depot_file, "w", newline="", encoding="utf-8") as csvfile:
-                fieldnames = ["时间", "data"]
-                writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-                writer.writeheader()
-                writer.writerow({"时间": current_datetime, "data": '{"空":0}'})
+    # Check if file exists, if not, create the file
+    if not os.path.exists(depot_file):
+        with open(depot_file, "w", newline="", encoding="utf-8") as csvfile:
+            fieldnames = ["时间", "data"]
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerow({"时间": datetime.datetime.now(), "data": '{"空":0}'})
 
         # Append data to the CSV file
-        with open(depot_file, "a", newline="", encoding="utf-8") as csvfile:
-            fieldnames = itemlist.keys()
-            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-            writer.writerow(itemlist)
-
+    with open(depot_file, "a", newline="", encoding="utf-8") as csvfile:
+        fieldnames = itemlist.keys()
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writerow(itemlist)
 
 def read_and_compare_depots():
     def format_data(depot_data):
@@ -84,7 +80,7 @@ def read_and_compare_depots():
             fieldnames = ["时间", "data"]
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
             writer.writeheader()
-            writer.writerow({"时间": current_datetime, "data": '{"空":0}'})
+            writer.writerow({"时间": datetime.datetime.now(), "data": '{"空":0}'})
     with open(depot_file, "r", encoding="utf-8") as csvfile:
         csvreader = csv.reader(csvfile)
         all_rows = list(csvreader)

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -61,12 +61,21 @@
                   role="dialog"
                   aria-modal="true"
                 >
-                  <n-button @click=";(showModal = false), $router.push('/record/line')">
-                    心情曲线
-                  </n-button>
-                  <n-button @click=";(showModal = false), $router.push('/record/pie')">
-                    心情饼图
-                  </n-button>
+                  <div>
+                    <n-button @click=";(showModal = false), $router.push('/record/line')">
+                      心情曲线
+                    </n-button>
+                  </div>
+                  <div>
+                    <n-button @click=";(showModal = false), $router.push('/record/pie')">
+                      心情饼图
+                    </n-button>
+                  </div>
+                  <div>
+                    <n-button @click=";(showModal = false), $router.push('/record/depot')">
+                      仓库
+                    </n-button>
+                  </div>
                 </n-card>
               </n-modal>
             </n-tab>

--- a/ui/src/pages/depot.vue
+++ b/ui/src/pages/depot.vue
@@ -1,9 +1,24 @@
 <template>
   <div>
-    <n-button @click="copyToClipboard">明日方舟工具箱代码 {{ reportData[4] }}</n-button>
+    <n-button @click="copyToClipboard"> 明日方舟工具箱代码</n-button>
   </div>
-  <h2>注：仅限MAA仓库扫描</h2>
-  <div>仓库变化{{ reportData[2] }}</div>
+  <div>这次扫描在{{ time }},下次扫描在{{ maa_gap }}小时之后。</div>
+  <div>注：目前仅限MAA仓库扫描</div>
+  <n-button @click="showModal = true"> 仓库变化 </n-button>
+
+  <n-modal v-model:show="showModal">
+    <n-card
+      style="width: 600px"
+      title="仓库变化："
+      :bordered="false"
+      size="huge"
+      role="dialog"
+      aria-modal="true"
+    >
+      {{ reportData[2] }}
+    </n-card>
+  </n-modal>
+
   <div class="card-container">
     <n-grid x-gap="10px" y-gap="10px" cols="2 s:4 m:5 l:6 xl:8 2xl:10" responsive="screen">
       <n-gi v-for="(key, item, index) in reportData[1]" content-indented="true">
@@ -27,6 +42,32 @@
 </style>
 
 <script setup>
+import { ref, onMounted } from 'vue'
+import { useConfigStore } from '@/stores/config'
+const store = useConfigStore()
+import { storeToRefs } from 'pinia'
+const { maa_gap } = storeToRefs(store)
+
+//模态框
+const showModal = ref(false)
+
+//进入网页就拿参数
+document.addEventListener('DOMContentLoaded', async function () {
+  await axios.get(`${import.meta.env.VITE_HTTP_URL}/depot/readdepot`)
+})
+//拿参数 实时同步参数
+import { usedepotStore } from '@/stores/depot'
+
+const depotStore = usedepotStore()
+const { getDepotinfo } = depotStore
+const reportData = ref([])
+const time = ref('')
+onMounted(async () => {
+  reportData.value = await getDepotinfo()
+  time.value = reportData.value[4].slice(0, -7)
+})
+
+//复制到剪贴板
 const copyToClipboard = async () => {
   try {
     await navigator.clipboard.writeText(reportData.value[3])
@@ -35,23 +76,6 @@ const copyToClipboard = async () => {
     console.error('Failed to copy text:', err)
   }
 }
-import { ref, onMounted } from 'vue'
-
-import { usedepotStore } from '@/stores/depot'
-
-const depotStore = usedepotStore()
-const { getDepotinfo } = depotStore
-
-// Mock report data
-const reportData = ref([])
-const depotinfo = reportData[0]
-onMounted(async () => {
-  reportData.value = await getDepotinfo()
-})
-
-document.addEventListener('DOMContentLoaded', async function () {
-  await axios.get(`${import.meta.env.VITE_HTTP_URL}/depot/readdepot`)
-})
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
把时间从current_datetime 改为 datetime.datetime.now()
给移动端也用上“仓库”页面
把“仓库变化”塞到模态框里（暂时没有画图，不知到差距太大的时候怎么画）
稍微整理一下depot.vue的变量们的顺序