### PR TITLE
增加match success条件，纠错任务调整

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -829,9 +829,8 @@ class BaseSchedulerSolver(BaseSolver, BaseMixin):
                         fix_plan[moved_room] = ["Current"] * len(
                             self.op_data.plan[moved_room]
                         )
-                    fix_plan[moved_room][moved_index] = self.op_data.plan[moved_room][
-                        moved_index
-                    ].agent
+                    for index in range(len(self.op_data.plan[moved_room])):
+                        fix_plan[moved_room][index] = self.op_data.plan[moved_room][index].agent
         if len(fix_plan.keys()) > 0:
             # 不能在房间里安排同一个人 如果有重复则换成Free
             remove_keys = []

--- a/arknights_mower/utils/matcher.py
+++ b/arknights_mower/utils/matcher.py
@@ -75,7 +75,7 @@ class Matcher(object):
             logger.debug(f'match fail: {rect_score}')
             return None  # failed in matching
         else:
-            if prescore>0 and score[3]<prescore:
+            if (prescore>0 and score[3]<prescore) or score[1]<=0.1:
                 logger.debug(f'score is not greater than {prescore}: {rect_score}')
                 return None
             logger.debug(f'match success: {rect_score}')


### PR DESCRIPTION
match success条件增加要求score[1]大于0.1，宿舍误触bug中均出现该项小于0.1但判定为match success的日志。
当纠错任务为排序任务时，重排整个工作站，否则，从[c,a,b]纠错为[a,b,c]生成的纠错任务为[a,current,c]，实际为[a,a,c]。