### PR TITLE
新线索 Bug Fix

### DIFF
--- a/arknights_mower/solvers/__init__.py
+++ b/arknights_mower/solvers/__init__.py
@@ -1,0 +1,34 @@
+from mower.solvers.shop import CreditShop
+from mower.utils.log import logger
+
+from .daily import DailySolver
+from .get_clue_count import GetClueCountSolver
+from .give_away import GiveAwaySolver
+from .party_time import PartyTimeSolver
+from .place import PlaceSolver
+from .receive import ReceiveSolver
+
+
+class ClueManager:
+    solver_name = "线索交流"
+
+    def run(self):
+        logger.info("基建：线索")
+
+        clue_count = GetClueCountSolver().run()
+        if clue_count > 9:
+            DailySolver().run()
+
+        ReceiveSolver().run()
+
+        PlaceSolver().run()
+
+        GiveAwaySolver().run(clue_count)
+
+        DailySolver().run()
+
+        self.party_time = PartyTimeSolver().run()
+
+        CreditShop().run()
+
+        return True

--- a/arknights_mower/solvers/__init__.py
+++ b/arknights_mower/solvers/__init__.py
@@ -16,7 +16,7 @@ class ClueManager:
         logger.info("基建：线索")
 
         clue_count = GetClueCountSolver().run()
-        if clue_count > 9:
+        if clue_count <= 9:
             DailySolver().run()
 
         ReceiveSolver().run()

--- a/server.py
+++ b/server.py
@@ -545,6 +545,8 @@ def get_count():
     from arknights_mower.utils.operators import SkillUpgradeSupport
     from arknights_mower.utils.scheduler_task import SchedulerTask, TaskTypes
 
+    #
+
     if request.method == "POST":
         try:
             req = request.json

--- a/server.py
+++ b/server.py
@@ -545,8 +545,6 @@ def get_count():
     from arknights_mower.utils.operators import SkillUpgradeSupport
     from arknights_mower.utils.scheduler_task import SchedulerTask, TaskTypes
 
-    #
-
     if request.method == "POST":
         try:
             req = request.json


### PR DESCRIPTION
麻烦各位大佬看一下，我用的code base source from：https://git.zhaozuohong.vip/mower-ng/mower-ng 
这个repo和github的repo不太一样，但是苦于没有办法联系到repo owner，对于Forgejo不是很熟悉没有账号无法contribute，只能在这里post PR。
实际的code update route 应该是：mower-ng\mower\solvers\infra\clue\__init__.py : ClueManager

---

**标题:** 修复线索满时无法收集每日线索的 bug

**描述:**
根据 Issue #557 “新线索” Bug-3 的修复。当线索数量满时，"DailySolver" 无法收集每日线索。旧代码中，`DailySolver.run()` 被调用在 `GiveAwaySolver` 和 `GetClueCountSolver` 之前，导致如果线索数量已满时，无法收集每日线索。

**变更内容:**
- 根据我自己的游玩经验更新了操作顺序：1. 首先收集朋友线索 (`GiveAwaySolver`)； 2. 接着赠送线索 (`GiveAwaySolver`)；3. 最后收集每日线索 (`DailySolver`)。
- 考虑到不同玩家需求，如果线索数量未满，`DailySolver.run()` 将在 `GiveAwaySolver` 之前调用以收集每日线索（DailySolver 会被call两次）

**Title:** Fix bug where daily clues cannot be collected when clue count is full

---


**Description:**
This update fixes the issue where the "DailySolver" cannot collect daily clues when the clue count is full (i.e., 10). In the old code, `DailySolver.run()` was called before `GiveAwaySolver` and `GetClueCountSolver`, preventing the collection of daily clues if the clue count was full. 

**Changes:**
- The sequence of operations has been updated:
  1. First, we collect the clues from friends (`GiveAwaySolver`).
  2. Next, we give away the clues (`GiveAwaySolver`).
  3. Finally, we collect the daily clues (`DailySolver`), but only if the clue count is not full (<= 9).
- If the clue count is not full, `DailySolver.run()` will still be called before `GiveAwaySolver` to collect the daily clues.

This fix ensures that the system will always collect daily clues when the clue count is not full and gives priority to giving away clues when necessary.