### PR TITLE
fix(build): 修复 Linux 独立包缺少 pywebview 的 GTK 后端导致窗口无法启动

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,38 @@ pyinstaller webui_zip.spec
 
 ### 打包（Linux）
 
+先安装**构建机**上打包 pywebview GTK 后端所需的系统依赖（PyGObject 与 GTK/WebKit2
+的 gir typelib，否则打包时 gi 收不进产物）：
+
+```bash
+sudo apt install python3-gi gir1.2-gtk-3.0 gir1.2-webkit2-4.1 gir1.2-soup-3.0 libgirepository1.0-dev
+```
+
+如果用的是 venv，需要让 venv 能看到系统的 PyGObject，用 `--system-site-packages`
+创建，或在 venv 里 `pip install pygobject`（后者需要先安装编译依赖）。
+
+再打包：
+
 ```bash
 pip install pyinstaller
 python scripts/prune_opencv.py
 pyinstaller webui_zip_for_linux.spec
 ```
 
-生成的 `mower` 在 `dist` 文件夹中，到此打包完成，已可使用。
+生成的 `mower` 在 `dist` 文件夹中，到此打包完成，已可使用。Linux 独立包的窗口后端是
+GTK（`gi`/PyGObject），Qt 后端不随包分发。宿主若缺 GTK/WebKit2 原生库与 gir typelib，
+程序启动时会给出中文安装提示，也可按发行版安装：
+
+```bash
+# Debian / Ubuntu
+sudo apt install libgtk-3-0 libwebkit2gtk-4.1-0 gir1.2-webkit2-4.1 gir1.2-gtk-3.0 gir1.2-soup-3.0
+# Fedora
+sudo dnf install webkit2gtk4.1 gi-girepository libgtk-3
+# Arch Linux
+sudo pacman -S webkit2gtk-4.1 gobject-introspection
+```
+
+各发行版的详细依赖与打包命令见 `doc/release-platforms.md`。
 
 注：Linux 下运行时，shell 会显示如 `Running on http://127.0.0.1:53703` 的输出，本地浏览器访问 `http://127.0.0.1:53703` 即进入 Mower 页面。
 

--- a/arknights_mower/tests/webview_ui_tests.py
+++ b/arknights_mower/tests/webview_ui_tests.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest import mock
+
+from webview_ui import (
+    _LINUX_WEBVIEW_INSTALL_HINT,
+    linux_webview_backend_error,
+)
+
+
+class TestLinuxWebviewBackendError(unittest.TestCase):
+    def test_non_linux_platform_returns_none(self):
+        # 后端检查只在 Linux 上生效；其它平台直接放行，避免在 macOS/Windows 误触发。
+        with mock.patch("webview_ui.platform.system", return_value="Windows"):
+            self.assertIsNone(linux_webview_backend_error())
+        with mock.patch("webview_ui.platform.system", return_value="Darwin"):
+            self.assertIsNone(linux_webview_backend_error())
+
+    def test_linux_without_backend_returns_hint(self):
+        # 显式让两个后端都导入失败，无论开发机是否装了 webview/gi/qtpy，断言都确定
+        # 成立，避免在配好依赖的 Linux 机器上跑单测时误报失败。
+        with (
+            mock.patch("webview_ui.platform.system", return_value="Linux"),
+            mock.patch(
+                "builtins.__import__", side_effect=ImportError("backend unavailable")
+            ),
+        ):
+            self.assertEqual(linux_webview_backend_error(), _LINUX_WEBVIEW_INSTALL_HINT)
+
+    def test_install_hint_covers_each_distro(self):
+        # 提示文案必须覆盖三个发行版的具体安装命令，缺库时用户能照着安装。
+        hint = _LINUX_WEBVIEW_INSTALL_HINT
+        self.assertIn("libwebkit2gtk-4.1-0", hint)
+        self.assertIn("gir1.2-webkit2-4.1", hint)
+        self.assertIn("webkit2gtk4.1", hint)
+        self.assertIn("gi-girepository", hint)
+        self.assertIn("webkit2gtk-4.1", hint)
+        self.assertIn("sudo apt install", hint)
+        self.assertIn("sudo dnf install", hint)
+        self.assertIn("sudo pacman -S", hint)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/doc/release-platforms.md
+++ b/doc/release-platforms.md
@@ -122,3 +122,57 @@ Windows ARM64 继续暂缓，避免它阻塞其他平台的 Release。
 这套流程只创建当前仓库的分支提交、tag 和 GitHub Release，不包含 OTA、
 多仓库分发或镜像推送。现有 `.github/workflows/python-publish.yml` 仍是独立的
 PyPI 发布流程，发布准备任务不会显式调用它。
+
+## Linux 独立包的窗口后端与宿主依赖
+
+上面各节描述跨平台构建与 Release 流程，这里补充 Linux 独立包运行时窗口后端的
+两层依赖，以及各发行版的宿主安装命令。
+
+### 窗口后端
+
+| 平台 | 独立包窗口后端 | 依赖 |
+| --- | --- | --- |
+| Windows | `webview.platforms.edgechromium` | WebView2 |
+| macOS | `webview.platforms.cocoa` | PyObjC |
+| Linux | `webview.platforms.gtk` | PyGObject（`gi`） |
+
+pywebview 在 Linux 上的默认调度是先试 GTK（`webview.platforms.gtk`），失败再试
+Qt（`webview.platforms.qt`）。`KDE_FULL_SESSION` 或 `PYWEBVIEW_GUI=qt` 时反过来。
+
+Linux **独立包**只随包分发 GTK 后端的 Python 依赖（`gi`/PyGObject），Qt 后端
+（`qtpy` + PyQt/PySide）刻意不收集：它不是默认路径、体积也大。因此 Linux 独立包
+一律走 GTK；Qt 版只能在源码运行时使用。
+
+### 构建机依赖
+
+构建机（运行 PyInstaller 的机器）需要在打包前安装 PyGObject 与 GTK/WebKit2 的
+gir typelib，否则 `webui_zip_for_linux.spec` 收集不到 `gi`：
+
+```bash
+# Debian / Ubuntu
+sudo apt install python3-gi gir1.2-gtk-3.0 gir1.2-webkit2-4.1 gir1.2-soup-3.0 libgirepository1.0-dev
+```
+
+如果使用 venv，需要用 `--system-site-packages` 创建以便看到系统 PyGObject，或在
+venv 中 `pip install pygobject`（后者需先安装编译依赖）。
+
+### 宿主运行依赖
+
+宿主（运行独立包的机器）只需安装 GTK/WebKit2 原生库与 gir typelib，缺库时程序启动
+会给出中文安装提示：
+
+```bash
+# Debian / Ubuntu
+sudo apt install libgtk-3-0 libwebkit2gtk-4.1-0 gir1.2-webkit2-4.1 gir1.2-gtk-3.0 gir1.2-soup-3.0
+
+# Fedora
+sudo dnf install webkit2gtk4.1 gi-girepository libgtk-3
+
+# Arch Linux
+sudo pacman -S webkit2gtk-4.1 gobject-introspection
+```
+
+说明：Debian 的 `gir1.2-webkit2-4.1` 依赖 `libwebkit2gtk-4.1-0`，`gir1.2-gtk-3.0`
+依赖 `libgtk-3-0`，`gir1.2-soup-3.0` 依赖 `libsoup-3.0-0`，传递依赖会随之安装。
+Fedora 的 `webkit2gtk4.1 + gi-girepository` 覆盖 WebKit2 与 GObject 内省，`libgtk-3`
+提供 GTK3。Arch 的 `webkit2gtk-4.1` 会带 `gobject-introspection` 与 GTK3。

--- a/manager.py
+++ b/manager.py
@@ -73,6 +73,12 @@ def jump_to_index(window):
 
 
 if __name__ == "__main__":
+    from webview_ui import exit_if_webview_backend_missing
+
+    # 多开管理器和主程序一样依赖窗口后端，宿主缺 GTK/WebKit2 原生库时先给出中文
+    # 安装指引再退出，避免裸 WebViewException。
+    exit_if_webview_backend_missing()
+
     api = Api()
     window = webview.create_window(
         title="多开管理器",

--- a/webui_zip_for_linux.spec
+++ b/webui_zip_for_linux.spec
@@ -3,6 +3,7 @@ from pathlib import Path
 import sys
 
 import rapidocr_onnxruntime
+from PyInstaller.utils.hooks import collect_submodules
 
 SPEC_DIR = Path(__file__).resolve().parent if "__file__" in globals() else Path.cwd()
 if str(SPEC_DIR) not in sys.path:
@@ -11,6 +12,48 @@ if str(SPEC_DIR) not in sys.path:
 from build_assets import get_pyinstaller_common_datas
 
 block_cipher = None
+
+# pywebview 在 Linux 上默认先加载 GTK 后端（webview.platforms.gtk），该后端只依赖
+# PyGObject（gi），Qt 后端（qtpy + PyQt/PySide）不是默认路径、体积也大，刻意不收集，
+# 避免把不需要的 Qt 全家打进包。guilib.py 对 webview.platforms.gtk 的 import 位于
+# 惰性加载路径，PyInstaller 并不稳定地沿它收集 gi；这里显式收集 gi 的 Python 包并
+# 强制 webview.platforms.gtk，保证产物带上 PyGObject。运行期经 gi.repository 的
+# DynamicImporter 从宿主加载 Gtk/WebKit2 等 typelib。宿主仍需安装 libgtk-3、
+# libwebkit2gtk-4.1、gir1.2-webkit2 等原生库。
+PYWEBVIEW_GTK_HIDDENIMPORTS = []
+PYWEBVIEW_GTK_EXCLUDES = []
+try:
+    import gi  # noqa: F401  # 仅探测构建机是否安装 PyGObject
+
+    PYWEBVIEW_GTK_HIDDENIMPORTS = [
+        "webview.platforms.gtk",
+        "gi",
+        "gi.repository",
+    ]
+    try:
+        PYWEBVIEW_GTK_HIDDENIMPORTS += collect_submodules("gi")
+    except Exception:
+        pass
+    # GTK/WebKit2 的原生库与 typelib 一律来自宿主，不进产物，避免把 libgtk-3、
+    # libwebkit2gtk-4.1 整棵依赖树打包并与宿主 WebKit2 版本不一致。
+    PYWEBVIEW_GTK_EXCLUDES = [
+        "gi.repository.GLib",
+        "gi.repository.GObject",
+        "gi.repository.Gio",
+        "gi.repository.Gdk",
+        "gi.repository.GdkPixbuf",
+        "gi.repository.Gtk",
+        "gi.repository.Pango",
+        "gi.repository.PangoCairo",
+        "gi.repository.cairo",
+        "gi.repository.Soup",
+        "gi.repository.WebKit2",
+        "gi.repository.HarfBuzz",
+    ]
+except ImportError:
+    # 构建机没有安装 PyGObject：产物不含 pywebview 的 GTK 后端，运行期会用中文提示
+    # 宿主安装原生库，而不是抛出裸 ImportError。
+    pass
 
 # 参考 https://github.com/RapidAI/RapidOCR/blob/main/ocrweb/rapidocr_web/ocrweb.spec
 package_name = "rapidocr_onnxruntime"
@@ -48,7 +91,7 @@ mower_a = Analysis(
         ),
     ]
     + add_data,
-    hiddenimports=[],
+    hiddenimports=PYWEBVIEW_GTK_HIDDENIMPORTS,
     hooksconfig={},
     runtime_hooks=[],
     excludes=[
@@ -72,6 +115,7 @@ mower_a = Analysis(
         "openpyxl",
         "_pytest",
         "pytest",
+        *PYWEBVIEW_GTK_EXCLUDES,
     ],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,
@@ -113,7 +157,7 @@ manager_a = Analysis(
     pathex=[],
     binaries=[],
     datas=[],
-    hiddenimports=[],
+    hiddenimports=PYWEBVIEW_GTK_HIDDENIMPORTS,
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
@@ -129,6 +173,7 @@ manager_a = Analysis(
         "openpyxl",
         "_pytest",
         "pytest",
+        *PYWEBVIEW_GTK_EXCLUDES,
     ],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,

--- a/webview_ui.py
+++ b/webview_ui.py
@@ -1,6 +1,72 @@
 #!/usr/bin/env python3
 import multiprocessing as mp
+import os
+import platform
+import sys
 from urllib.parse import quote
+
+# Linux 版独立包运行期需要宿主提供 GTK/WebKit2 原生库与 typelib，PyInstaller 只把
+# pywebview 的 Python 依赖打进包。这份提示在窗口后端初始化失败时展示，直接给出
+# 三个发行版的安装命令，避免用户对着裸 ImportError 无从下手。
+_LINUX_WEBVIEW_INSTALL_HINT = (
+    "Linux 版 mower 需要宿主安装 GTK/WebKit2 原生库，窗口后端无法初始化。\n\n"
+    "Debian / Ubuntu：\n"
+    "    sudo apt install libgtk-3-0 libwebkit2gtk-4.1-0 gir1.2-webkit2-4.1 gir1.2-gtk-3.0 gir1.2-soup-3.0\n"
+    "Fedora：\n"
+    "    sudo dnf install webkit2gtk4.1 gi-girepository libgtk-3\n"
+    "Arch Linux：\n"
+    "    sudo pacman -S webkit2gtk-4.1 gobject-introspection\n\n"
+    "安装完成后重新运行 mower。更完整的说明见 README 的 Linux 打包一节。"
+)
+
+
+def linux_webview_backend_error() -> str | None:
+    """Linux 上检查 pywebview 的窗口后端能否初始化；缺失时返回中文安装指引。"""
+    if platform.system() not in ("Linux", "OpenBSD"):
+        return None
+
+    # 复刻 pywebview 5.1 guilib.initialize 的调度：PYWEBVIEW_GUI 优先，其次
+    # KDE_FULL_SESSION 触发 Qt，否则默认 GTK 优先。
+    requested_gui = os.environ.get("PYWEBVIEW_GUI", "").strip().lower()
+    if requested_gui not in ("qt", "gtk"):
+        requested_gui = "qt" if "KDE_FULL_SESSION" in os.environ else None
+    candidates = (
+        ["webview.platforms.qt", "webview.platforms.gtk"]
+        if requested_gui == "qt"
+        else ["webview.platforms.gtk", "webview.platforms.qt"]
+    )
+    for module in candidates:
+        # GTK 后端还会因宿主缺 typelib 抛 ValueError，Qt 后端只抛 ImportError，
+        # 与 guilib 的 import_gtk / import_qt 保持一致。
+        errors = (
+            (ImportError, ValueError) if module.endswith(".gtk") else (ImportError,)
+        )
+        try:
+            __import__(module)
+            return None  # 有一个后端可用即可，无需提示
+        except errors:
+            continue
+
+    return _LINUX_WEBVIEW_INSTALL_HINT
+
+
+def exit_if_webview_backend_missing():
+    """Linux 上窗口后端缺失时输出安装指引并退出；其它平台直接返回。"""
+    backend_error = linux_webview_backend_error()
+    if backend_error is None:
+        return
+    print(backend_error, file=sys.stderr)
+    try:
+        import tkinter as tk
+        from tkinter import messagebox
+
+        root = tk.Tk()
+        root.withdraw()
+        messagebox.showerror("arknights-mower", backend_error)
+        root.destroy()
+    except Exception:
+        pass  # 无显示环境（如 headless）时 stderr 已足够
+    sys.exit(1)
 
 
 def splash_screen(queue: mp.Queue):
@@ -199,6 +265,10 @@ def webview_window(child_conn, global_space, instance_name, host, port, url, tra
 
 if __name__ == "__main__":
     mp.freeze_support()
+
+    # 先检查窗口后端是否可用。Linux 独立包若宿主缺 GTK/WebKit2 原生库，在这里给出
+    # 中文安装指引并退出，而不是让 webview 子进程走到裸 ImportError 后悄悄开浏览器。
+    exit_if_webview_backend_missing()
 
     splash_queue = mp.Queue()
     splash_process = mp.Process(target=splash_screen, args=(splash_queue,), daemon=True)


### PR DESCRIPTION
## 变更

Linux x64 独立包此前只收集了入口脚本显式导入的模块，pywebview 在 Linux 上按需加载的 GTK 后端（`webview.platforms.gtk`，依赖 PyGObject `gi`）没有被放进产物，运行后先报 `gi` 缺失，回退到 Qt 后端又缺 `qtpy`，窗口无法启动。这次在 `webui_zip_for_linux.spec` 里让 `mower` 与 `manager` 两个 Analysis 都收集 `gi`、`gi.repository` 与 `webview.platforms.gtk`；同时把 `gi.repository.*` 排除在产物之外，让 GTK/WebKit2 的原生库与 typelib 全部留在宿主，避免把 `libgtk-3`、`libwebkit2gtk-4.1` 整棵依赖树打包并与宿主 WebKit2 版本不一致。

宿主缺少原生库时，`webview_ui.py` 与 `manager.py` 会在启动时先给出中文安装指引再退出，而不是抛出裸的 `ImportError`。各发行版的安装命令写进了 README 的 Linux 打包一节和 `doc/release-platforms.md`。

## 限制

- 本次改动只涉及 Linux 打包脚本、入口检查与文档；`webui_zip.spec`（Windows）与 `build_assets.py` 的三平台共用逻辑没有改动。macOS 走 Cocoa 后端，不经过 `gi`/`qtpy`，不受影响。
- Linux 独立包只随包分发 GTK 后端的 Python 依赖，Qt 后端（`qtpy` + Qt 绑定）刻意不收集，因此独立包一律走 GTK；Qt 版本只能在源码运行时使用。
- 本机（Windows）无法构建 Linux 包做容器内实测，需要一次真实 Linux 构建验证窗口能打开，通常由发布流水线完成。

## 验证

- `arknights_mower/tests` 全量（venv）：778 通过，10 跳过，无回归。
- `ruff check` 与 `ruff format --check`：通过。
- README 与 `doc/release-platforms.md` 的安装命令逐字一致。
