### PR TITLE
fix(build): changelog 按版本类型选取基准并新增依赖升级分组

### DIFF
--- a/scripts/changelog_generator.py
+++ b/scripts/changelog_generator.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """从 git 提交自动生成 release changelog。
 
-- 分类：conventional commit 前缀 + 中文关键词兜底，跳过 build/ci/style/debug
-  以及正文含 [skip changelog] 的提交
+- 分类：conventional commit 前缀 + 中文关键词兜底，deps/依赖升级类提交
+  进 Dependencies 分组，跳过 build/ci/style/debug 以及正文含 [skip changelog]
+  的提交
 - 版本头：tag 去 v 前缀并补发布日期（tag 创建日；手动触发未打 tag 时回退 HEAD 提交日）
-- 条目：提交标题原文 + 末尾括号组 `([#N](url) @user)`，无 PR 时仅 `(@user)`
+- 条目：提交标题原文 + PR 链接 + 裸 @署名 `[(#N)](url) @user`，无 PR 时仅
+  `@user`
 - 贡献者：通过 GitHub API 把 git 提交解析成裸 @登录名，逐条署名；GitHub Release
   根据 mention 生成原生 Contributors 头像区
-- 对比基准：最近的可达 tag；没有则回退到仓库最新 tag
+- 对比基准：正式版 tag 只取上一个正式版 tag；测试版 tag 优先取上一个测试版
+  tag，没有则取上一个正式版 tag；都无可达 tag 时回退到仓库最新对应类型 tag
 """
 
 import argparse
@@ -24,6 +27,7 @@ CATEGORY_ORDER = [
     ("feat", "New"),
     ("fix", "Bug Fixes"),
     ("perf", "Improvements"),
+    ("deps", "Dependencies"),
     ("chore", "Maintenance"),
     ("docs", "Documentation"),
     ("other", "Other"),
@@ -51,6 +55,16 @@ KEYWORD_CATEGORY = {
 }
 
 IGNORE_PREFIXES = ("build", "ci", "style", "debug")
+
+STABLE_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
+ALPHA_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$")
+VERSION_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+(?:-alpha\.[0-9]+)?$")
+
+DEPENDENCY_SCOPE_RE = re.compile(r"^\w+\(deps(?:-dev)?\): *")
+DEPENDENCY_PATTERNS = (
+    re.compile(r"依赖.*(?:升级|更新)"),
+    re.compile(r"(?:升级|更新).*依赖"),
+)
 
 SEP = "\x1f"
 REC = "\x1e"
@@ -92,7 +106,15 @@ def mention_login(login: str) -> str:
 
 
 def parse_category(message: str) -> str | None:
-    """返回分类名；build/ci/style/debug 前缀返回 None（跳过）。"""
+    """返回分类名；build/ci/style/debug 前缀返回 None（跳过）。
+
+    依赖升级类提交（deps 前缀/scope 或中文"依赖…升级/更新"句式）优先归入
+    deps，不因 build 前缀被跳过。
+    """
+    if DEPENDENCY_SCOPE_RE.match(message) or any(
+        pattern.search(message) for pattern in DEPENDENCY_PATTERNS
+    ):
+        return "deps"
     if re.match(rf"^(?:{'|'.join(IGNORE_PREFIXES)}) *(?:\([^)]*\))?: *", message):
         return None
     match = re.match(r"^(?P<prefix>\w+)(?:\([\w\-]+\))?:\s*", message)
@@ -181,20 +203,75 @@ def commit_login(repo: str, commit_hash: str, email: str) -> str | None:
     return login
 
 
-def find_base_tag(tag: str) -> str:
-    """最近的可达祖先 tag；失败则回退到仓库最新的版本格式 tag。"""
-    try:
-        base = git("describe", "--tags", "--abbrev=0", "--exclude", tag, "HEAD")
-        if base.strip():
-            return base.strip()
-    except subprocess.CalledProcessError:
-        pass
-    version_re = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+")
-    for name in git("tag", "--sort=-creatordate").splitlines():
-        name = name.strip()
-        if name != tag and version_re.match(name):
-            return name
+def _reachable_commit_count(name: str) -> int | None:
+    """HEAD 到 name 祖先的提交数；name 不是 HEAD 的祖先时返回 None。"""
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", name, "HEAD"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        return None
+    count = git("rev-list", "--count", f"{name}..HEAD").strip()
+    return int(count) if count.isdigit() else None
+
+
+def _tag_matches_kind(name: str, kinds: tuple[str, ...]) -> bool:
+    return ("stable" in kinds and bool(STABLE_TAG_RE.match(name))) or (
+        "alpha" in kinds and bool(ALPHA_TAG_RE.match(name))
+    )
+
+
+def _nearest_tag(name: str, kinds: tuple[str, ...]) -> str:
+    """HEAD 的可达版本 tag 里，按提交距离取最近的指定类型 tag。"""
+    candidates: list[tuple[int, str]] = []
+    for candidate in git("tag", "-l").splitlines():
+        candidate = candidate.strip()
+        if candidate == name or not VERSION_TAG_RE.match(candidate):
+            continue
+        if not _tag_matches_kind(candidate, kinds):
+            continue
+        distance = _reachable_commit_count(candidate)
+        if distance is not None:
+            candidates.append((distance, candidate))
+    if candidates:
+        return min(candidates)[1]
     return ""
+
+
+def _latest_tag(name: str, kinds: tuple[str, ...]) -> str:
+    """按创建时间取仓库里最新的指定类型版本 tag（不要求可达）。"""
+    for candidate in git("tag", "--sort=-creatordate").splitlines():
+        candidate = candidate.strip()
+        if candidate == name or not _tag_matches_kind(candidate, kinds):
+            continue
+        return candidate
+    return ""
+
+
+def find_base_tag(tag: str) -> str:
+    """按发布类型选取 changelog 对比基准 tag。
+
+    正式版（vX.Y.Z）只取上一个正式版 tag；测试版（vX.Y.Z-alpha.N）优先取
+    上一个测试版 tag，没有则取上一个正式版 tag。都在 HEAD 的可达祖先里按
+    提交距离取最近；没有可达 tag 时回退到仓库里最新创建的对应类型 tag。
+    """
+    if ALPHA_TAG_RE.match(tag):
+        base = _nearest_tag(tag, ("alpha",))
+        if base:
+            return base
+        base = _nearest_tag(tag, ("stable",))
+        if base:
+            return base
+        base = _latest_tag(tag, ("alpha",))
+        if base:
+            return base
+        return _latest_tag(tag, ("stable",))
+    base = _nearest_tag(tag, ("stable",))
+    if base:
+        return base
+    return _latest_tag(tag, ("stable",))
 
 
 def collect_commits(base: str) -> list[dict]:
@@ -301,10 +378,10 @@ def render_release_body(tag: str, repo: str, base: str, commits: list[dict]) -> 
             logins = resolve_logins(repo, commit["hash"], commit["authors"])
             mentions = " ".join(mention_login(login) for login in logins)
             if commit["number"]:
-                pr = f"[#{commit['number']}](https://github.com/{repo}/pull/{commit['number']})"
-                lines.append(f"- {commit['desc']} ({pr} {mentions})")
+                pr = f"[(#{commit['number']})](https://github.com/{repo}/pull/{commit['number']})"
+                lines.append(f"- {commit['desc']} {pr} {mentions}")
             else:
-                lines.append(f"- {commit['desc']} ({mentions})")
+                lines.append(f"- {commit['desc']} {mentions}")
         lines.append("")
     if base:
         lines.append(

--- a/scripts/tests/changelog_generator_tests.py
+++ b/scripts/tests/changelog_generator_tests.py
@@ -4,6 +4,7 @@
 插入到正确位置、前缀版本不误判、插入不删除其他版本内容。
 """
 
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -29,6 +30,33 @@ def _write(tmp: str, content: str) -> Path:
     path = Path(tmp) / "CHANGELOG.md"
     path.write_text(content, encoding="utf-8")
     return path
+
+
+def _fake_git(tags: dict[str, int | None], creation_order: list[str] | None = None):
+    """模拟 changelog_generator.git()：tag 值=HEAD 到该 tag 的提交距离，None=不可达。"""
+
+    def fake_git(*args):
+        if args == ("tag", "-l"):
+            return "\n".join(tags) + "\n"
+        if args == ("tag", "--sort=-creatordate"):
+            return "\n".join(creation_order or list(tags)) + "\n"
+        if args[0] == "rev-list" and args[1] == "--count":
+            name = args[2].removesuffix("..HEAD")
+            distance = tags.get(name)
+            return str(distance if distance is not None else 0)
+        raise AssertionError(f"unexpected git call: {args}")
+
+    return fake_git
+
+
+def _fake_run(tags: dict[str, int | None]):
+    """模拟 merge-base --is-ancestor 的可达性判断（returncode 0=可达）。"""
+
+    def fake_run(cmd, capture_output=True, text=True, encoding="utf-8"):
+        name = cmd[-1]
+        return subprocess.CompletedProcess(cmd, 0 if tags.get(name) is not None else 1)
+
+    return fake_run
 
 
 class PrependChangelogTests(unittest.TestCase):
@@ -229,7 +257,7 @@ class ContributorLoginTests(unittest.TestCase):
             )
 
         self.assertIn(
-            "- 修复发布流程 ([#42](https://github.com/owner/repo/pull/42) @Alice @Bob)",
+            "- 修复发布流程 [(#42)](https://github.com/owner/repo/pull/42) @Alice @Bob",
             body,
         )
         self.assertNotIn("[@Alice]", body)
@@ -252,6 +280,120 @@ class ContributorLoginTests(unittest.TestCase):
                 ("Primary Name", "primary@example.com"),
                 ("Shared Name", "shared@example.com"),
             ],
+        )
+
+
+class FindBaseTagTests(unittest.TestCase):
+    def test_stable_tag_skips_nearer_alpha_and_uses_previous_stable(self):
+        tags = {"v4.1.6-alpha.1": 1, "v4.1.5": 86, "v4.1.2": 300}
+        with (
+            mock.patch.object(changelog_generator, "git", side_effect=_fake_git(tags)),
+            mock.patch.object(
+                changelog_generator.subprocess, "run", side_effect=_fake_run(tags)
+            ),
+        ):
+            self.assertEqual(changelog_generator.find_base_tag("v4.1.6"), "v4.1.5")
+
+    def test_alpha_tag_uses_previous_alpha(self):
+        tags = {"v4.1.6-alpha.1": 5, "v4.1.5": 100}
+        with (
+            mock.patch.object(changelog_generator, "git", side_effect=_fake_git(tags)),
+            mock.patch.object(
+                changelog_generator.subprocess, "run", side_effect=_fake_run(tags)
+            ),
+        ):
+            self.assertEqual(
+                changelog_generator.find_base_tag("v4.1.6-alpha.2"), "v4.1.6-alpha.1"
+            )
+
+    def test_alpha_tag_without_previous_alpha_falls_back_to_stable(self):
+        tags = {"v4.1.5": 100}
+        with (
+            mock.patch.object(changelog_generator, "git", side_effect=_fake_git(tags)),
+            mock.patch.object(
+                changelog_generator.subprocess, "run", side_effect=_fake_run(tags)
+            ),
+        ):
+            self.assertEqual(
+                changelog_generator.find_base_tag("v4.1.6-alpha.1"), "v4.1.5"
+            )
+
+    def test_stable_tag_falls_back_to_latest_stable_by_creation_when_none_reachable(
+        self,
+    ):
+        tags = {"v4.1.5": None, "v4.1.2": None}
+        with (
+            mock.patch.object(changelog_generator, "git", side_effect=_fake_git(tags)),
+            mock.patch.object(
+                changelog_generator.subprocess, "run", side_effect=_fake_run(tags)
+            ),
+        ):
+            self.assertEqual(changelog_generator.find_base_tag("v4.1.6"), "v4.1.5")
+
+    def test_non_version_tags_are_ignored(self):
+        tags = {"backup/pre-split-abc": 1, "v4.1.5": 50}
+        with (
+            mock.patch.object(changelog_generator, "git", side_effect=_fake_git(tags)),
+            mock.patch.object(
+                changelog_generator.subprocess, "run", side_effect=_fake_run(tags)
+            ),
+        ):
+            self.assertEqual(changelog_generator.find_base_tag("v4.1.6"), "v4.1.5")
+
+
+class ParseCategoryTests(unittest.TestCase):
+    def test_dependency_upgrade_keyword_maps_to_deps(self):
+        self.assertEqual(
+            changelog_generator.parse_category(
+                "build(ui): 前端依赖整体升级 + 图表修复"
+            ),
+            "deps",
+        )
+
+    def test_deps_scope_maps_to_deps(self):
+        self.assertEqual(
+            changelog_generator.parse_category("build(deps): bump vite"), "deps"
+        )
+
+    def test_dependency_update_keyword_maps_to_deps(self):
+        self.assertEqual(
+            changelog_generator.parse_category("chore(ui): 更新依赖"), "deps"
+        )
+
+    def test_build_release_prepare_is_still_skipped(self):
+        self.assertIsNone(
+            changelog_generator.parse_category("build(release): prepare release v4.1.6")
+        )
+
+    def test_ci_prefix_is_still_skipped(self):
+        self.assertIsNone(changelog_generator.parse_category("ci: fix build"))
+
+    def test_release_body_includes_dependencies_heading(self):
+        commits = [
+            {
+                "category": "deps",
+                "hash": "aaa",
+                "authors": [("Alice", "alice@example.com")],
+                "desc": "前端依赖整体升级",
+                "number": 154,
+            }
+        ]
+        with (
+            mock.patch.object(
+                changelog_generator, "release_date", return_value="2026-09-01"
+            ),
+            mock.patch.object(
+                changelog_generator, "resolve_logins", return_value=["Alice"]
+            ),
+        ):
+            body = changelog_generator.render_release_body(
+                "v4.1.6-alpha.2", "owner/repo", "v4.1.6-alpha.1", commits
+            )
+        self.assertIn("### Dependencies", body)
+        self.assertIn(
+            "- 前端依赖整体升级 "
+            "[(#154)](https://github.com/owner/repo/pull/154) @Alice",
+            body,
         )
 
 


### PR DESCRIPTION
## 目标

changelog 生成器用 git describe 取最近可达 tag 作为对比基准，不区分正式版与测试版。正式版与 alpha 同线发布时，正式版会以最近的 alpha tag 为基准，changelog 只覆盖 alpha 以来的提交，正式版历史几乎为空；依赖升级类提交又被 build 前缀整体跳过，changelog 看不到前端依赖升级等变更。

本次修正基准选择逻辑并新增依赖升级分组，让 changelog 按发布类型正确反映变更。

## 主要改动

- 基准 tag 按发布类型选择：正式版只取可达的正式版 tag；测试版优先取可达的测试版 tag，没有则取正式版；不可达时按创建时间回退到对应类型的最新 tag，并过滤 backup 等非版本 tag
- 新增 Dependencies 分组，识别 deps 前缀或"依赖……升级/更新"句式，排在 Improvements 与 Maintenance 之间
- 条目格式由 `([#N](url) @user)` 调整为 `[(#N)](url) @user`：PR 数字带括号并保持链接，署名使用裸 @mention

## 验证

- 实测 v4.1.6 正式版基准从 v4.1.6-alpha.1 修正为 v4.1.5
- 新增 find_base_tag 与 parse_category 单测覆盖正式版跳过 alpha、测试版回退正式版、非版本 tag 过滤、依赖句式识别
- scripts/tests 全部通过；ruff 检查与格式检查通过

## 风险

- 条目格式改动影响发布 changelog 的渲染；@mention 由 GitHub Release 解析生成 Contributors 头像区，改动后仍保留裸 @ 形式
