### PR TITLE
去除九色鹿暴击后误发的报错邮件

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -994,6 +994,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             inf_material = "基建材料"
             gap = 0
             start_time = datetime.now()
+            9colored_crit = False
             while tasks:
                 if datetime.now() - start_time > timedelta(
                     minutes=5
@@ -1042,6 +1043,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                                     logger.info(
                                         "检测到九色鹿即将暴击，即将切换成暴击用材料"
                                     )
+                                    9colored_crit = True
                                     continue
                             if gap >= 5:
                                 if material_tab != inf_material:
@@ -1095,11 +1097,14 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         self.back()
                     else:
                         if not tab_queue:
-                            logger.info("没有任何材料满足条件，任务结束")
-                            send_message(
-                                f"找不到任何满足{agent}的加工站材料，请及时更新设置",
-                                level="WARNING",
-                            )
+                            if not 9colored_crit:
+                                logger.info("没有任何材料满足条件，任务结束")
+                                send_message(
+                                    f"找不到任何满足{agent}的加工站材料，请及时更新设置",
+                                    level="WARNING",
+                                )
+                            else:
+                                logger.info("暴击材料合成完毕，九色鹿返回休息")
                             tasks = []
                             continue
                         tab, item_list = tab_queue.popleft()


### PR DESCRIPTION
九色鹿暴击合成结束且暴击后心情>4，理论上应该重新寻找垫刀材料，但由于已经在材料list底部，会导致误发"找不到任何满足{agent}的加工站材料，请及时更新设置"的warning邮件。反正九色鹿会回宿舍，回满会继续垫刀，先把邮件disable吧。