### PR TITLE
修复 误触进入充值页面

### DIFF
--- a/arknights_mower/utils/solver.py
+++ b/arknights_mower/utils/solver.py
@@ -410,7 +410,6 @@ class BaseSolver:
                     self.tap((100, 60))
                 elif scene == Scene.ANNOUNCEMENT:
                     self.tap(detector.announcement_close(self.recog.img))
-                    self.tap((1800,100))
                 elif scene == Scene.MATERIEL:
                     self.tap_element('materiel_ico')
                 elif scene // 100 == 1:


### PR DESCRIPTION
- [ ] 没有后续退出功能
- [ ] 单页面循环识别的重启也没有触发