### PR TITLE
fix: 加固 read_log WebSocket 推送，避免日志线程挂死

### DIFF
--- a/server.py
+++ b/server.py
@@ -109,15 +109,33 @@ def read_log():
     global ws_connections
 
     while True:
-        msg = config.log_queue.get()
-        log_lines.append(msg)
-        log_lines = log_lines[-100:]
-        for ws in ws_connections:
-            ws.send(
-                json.dumps(
-                    {"type": "log", "data": msg, "screenshot": get_latest_screenshot()}
-                )
+        # 推送线程绝不能死：死连接 send / 启动期 NameError 都会让 WebUI 日志永久冻结
+        try:
+            msg = config.log_queue.get()
+            log_lines.append(msg)
+            log_lines = log_lines[-100:]
+            from arknights_mower.utils.log import last_screenshot
+
+            payload = json.dumps(
+                {
+                    "type": "log",
+                    "data": msg,
+                    "screenshot": last_screenshot or "",
+                }
             )
+            dead = []
+            for ws in list(ws_connections):
+                try:
+                    ws.send(payload)
+                except Exception:
+                    dead.append(ws)
+            for ws in dead:
+                try:
+                    ws_connections.remove(ws)
+                except ValueError:
+                    pass
+        except Exception:
+            time.sleep(0.1)
 
 
 Thread(target=read_log, daemon=True).start()


### PR DESCRIPTION
## 问题

`read_log` 后台线程负责把日志推到 WebUI。任一异常都会让线程退出，之后 WebUI 日志永久冻结：

1. 客户端断开后 `ws.send` 抛错 → 整段循环中断
2. 启动早期调用 `get_latest_screenshot()` 时，相关符号/状态可能尚未就绪 → `NameError` 等
3. 外层无保护，任意一次异常即杀死推送线程

## 改动

`server.py` `read_log()`：

- 每个 `ws.send` 包 try，失败连接从 `ws_connections` 移除
- 截图改为直接读 `arknights_mower.utils.log.last_screenshot`（缺省 `""`）
- 整轮循环再包 try + 短暂 sleep，保证线程不退出

## 测试

- [ ] 打开 WebUI 日志流正常
- [ ] 刷新/关闭页面后服务端不再因死连接中断日志推送
- [ ] 启动初期也能持续推送日志（无截图时 screenshot 为空串）

手机端已同步并重启验证。