### PR TITLE
声明：以下两个文件基于2025.5.3beta修改 可能有部分代码未同步最新，注意甄别；

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -2543,7 +2543,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             for agent in agents:
                 if agent != "阿米娅" and agent:
                     logger.debug(f"检测到{agent}选择时间过长，自动使用职介筛选")
-                    self.op_data.profession_filter.add(agent)
+                    self.op_data.profession_filter.append(agent) #使用add报错 修改为append
         if not self.verify_agent(agents):
             logger.debug(agents)
             raise Exception("检测到干员选择错误，重新选择")

--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -52,6 +52,9 @@ from arknights_mower.utils.scheduler_task import (
 from arknights_mower.utils.trading_order import TradingOrder
 
 
+
+
+
 class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
     """
     收集基建的产物：物资、赤金、信赖
@@ -1055,27 +1058,37 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         break
             if valid:
                 # 处理龙舌兰/但书/佩佩的插拔
-                for k, v in self.op_data.run_order_rooms.items():
+                run_order_rooms =self.op_data.run_order_rooms
+                for k, v in run_order_rooms.items():
                     self.plan_run_order(k)
-                adj_task = scheduling(self.tasks)
+                adj_tasks = scheduling(self.tasks) #修改scheduling 同时输出撞在一起的前后两个任务
                 max_execution = 3
                 adj_count = 0
-                while adj_task is not None and adj_count < max_execution:
-                    adjust_room = adj_task.meta_data
-                    # 如果加速房间为跑单房间，则优先使用
-                    if self.drone_room in self.op_data.run_order_rooms:
-                        adjust_room = self.drone_room
-                    else:
-                        lowest_room = next(iter(self.op_data.run_order_rooms.keys()))
-                        for room in self.op_data.run_order_rooms:
-                            if len(self.op_data.plan[room]) < len(
-                                self.op_data.plan[lowest_room]
-                            ):
-                                lowest_room = room
-                        adjust_room = lowest_room
-                    self.drone(adjust_room, adjust_time=True)
-                    adj_task = scheduling(self.tasks)
+
+                if run_order_rooms is not None and len(run_order_rooms) >= 3:
+                    n = len(run_order_rooms)
+                    dp = [0] * (n + 1)
+                    dp[1] = 0
+                    if n >1:
+                        dp[2] = 1
+                    for i in range(3, n + 1):
+                        dp[i] = 3 * dp[i - 1] + 2 * dp[i - 2]
+                    max_execution = min (dp[n] * 1.25,15) #通过跑单房间计算得到循环次数 同时限制最大次数
+                    logger.debug(f'max_execution = {max_execution}')
+                    logger.info(run_order_rooms)
+                    logger.info(f'当前跑单房间数量为：{n}，计算最大循环次数为: {max_execution+1}')
+                while adj_tasks is not None and adj_count <= max_execution: #由于改动会增加触发次数 改为<= 多触发一次
+                    # logger.error("<UNK>,<UNK>")
+                    adjust_0_room = self.get_run_order_adjust_room(adj_tasks) #抽离成单独的
+                    if adjust_0_room is None:
+                        logger.error(f'adjust_0_room的结果为：{adjust_0_room}，获取跑单房间失败，停止循环')
+                        return
+                    is_run=self.drone(adjust_0_room, adjust_time=True)
+                    adj_tasks = scheduling(self.tasks)
                     adj_count += 1
+                    logger.info(f'第{adj_count}次循环结束')
+                    if is_run is not None and is_run == False:
+                        return
         fia_plan, fia_room = self.check_fia()
         if fia_room is not None and fia_plan is not None:
             if self.find_next_task(task_type=TaskTypes.FIAMMETTA) is None:
@@ -1179,6 +1192,43 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     # 如果是生成的过去时间，则停止 plan 其他
                     if _time < datetime.now():
                         break
+    #根据优先级获取跑单冲突时应该要加速的房间
+    def get_run_order_adjust_room(self, adj_tasks):
+        #此处出异常会一直运行，抛出None会终止循环，下面还没考虑过会出什么问题，可自行添加
+        try:
+            adj_0_task, adj_task = adj_tasks
+        except TypeError:
+            return None
+        adjust_0_room = adj_0_task.meta_data
+        adjust_room = adj_task.meta_data
+        # 如果加速房间为跑单房间，则优先使用
+        drone_room = self.drone_room
+        if any(task.meta_data == drone_room for task in adj_tasks):
+            logger.info('检测到加速房间在冲突的跑单任务中，直接采用')
+            adjust_0_room = drone_room
+        else:
+            logger.info('开始比较跑单任务')
+            run_order_rooms = self.op_data.run_order_rooms
+            logger.debug(f'run_order_rooms：{run_order_rooms}')
+            logger.debug(f'adjust_0_room：{adjust_0_room}')
+            logger.debug(f'adjust_room：{adjust_room}')
+
+            adjust_0_room_len = len(self.op_data.plan[adjust_0_room])  # 跑单任务首个
+            adjust_room_len = len(self.op_data.plan[adjust_room])  # 跑单任务第二个
+            # 正常情况按照82算法 1>3>2 进行加速
+            # 如果 adjust_0_room 为 2 adjust_room 为 3 则是 2>3, 两者收益比较接近，先加速前面的订单可能更优，故保留特性
+            if adjust_0_room_len == 3 and adjust_room_len != 1:  # 参考82算法 优先加速3级
+                logger.debug(f'adjust_0_room_len ===> {adjust_0_room_len}')
+                logger.debug(f'adjust_room_len ===> {adjust_room_len}')
+            elif adjust_0_room_len > adjust_room_len:  # 如果首个任务房间比第二个大 #参考82算法
+                adjust_0_room = adjust_room
+                adjust_0_room_len = adjust_room_len
+            logger.info(f'加速房间 :{adjust_0_room}')
+            logger.info(f'加速房间长度 :{adjust_0_room_len}')
+
+        # return adjust_0_room , adjust_0_room_len
+        return adjust_0_room
+
 
     def plan_solver(self):
         # 准备数据
@@ -1887,24 +1937,39 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
     def adjust_order_time(self, accelerate, room):
         error_count = 0
         action_required_task = scheduling(self.tasks)
-        while action_required_task:
+        # logger.error(f"action_required_task:{action_required_task}")
+        logger.debug(f"room:{room}")
+        logger.debug(any(task.meta_data == room for task in action_required_task))
+        # while  action_required_task is not None and any(task.meta_data == room for task in action_required_task):
+
+        #设置为每次循环都验证一次当前房间 是否适合加速
+        while  action_required_task is not None and self.get_run_order_adjust_room(action_required_task) == room:
+            #如果不加判断 在无人机为0时将会一直触发循环 暂时设置默认值为20 可以考虑动态值
+            drone_count = self.digit_reader.get_drone(self.recog.gray)
+            logger.info(f"当前无人机数量为：{drone_count}")
+            if drone_count <= 20:
+                logger.error(f"无人机数量不足无法加速")
+                # 看订单加速本体触发的频率，考虑到无人机回复较慢暂时先不加延迟触发了
+                return False
             self.tap(accelerate)
             if self.scene() in self.waiting_scene:
                 if not self.waiting_solver():
-                    return
+                    return None
             self.tap((self.recog.w * 1320 // 1920, self.recog.h * 502 // 1080))
             if self.scene() in self.waiting_scene:
                 if not self.waiting_solver():
-                    return
+                    return None
             self.tap((self.recog.w * 3 // 4, self.recog.h * 4 // 5))
             if self.scene() in self.waiting_scene:
                 if not self.waiting_solver():
-                    return
+                    return None
+
             while self.find("bill_accelerate") is None:
                 if error_count > 5:
                     raise Exception("未成功进入订单界面")
                 self.tap((self.recog.w // 20, self.recog.h * 19 // 20), interval=1)
                 error_count += 1
+
             _time = self.double_read_time(
                 (
                     (self.recog.w * 650 // 2496, self.recog.h * 660 // 1404),
@@ -1923,6 +1988,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 action_required_task = scheduling(self.tasks)
             else:
                 break
+        return None
 
     def drone(
         self,
@@ -2006,7 +2072,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         break
                 accelerate = self.find("bill_accelerate")
             if adjust_time:
-                self.adjust_order_time(accelerate, room)
+                return self.adjust_order_time(accelerate, room)
         if not_return:
             return
         self.scene_graph_navigation(Scene.INFRA_MAIN)

--- a/arknights_mower/utils/scheduler_task.py
+++ b/arknights_mower/utils/scheduler_task.py
@@ -114,7 +114,7 @@ def scheduling(tasks, run_order_delay=5, execution_time=0.75, time_now=None):
                         and time_now < last_priority_0_task.time
                     ):
                         logger.info("检测到跑单任务过于接近，准备修正跑单时间")
-                        return last_priority_0_task
+                        return last_priority_0_task, task
                 # 更新上一个优先级0任务和总执行时间
                 last_priority_0_task = task
                 total_execution_time = 0


### PR DESCRIPTION
同时代码修改基于且仅注重这一部分功能，较少考虑全局其它地方是否有调用相关代码，注意甄别；
个人习惯导致info日志输出比较频繁，可以适当控制数量；

scheduler_task中的修改:
1.设置TaskTypes类下的scheduling，在跑单冲突时,同时输出冲突的两个任务

base_schedule中的修改:
1.优化跑单房间相近时的加速设置，加速优先级默认3>1>2;
1.2.有一个情况会出现2>3(触发条件看新增注释),经过加速收益讨论觉得合理故保留;

2.设置BaseSchedulerSolver类下的adjust_order_time:
2.1.新增无人机数量检测，默认20，<=就停止当前加速任务;
2.2.修改while条件，每次运行都会查询当前房间是否值得加速，贸易站过多会增加运行时间，有需求未来会优化运行时长;

3.新增get_run_order_adjust_room负责传入adj_tasks = scheduling(self.tasks)获取的两个订单冲突任务，以获取应该被加速的订单房间