### PR TITLE
修复不养闲人任务合并

### DIFF
--- a/arknights_mower/utils/scheduler_task.py
+++ b/arknights_mower/utils/scheduler_task.py
@@ -220,10 +220,7 @@ def generate_plan_by_drom(tasks, op_data):
             if rest_in_full is None and not op_data.config.free_room:
                 continue
             for idx in range(len(result) - 1, -1, -1):
-                interval = config.conf.merge_interval
-                if result[idx].time < time - timedelta(
-                    minutes=interval if rest_in_full is None else 3 * interval
-                ):
+                if result[idx].time < time:
                     break
                 if result[idx].type == (
                     TaskTypes.RELEASE_DORM
@@ -259,6 +256,8 @@ def generate_plan_by_drom(tasks, op_data):
                         else TaskTypes.SHIFT_ON,
                     )
                 )
+    interval = config.conf.merge_interval
+    merge_release_dorm(result, interval)
     logger.debug("生成任务: " + ("||".join([str(t) for t in result])))
     return result
 


### PR DESCRIPTION
原来的合并逻辑中的interval改为0，相当于不进行合并，在任务生成后调用以前的合并函数