### PR TITLE
fix(device): 修复连接错误被误判导致运行中的游戏退出与资源残留

### DIFF
--- a/arknights_mower/__main__.py
+++ b/arknights_mower/__main__.py
@@ -9,8 +9,6 @@ from arknights_mower.utils.csleep import MowerExit
 from arknights_mower.utils.csv_utils import EmptyDataError, read_csv_rows
 from arknights_mower.utils.datetime import get_server_time
 from arknights_mower.utils.depot import 创建csv, 创建json
-from arknights_mower.utils.device.adb_client.session import Session
-from arknights_mower.utils.device.scrcpy import Scrcpy
 from arknights_mower.utils.email import send_message
 from arknights_mower.utils.log import logger
 from arknights_mower.utils.maa_check import is_maa_connectivity_check_enabled
@@ -106,14 +104,10 @@ def simulate(saved, restart_after_mood_read=False):
             reconnect_tries += 1
             if reconnect_tries < 3:
                 restart_simulator()
-                base_scheduler.device.client.check_server_alive()
-                Session().connect(config.conf.adb)
-                if config.conf.droidcast.enable:
-                    base_scheduler.device.start_droidcast()
-                if config.conf.touch_method == "scrcpy":
-                    base_scheduler.device.control.scrcpy = Scrcpy(
-                        base_scheduler.device.client
-                    )
+                # 首次 initialize 失败时模块全局 base_scheduler 仍是 None（initialize 内是局部变量），
+                # 不能拿它重连；下一次 initialize 会新建 Device 自然重连
+                if base_scheduler is not None:
+                    base_scheduler.device.reconnect()
                 continue
             else:
                 raise e
@@ -122,7 +116,7 @@ def simulate(saved, restart_after_mood_read=False):
             base_scheduler.check_maa_connectivity("启动预检")
         except RuntimeError as e:
             message = str(e)
-            logger.error(message)
+            logger.warning(message)
             send_message(
                 message,
                 "Mower启动中止：Maa连接测试失败",
@@ -333,28 +327,14 @@ def simulate(saved, restart_after_mood_read=False):
                             raise
                         logger.exception(e)
                         restart_simulator()
-                        base_scheduler.device.client.check_server_alive()
-                        Session().connect(config.conf.adb)
-                        if config.conf.droidcast.enable:
-                            base_scheduler.device.start_droidcast()
-                        if config.conf.touch_method == "scrcpy":
-                            base_scheduler.device.control.scrcpy = Scrcpy(
-                                base_scheduler.device.client
-                            )
+                        base_scheduler.device.reconnect()
                 continue
             else:
                 raise e
         except RuntimeError as e:
             logger.exception(f"程序出错-尝试重启模拟器->{e}")
             restart_simulator()
-            base_scheduler.device.client.check_server_alive()
-            Session().connect(config.conf.adb)
-            if config.conf.droidcast.enable:
-                base_scheduler.device.start_droidcast()
-            if config.conf.touch_method == "scrcpy":
-                base_scheduler.device.control.scrcpy = Scrcpy(
-                    base_scheduler.device.client
-                )
+            base_scheduler.device.reconnect()
         except Exception as e:
             logger.exception(f"程序出错--->{e}")
             base_scheduler.recog.update()

--- a/arknights_mower/tests/adb_client_tests.py
+++ b/arknights_mower/tests/adb_client_tests.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from arknights_mower.utils.device.adb_client.core import Client
+
+
+def _client() -> Client:
+    client = object.__new__(Client)
+    client.device_id = "127.0.0.1:16928"
+    client.adb_bin = "adb"
+    return client
+
+
+class TestAdbClientConnectionError(unittest.TestCase):
+    """#157：run()/__run() 的重连循环必须兜住 base ConnectionError(b'closed')。
+
+    此前 except 元组是 (socket.timeout, ConnectionRefusedError, RuntimeError)，
+    server 拆线抛的 b'closed' 是 base ConnectionError（非 ConnectionRefusedError
+    子类），漏网冒泡到 check_current_focus 的 restart_simulator，杀掉运行中的游戏。
+    """
+
+    def test_run_recovers_from_connection_error_b_closed(self):
+        client = _client()
+        session_mock = MagicMock()
+        session_mock.exec.side_effect = [ConnectionError(b"closed"), b"ok"]
+
+        with (
+            patch.object(client, "session", return_value=session_mock),
+            patch.object(client, "_Client__exec") as exec_mock,
+            patch.object(client, "_Client__init_device") as init_device_mock,
+            patch(
+                "arknights_mower.utils.device.adb_client.core.query_mumu_adb_port",
+                return_value=None,
+            ),
+            patch("arknights_mower.utils.device.adb_client.core.time.sleep"),
+        ):
+            result = client.run("screencap 2>/dev/null | gzip -1")
+
+        self.assertEqual(result, b"ok")
+        self.assertEqual(
+            exec_mock.call_args_list[0].args[0], "disconnect 127.0.0.1:16928"
+        )
+        self.assertEqual(exec_mock.call_args_list[1].args[0], "connect 127.0.0.1:16928")
+        init_device_mock.assert_called_once_with()
+
+    def test_run_reraises_connection_error_after_retries(self):
+        client = _client()
+        session_mock = MagicMock()
+        session_mock.exec.side_effect = ConnectionError(b"closed")
+
+        with (
+            patch.object(client, "session", return_value=session_mock),
+            patch.object(client, "_Client__exec"),
+            patch.object(client, "_Client__init_device"),
+            patch("arknights_mower.utils.device.adb_client.core.time.sleep"),
+            self.assertRaisesRegex(ConnectionError, "closed"),
+        ):
+            client.run("screencap 2>/dev/null | gzip -1")
+
+    def test_run_helper_recovers_from_connection_error(self):
+        client = _client()
+        with (
+            patch(
+                "arknights_mower.utils.device.adb_client.core.Session"
+            ) as session_cls,
+            patch.object(client, "_Client__exec"),
+            patch(
+                "arknights_mower.utils.device.adb_client.core.query_mumu_adb_port",
+                return_value=None,
+            ),
+            patch("arknights_mower.utils.device.adb_client.core.time.sleep"),
+        ):
+            session_cls.return_value.run.side_effect = [
+                ConnectionError(b"closed"),
+                b"0001",
+            ]
+            result = client.check_server_alive()
+
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/device_tests.py
+++ b/arknights_mower/tests/device_tests.py
@@ -1,0 +1,186 @@
+import unittest
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+from arknights_mower.utils import config
+from arknights_mower.utils.csleep import MowerExit
+from arknights_mower.utils.device.device import Device
+
+
+def _device() -> Device:
+    device = object.__new__(Device)
+    device.client = MagicMock()
+    return device
+
+
+class TestIsAppRunningInBackground(unittest.TestCase):
+    """#159：is_app_running_in_background 走同一条持久 adb 会话 ps/stopped 双查，
+    无法判定时按「运行中」处理，避免误判重新拉起游戏（Bug 2 的 pidof 假阴性根因）。
+    """
+
+    def test_ps_found_process_returns_true(self):
+        device = _device()
+        device.client.run.return_value = (
+            f"u0_a123  456  789  1234  5678  ...  {config.conf.APPNAME}\n".encode()
+        )
+        self.assertTrue(device.is_app_running_in_background())
+        device.client.run.assert_called_once_with(
+            f"ps -A | grep {config.conf.APPNAME} | grep -v grep"
+        )
+
+    def test_ps_empty_force_stopped_returns_false(self):
+        device = _device()
+        device.client.run.side_effect = [b"", b"Packages:\n  stopped=true\n"]
+        self.assertFalse(device.is_app_running_in_background())
+
+    def test_ps_empty_not_force_stopped_returns_true(self):
+        device = _device()
+        device.client.run.side_effect = [b"", b"Packages:\n  stopped=false\n"]
+        self.assertTrue(device.is_app_running_in_background())
+
+    def test_ps_empty_no_stopped_field_returns_true(self):
+        device = _device()
+        device.client.run.side_effect = [b"", b"Packages:\n  userId=10104\n"]
+        self.assertTrue(device.is_app_running_in_background())
+
+    def test_query_error_returns_true(self):
+        device = _device()
+        device.client.run.side_effect = RuntimeError("adb server is not working")
+        self.assertTrue(device.is_app_running_in_background())
+
+    def test_ps_empty_dumpsys_error_returns_true(self):
+        device = _device()
+        device.client.run.side_effect = [
+            b"",
+            RuntimeError("adb server is not working"),
+        ]
+        self.assertTrue(device.is_app_running_in_background())
+
+    def test_bring_to_foreground_uses_persistent_session(self):
+        device = _device()
+        device.bring_to_foreground()
+        device.client.run.assert_called_once_with(
+            f"am start -n {config.conf.APPNAME}/{config.APP_ACTIVITY_NAME}"
+        )
+
+
+class TestCheckCurrentFocus(unittest.TestCase):
+    """#160：check_current_focus 四态 + 瞬时错误不重启、设备无法连接才自动重启模拟器。
+
+    前台→无动作；后台/无法判定→bring_to_foreground；进程停止→launch；
+    瞬时错误→重连重试；设备无法连接→自动重启模拟器（重启有上限）。
+    """
+
+    GAME_FOCUS = f"{config.conf.APPNAME}/{config.APP_ACTIVITY_NAME}"
+    LAUNCHER_FOCUS = "com.mumu.launcher/com.mumu.launcher.Launcher"
+
+    def setUp(self):
+        self.device = _device()
+        self.device.control = MagicMock()
+        self.device.is_app_running_in_background = MagicMock(return_value=True)
+        self.device.bring_to_foreground = MagicMock()
+        self.device.launch = MagicMock()
+        self.device.start_droidcast = MagicMock()
+        self.restart_mock = patch(
+            "arknights_mower.utils.device.device.restart_simulator"
+        ).start()
+        self.addCleanup(self.restart_mock.stop)
+
+    def _patchers(self) -> ExitStack:
+        stack = ExitStack()
+        stack.enter_context(patch("arknights_mower.utils.device.device.Session"))
+        stack.enter_context(patch("arknights_mower.utils.device.device.Scrcpy"))
+        stack.enter_context(patch("arknights_mower.utils.device.device.csleep"))
+        stack.enter_context(
+            patch("arknights_mower.utils.device.device.logger.exception")
+        )
+        return stack
+
+    def test_focus_is_game_no_update(self):
+        self.device.current_focus = MagicMock(return_value=self.GAME_FOCUS)
+        with self._patchers():
+            result = self.device.check_current_focus()
+        self.assertFalse(result)
+        self.device.bring_to_foreground.assert_not_called()
+        self.device.launch.assert_not_called()
+
+    def test_focus_other_game_in_background_brings_to_foreground(self):
+        self.device.current_focus = MagicMock(return_value=self.LAUNCHER_FOCUS)
+        with self._patchers():
+            result = self.device.check_current_focus()
+        self.assertTrue(result)
+        self.device.bring_to_foreground.assert_called_once_with()
+        self.device.launch.assert_not_called()
+
+    def test_focus_other_game_not_running_launches(self):
+        self.device.current_focus = MagicMock(return_value=self.LAUNCHER_FOCUS)
+        self.device.is_app_running_in_background = MagicMock(return_value=False)
+        with self._patchers():
+            result = self.device.check_current_focus()
+        self.assertTrue(result)
+        self.device.launch.assert_called_once_with()
+        self.device.bring_to_foreground.assert_not_called()
+
+    def test_transient_error_recovers_and_retries(self):
+        self.device.current_focus = MagicMock(
+            side_effect=[ConnectionError(b"closed"), self.LAUNCHER_FOCUS]
+        )
+        with self._patchers():
+            result = self.device.check_current_focus()
+        self.assertTrue(result)
+        self.assertEqual(self.device.current_focus.call_count, 2)
+        self.device.client.check_server_alive.assert_called_once_with()
+        self.device.bring_to_foreground.assert_called_once_with()
+
+    def test_confirmed_dead_auto_restarts_then_raises(self):
+        self.device.current_focus = MagicMock(side_effect=ConnectionError(b"closed"))
+        with self._patchers():
+            with self.assertRaisesRegex(ConnectionError, "重启模拟器"):
+                self.device.check_current_focus()
+        # retries=3 × restarts=3：9 次重试，判定设备无法连接自动重启 3 次后才放弃
+        self.assertEqual(self.device.current_focus.call_count, 9)
+        self.assertEqual(self.restart_mock.call_count, 3)
+        self.device.launch.assert_not_called()
+
+    def test_confirmed_dead_restarts_and_recovers(self):
+        # 3 次瞬时失败判定设备无法连接 → 自动重启模拟器 → 重启后恢复
+        self.device.current_focus = MagicMock(
+            side_effect=[ConnectionError(b"closed")] * 3 + [self.LAUNCHER_FOCUS]
+        )
+        with self._patchers():
+            result = self.device.check_current_focus()
+        self.assertTrue(result)
+        self.restart_mock.assert_called_once_with()
+        self.device.bring_to_foreground.assert_called_once_with()
+
+    def test_mower_exit_propagates_immediately(self):
+        self.device.current_focus = MagicMock(side_effect=MowerExit())
+        with self._patchers():
+            with self.assertRaises(MowerExit):
+                self.device.check_current_focus()
+        self.assertEqual(self.device.current_focus.call_count, 1)
+
+    def test_reconnect_failure_does_not_escape_recover(self):
+        # recover 里 reconnect 抛错不再穿出：计入重试，最终仍走自动重启（修复点）
+        self.device.current_focus = MagicMock(side_effect=ConnectionError(b"closed"))
+        self.device.reconnect = MagicMock(side_effect=RuntimeError("adb server 挂了"))
+        with self._patchers():
+            with self.assertRaisesRegex(ConnectionError, "重启模拟器"):
+                self.device.check_current_focus()
+        self.assertEqual(self.device.current_focus.call_count, 9)
+        self.assertEqual(self.restart_mock.call_count, 3)
+        self.device.launch.assert_not_called()
+
+
+class TestStartDroidcast(unittest.TestCase):
+    """install 失败（如设备瞬时离线）返回 False 而不抛错，不让重连崩（修复点）。"""
+
+    def test_install_failure_returns_false(self):
+        device = _device()
+        device.get_droidcast_classpath = MagicMock(return_value=None)
+        device.client.cmd = MagicMock(side_effect=RuntimeError("device offline"))
+        self.assertFalse(device.start_droidcast())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/solver_tests.py
+++ b/arknights_mower/tests/solver_tests.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch
+
+from arknights_mower.utils import config
+from arknights_mower.utils.solver import BaseSolver
+
+
+class TestSolverStartupLaunch(unittest.TestCase):
+    """启动时目标设备未注册到 adb=模拟器未启动，直接启动模拟器而不是重连（修复点）。"""
+
+    def setUp(self):
+        self.device_patch = patch("arknights_mower.utils.solver.Device")
+        self.device_mock = self.device_patch.start()
+        self.device_mock.side_effect = RuntimeError("Device connection failure")
+        self.session_patch = patch("arknights_mower.utils.solver.Session")
+        self.session_mock = self.session_patch.start()
+        self.session_mock.return_value.devices_list.return_value = []
+        self.restart_patch = patch("arknights_mower.utils.solver.restart_simulator")
+        self.restart_mock = self.restart_patch.start()
+        self.addCleanup(self.device_patch.stop)
+        self.addCleanup(self.session_patch.stop)
+        self.addCleanup(self.restart_patch.stop)
+
+    def test_no_device_launches_simulator(self):
+        old_adb = config.conf.adb
+        config.conf.adb = "127.0.0.1:16384"
+        try:
+            with self.assertRaises(ConnectionError):
+                BaseSolver()
+        finally:
+            config.conf.adb = old_adb
+        self.restart_mock.assert_called_with(stop=False, start=True)
+        self.assertEqual(self.restart_mock.call_count, 3)
+
+    def test_no_configured_adb_does_not_launch(self):
+        old_adb = config.conf.adb
+        config.conf.adb = ""
+        try:
+            with self.assertRaises(ConnectionError):
+                BaseSolver()
+        finally:
+            config.conf.adb = old_adb
+        self.restart_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/utils/device/adb_client/core.py
+++ b/arknights_mower/utils/device/adb_client/core.py
@@ -1,3 +1,5 @@
+import json
+import os
 import socket
 import subprocess
 import time
@@ -10,6 +12,54 @@ from arknights_mower.utils.device.adb_client.session import Session
 from arknights_mower.utils.device.adb_client.socket import Socket
 from arknights_mower.utils.device.adb_client.utils import run_cmd
 from arknights_mower.utils.log import logger
+
+
+def query_mumu_adb_port(simulator) -> Optional[str]:
+    """查询 MuMu 管理器返回的目标实例当前 adb 地址。
+
+    实例正在运行（Android 已启动）时返回「adb_host_ip:adb_port」；实例停止、管理器
+    不可用或非 MuMu 模拟器时返回 None（表明目标未就绪，应由上层启动模拟器再重探）。
+    adb_port 以管理器上报为准，避免按 16384+32*index 外推的端口与实际漂移不一致。
+    """
+    if simulator.name != "MuMu12":
+        return None
+    manager = os.path.join(simulator.simulator_folder, "MuMuManager.exe")
+    if not os.path.isfile(manager):
+        # 部分安装版本管理器位于安装根目录的 shell 子目录
+        manager = os.path.join(
+            os.path.dirname(simulator.simulator_folder), "shell", "MuMuManager.exe"
+        )
+    if not os.path.isfile(manager):
+        logger.debug(f"MuMuManager 不存在：{manager}")
+        return None
+    try:
+        out = subprocess.run(
+            [manager, "info", "-v", "all"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=True,
+            timeout=5,
+        ).stdout.strip()
+        instances = json.loads(out)
+    except (OSError, subprocess.CalledProcessError, ValueError):
+        return None
+    target = str(simulator.index)
+    if isinstance(instances, dict):
+        entry = instances.get(target)
+        if entry is None:
+            return None
+    else:
+        entry = next((x for x in instances if str(x.get("index")) == target), None)
+        if entry is None:
+            return None
+    port = entry.get("adb_port")
+    if not port:
+        # 实例存在但未启动/无 adb 字段：当前没有可连接的端点
+        return None
+    host = entry.get("adb_host_ip") or "127.0.0.1"
+    return f"{host}:{port}"
 
 
 class Client:
@@ -38,6 +88,12 @@ class Client:
     def __init_device(self) -> None:
         # wait for the newly started ADB server to probe emulators
         csleep(1)
+        # 启动时先确认 adb server 已启动：走 adb.exe 命令路径可让未运行的 server 自动拉起，
+        # 仅探活不依赖特定设备，避免因 disconnect 未注册设备抛错。拉起失败才抛。
+        try:
+            self.__exec("start-server")
+        except (subprocess.CalledProcessError, OSError) as e:
+            raise RuntimeError("Can't start adb server") from e
         if self.device_id is None or self.device_id != config.conf.adb:
             self.device_id = self.__choose_devices()
         if self.device_id is None:
@@ -68,6 +124,10 @@ class Client:
         devices = self.__available_devices()
         if config.conf.adb in devices:
             return config.conf.adb
+        # 配置端口不在线：重新发现模拟器当前真实 adb 端口（双模拟器下端口可能漂移或未连）
+        target = self.refresh_target()
+        if target in self.__available_devices():
+            return target
         if len(devices) > 0 and config.conf.adb == "":
             logger.debug(devices[0])
             return devices[0]
@@ -75,6 +135,19 @@ class Client:
     def __available_devices(self) -> list[str]:
         """return available devices"""
         return [x[0] for x in Session().devices_list() if x[1] != "offline"]
+
+    def refresh_target(self) -> str:
+        """重新发现目标模拟器当前 adb 端点并同步到 device_id / config.conf.adb。
+
+        优先读取模拟器管理器上报的真实 adb_port（如 MuMu 双开时端口可能漂移），
+        而不是一直连 config.conf.adb 里写死的端口；查询失败或实例未启动（无 adb
+        字段）时保留现有 device_id，由上层重试/重启兜底。只在内存更新，不写回配置。
+        """
+        discovered = query_mumu_adb_port(config.conf.simulator)
+        if discovered is not None:
+            config.conf.adb = discovered
+            self.device_id = discovered
+        return self.device_id or config.conf.adb
 
     def __exec(self, cmd: str, adb_bin: str = None) -> None:
         """exec command with adb_bin"""
@@ -87,6 +160,21 @@ class Client:
             creationflags=subprocess.CREATE_NO_WINDOW if __system__ == "windows" else 0,
         )
 
+    def _reconnect_device(self) -> None:
+        """断开并重连当前设备（走 adb server 5037）。
+
+        设备未注册或离线时 disconnect/connect 会以非零码退出，属瞬态，不应打断重连
+        流程；此前直接用 check=True 抛 CalledProcessError，会在恢复循环里冒泡出来。
+        """
+        try:
+            self.__exec(f"disconnect {self.device_id}")
+        except (subprocess.CalledProcessError, OSError):
+            logger.debug(f"disconnect {self.device_id} 失败（设备可能未注册）")
+        try:
+            self.__exec(f"connect {self.device_id}")
+        except (subprocess.CalledProcessError, OSError):
+            logger.debug(f"connect {self.device_id} 失败")
+
     def __run(self, cmd: str, restart: bool = True) -> Optional[bytes]:
         """run command with Session"""
         error_limit = 3
@@ -94,16 +182,17 @@ class Client:
         while True:
             try:
                 return Session().run(cmd)
-            except (socket.timeout, ConnectionRefusedError, RuntimeError):
+            except (socket.timeout, ConnectionError, RuntimeError):
                 if restart and error_limit > 0:
                     error_limit -= 1
                     if self.device_id and connect_retry > 0:
                         connect_retry -= 1
-                        self.__exec(f"disconnect {self.device_id}")
-                        self.__exec(f"connect {self.device_id}")
+                        self.refresh_target()
+                        self._reconnect_device()
                         time.sleep(0.5)
                     else:
-                        self.__exec("kill-server")
+                        # 只 start-server：未运行的 server 由 adb 客户端自动拉起；
+                        # 显式 kill-server 会中断本可恢复的 server 会话（放大瞬时故障）
                         self.__exec("start-server")
                         time.sleep(10)
                     continue
@@ -114,19 +203,15 @@ class Client:
         return self.__run("host:version", restart) is not None
 
     def __check_adb(self, adb_bin: str) -> bool:
-        """check adb_bin if it works"""
+        """check adb_bin if it works
+
+        只用 start-server（幂等，不会打断已运行的 adb server）。不做 kill-server：
+        重启全局 5037 server 会把共用它的另一台模拟器也踢下线（双模拟器场景互相干扰）。
+        """
         try:
             self.__exec("start-server", adb_bin)
-            if self.check_server_alive(False):
-                return True
-            self.__exec("kill-server", adb_bin)
-            self.__exec("start-server", adb_bin)
-            time.sleep(10)
-            if self.check_server_alive(False):
-                return True
+            return self.check_server_alive(False)
         except (FileNotFoundError, subprocess.CalledProcessError):
-            return False
-        else:
             return False
 
     def session(self) -> Session:
@@ -143,17 +228,20 @@ class Client:
             try:
                 resp = self.session().exec(cmd)
                 break
-            except (socket.timeout, ConnectionRefusedError, RuntimeError) as e:
+            except (socket.timeout, ConnectionError, RuntimeError) as e:
+                # b'closed' 是 base ConnectionError（非 ConnectionRefusedError 子类），
+                # 漏掉会冒泡到 check_current_focus 的 restart_simulator，杀掉运行中的游戏
                 if error_limit > 0:
                     error_limit -= 1
                     # 只断开并重连当前设备，避免影响其他adb连接
                     if self.device_id:
-                        self.__exec(f"disconnect {self.device_id}")
-                        self.__exec(f"connect {self.device_id}")
+                        self.refresh_target()
+                        self._reconnect_device()
                         time.sleep(3)
                         self.__init_device()
                     else:
-                        self.__exec("kill-server")
+                        # 只 start-server：未运行的 server 由 adb 客户端自动拉起；
+                        # 显式 kill-server 会中断本可恢复的 server 会话（放大瞬时故障）
                         self.__exec("start-server")
                         time.sleep(10)
                         self.__init_device()

--- a/arknights_mower/utils/device/device.py
+++ b/arknights_mower/utils/device/device.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import atexit
 import gzip
 import subprocess
 import time
@@ -124,6 +125,8 @@ class Device:
         self.client = None
         self.control = None
         self.start()
+        # 进程退出时释放 adb 资源，避免退出后 DroidCast/scrcpy 等常驻连接藕断丝连
+        atexit.register(self.close)
 
     def start(self) -> None:
         self.client = ADBClient(self.device_id, self.connect)
@@ -178,17 +181,24 @@ class Device:
         self.run(command)
 
     def is_app_running_in_background(self) -> bool:
+        """检查游戏进程是否存活；无法判定时按「运行中」处理，避免误判重新拉起游戏。"""
         try:
-            output = self.client.cmd_shell(f"pidof {config.conf.APPNAME}")
-            return bool(output.strip())
+            # 同一条持久 adb 会话查询，避免另起 adb.exe 进程的竞态假阴性（#159 根因）
+            output = self.run(f"ps -A | grep {config.conf.APPNAME} | grep -v grep")
+            if output.strip():
+                return True
+            # ps 查不到：只有 dumpsys package 能检出 force-stop（stopped=true）
+            package = self.run(f"dumpsys package {config.conf.APPNAME}")
+            if b"stopped=true" in package:
+                return False
         except Exception as e:
             logger.debug(f"检查应用是否在后台运行时出错：{e}")
-            return False
+            return True
+        # ps 查不到、又非 force-stop：无法判定，按「运行中」处理
+        return True
 
     def bring_to_foreground(self):
-        self.client.cmd_shell(
-            f"am start -n {config.conf.APPNAME}/{config.APP_ACTIVITY_NAME}"
-        )
+        self.run(f"am start -n {config.conf.APPNAME}/{config.APP_ACTIVITY_NAME}")
 
     def get_droidcast_classpath(self) -> str | None:
         # TODO: 退出时（并非结束mower线程时）关闭DroidCast进程、取消ADB转发
@@ -211,7 +221,12 @@ class Device:
         if not class_path:
             logger.info("安装DroidCast")
             apk_path = f"{__rootdir__}/vendor/droidcast/DroidCast-debug-1.2.1.apk"
-            out = self.client.cmd(["install", apk_path], decode=True)
+            try:
+                out = self.client.cmd(["install", apk_path], decode=True)
+            except Exception as e:
+                # 设备瞬时离线时 install 会失败：按「装不上」返回 False，不让重连崩
+                logger.warning(f"DroidCast安装失败：{e}")
+                return False
             if "Success" in out:
                 logger.info("DroidCast安装完成，获取CLASSPATH")
             else:
@@ -271,70 +286,53 @@ class Device:
             start_time = min_time
 
         if self.control.mumu12IPC:
-            while True:
+            # 瞬时错误重建 IPC 重试；重试耗尽且设备无法连接时自动重启模拟器
+            for _ in range(3):
                 try:
                     img = self.control.mumu12IPC.capture_display()
                     gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
                     break
+                except MowerExit:
+                    raise
                 except Exception as e:
                     logger.exception(e)
-                    restart_simulator()
                     self.control.mumu12IPC = MuMu12IPC(self.device)
+            else:
+                restart_simulator()
+                self.control.mumu12IPC = MuMu12IPC(self.device)
+                img = self.control.mumu12IPC.capture_display()
+                gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
         elif config.conf.droidcast.enable:
             session = config.droidcast.session
-            while True:
-                try:
-                    port = config.droidcast.port
-                    url = f"http://127.0.0.1:{port}/screenshot"
-                    logger.debug(f"GET {url}")
-                    r = session.get(url)
-                    img = bytes2img(r.content)
-                    if config.conf.droidcast.rotate:
-                        img = cv2.rotate(img, cv2.ROTATE_180)
-                    gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
-                    break
-                except Exception as e:
-                    logger.exception(e)
-                    restart_simulator()
-                    self.client.check_server_alive()
-                    Session().connect(config.conf.adb)
-                    self.start_droidcast()
-                    if config.conf.touch_method == "scrcpy":
-                        self.control.scrcpy = Scrcpy(self.client)
+
+            def grab_droidcast() -> bytes:
+                port = config.droidcast.port
+                url = f"http://127.0.0.1:{port}/screenshot"
+                logger.debug(f"GET {url}")
+                return session.get(url).content
+
+            img = bytes2img(self.recover(grab_droidcast))
+            if config.conf.droidcast.rotate:
+                img = cv2.rotate(img, cv2.ROTATE_180)
+            gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
         elif config.conf.custom_screenshot.enable:
             command = config.conf.custom_screenshot.command
-            while True:
-                try:
-                    data = subprocess.check_output(
-                        command,
-                        shell=True,
-                        creationflags=subprocess.CREATE_NO_WINDOW
-                        if __system__ == "windows"
-                        else 0,
-                    )
-                    break
-                except Exception as e:
-                    logger.exception(e)
-                    restart_simulator()
-                    self.client.check_server_alive()
-                    Session().connect(config.conf.adb)
-                    if config.conf.touch_method == "scrcpy":
-                        self.control.scrcpy = Scrcpy(self.client)
+
+            def grab_custom() -> bytes:
+                return subprocess.check_output(
+                    command,
+                    shell=True,
+                    creationflags=subprocess.CREATE_NO_WINDOW
+                    if __system__ == "windows"
+                    else 0,
+                )
+
+            data = self.recover(grab_custom)
             img = bytes2img(data)
             gray = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
         else:
             command = "screencap 2>/dev/null | gzip -1"
-            while True:
-                try:
-                    resp = self.run(command)
-                    break
-                except Exception as e:
-                    logger.exception(e)
-                    restart_simulator()
-                    self.client.check_server_alive()
-                    Session().connect(config.conf.adb)
-                    if config.conf.touch_method == "scrcpy":
-                        self.control.scrcpy = Scrcpy(self.client)
+            resp = self.recover(lambda: self.run(command))
             data = gzip.decompress(resp)
             array = np.frombuffer(data[-1920 * 1080 * 4 :], np.uint8).reshape(
                 1080, 1920, 4
@@ -400,40 +398,88 @@ class Device:
         )
         self.control.swipe_ext(points, durations, up_wait)
 
-    def check_current_focus(self) -> bool:
-        """check if the application is in the foreground"""
-        update = False
-        while True:
-            try:
-                focus = self.current_focus()
-                expected_focuses = [
-                    f"{config.conf.APPNAME}/{config.APP_ACTIVITY_NAME}",
-                    "com.hypergryph.arknights.bilibili/com.gsc.welcome.WelcomeActivity",
-                    "com.hypergryph.arknights.bilibili/com.gsc.auto_login.AutoLoginActivity",
-                ]
+    def close(self) -> None:
+        """释放 adb 相关资源（常驻子进程与 socket）。
 
-                if focus not in expected_focuses:
-                    if self.is_app_running_in_background():
-                        self.bring_to_foreground()
-                        csleep(2)
-                    else:
-                        # 游戏既不在前台也不在后台，尝试直接拉起前台
-                        self.launch()
-                        csleep(10)
-                    update = True
+        mower 的 DroidCast 截图子进程与 scrcpy 常驻连接都依赖模拟器连接；退出时不清理
+        会一直占住（共享 adb socket 与 mower 所在目录），需关闭模拟器才释放。该方法由
+        atexit 注册，进程退出时调用，幂等可重复调用。
+        """
+        try:
+            process = getattr(config.droidcast, "process", None)
+            if process is not None:
+                process.terminate()
+                config.droidcast.process = None
+        except Exception:
+            logger.debug("终止 DroidCast 进程失败", exc_info=True)
+        try:
+            if self.control is not None and self.control.scrcpy is not None:
+                self.control.scrcpy.stop()
+        except Exception:
+            logger.debug("关闭 scrcpy 失败", exc_info=True)
+
+    def reconnect(self) -> None:
+        """重连 adb 会话 + 重初始化显示/触摸管线（不杀游戏、不重启模拟器）。
+
+        先重新发现目标模拟器当前 adb 端点（如 MuMu 双开端口漂移），避免一直连
+        config.conf.adb 里已失效的旧端口。"""
+        self.client.check_server_alive()
+        target = self.client.refresh_target()
+        self.device_id = target
+        Session().connect(target)
+        if config.conf.droidcast.enable:
+            self.start_droidcast()
+        if config.conf.touch_method == "scrcpy":
+            self.control.scrcpy = Scrcpy(self.client)
+
+    def _safe_reconnect(self) -> None:
+        """重连失败不抛给上层，计入 recover 的重试/重启语义。"""
+        try:
+            self.reconnect()
+        except Exception as e:
+            logger.warning(f"重连失败：{e}")
+
+    def recover(self, func, retries: int = 3, restarts: int = 2):
+        """瞬时错误重连重试；重试耗尽且设备无法连接时自动重启模拟器；重启有上限。"""
+        last_exc = None
+        for _ in range(restarts):
+            for _ in range(retries):
+                try:
+                    return func()
+                except MowerExit:
+                    raise
+                except Exception as e:
+                    last_exc = e
+                    logger.warning(f"重试失败：{e}")
+                    self._safe_reconnect()
+            logger.warning(f"重试 {retries} 次仍失败，判定设备无法连接，自动重启模拟器")
+            restart_simulator()
+            self._safe_reconnect()
+        raise ConnectionError(
+            f"设备连不上，自动重启模拟器 {restarts} 次后仍失败"
+        ) from last_exc
+
+    def check_current_focus(self) -> bool:
+        """检查游戏是否在前台；不在则切回/拉起；仅设备无法连接时才自动重启模拟器。"""
+        update = False
+
+        def check() -> bool:
+            nonlocal update
+            focus = self.current_focus()
+            # 前台判定：package 前缀匹配（游戏包下任何界面都算前台，免疫新 activity）
+            if focus.startswith(config.conf.APPNAME + "/"):
                 return update
-            except MowerExit:
-                raise
-            except Exception as e:
-                logger.exception(e)
-                restart_simulator()
-                self.client.check_server_alive()
-                Session().connect(config.conf.adb)
-                if config.conf.droidcast.enable:
-                    self.start_droidcast()
-                if config.conf.touch_method == "scrcpy":
-                    self.control.scrcpy = Scrcpy(self.client)
-                update = True
+            if self.is_app_running_in_background():
+                self.bring_to_foreground()
+                csleep(2)
+            else:
+                # 游戏进程已停止（force-stop），重拉前台
+                self.launch()
+                csleep(10)
+            update = True
+            return update
+
+        return self.recover(check, retries=3, restarts=3)
 
     def check_resolution(self) -> bool:
         """检查分辨率"""

--- a/arknights_mower/utils/device/mumu12ipc/core.py
+++ b/arknights_mower/utils/device/mumu12ipc/core.py
@@ -53,18 +53,28 @@ def retry_wrapper(max_retries: int = 3, delay: float = 0.5):
                     logger.info(
                         f"{func.__name__} failed (attempt {attempt}/{max_retries}): {e}"
                     )
-
+                    # 瞬时错误：重置 IPC 状态 + 重连，不杀游戏/不重启模拟器
                     try:
                         if hasattr(self, "_conn"):
                             self._conn = 0
                         if hasattr(self, "_display_id"):
                             self._display_id = -1
-                        restart_simulator()
+                        if hasattr(self, "device") and hasattr(
+                            self.device, "reconnect"
+                        ):
+                            self.device.reconnect()
                     except Exception as inner:
-                        logger.error(f"restart_simulator failed: {inner}")
+                        logger.error(f"reconnect failed: {inner}")
                 time.sleep(delay)
+            # 重试耗尽且设备无法连接时自动重启模拟器，再试最后一次
             if last_exc is not None:
-                raise last_exc
+                logger.warning(
+                    f"{func.__name__} 重试 {max_retries} 次仍失败，判定设备无法连接，自动重启模拟器"
+                )
+                restart_simulator()
+                if hasattr(self, "device") and hasattr(self.device, "reconnect"):
+                    self.device.reconnect()
+                return func(self, *args, **kwargs)
             raise RuntimeError(f"{func.__name__} failed after {max_retries} retries")
 
         return wrapper
@@ -385,7 +395,6 @@ class MuMu12IPC:
             # Attempt soft recovery for next call
             self._conn = 0
             self._display_id = -1
-            self.device.exit()
             return np.zeros((self._H, self._W, 3), dtype=np.uint8)
 
     def _map_xy(self, x: int, y: int) -> tuple[int, int]:
@@ -410,7 +419,6 @@ class MuMu12IPC:
             logger.error(f"key_down error: {e}")
             self._conn = 0
             self._display_id = -1
-            self.device.exit()
 
     def key_up(self, key_code: int):
         try:
@@ -424,7 +432,6 @@ class MuMu12IPC:
             logger.error(f"key_up error: {e}")
             self._conn = 0
             self._display_id = -1
-            self.device.exit()
 
     def touch_down(self, x: int, y: int):
         try:
@@ -439,7 +446,6 @@ class MuMu12IPC:
             logger.error(f"touch_down error: {e}")
             self._conn = 0
             self._display_id = -1
-            self.device.exit()
 
     def touch_up(self):
         try:
@@ -451,7 +457,6 @@ class MuMu12IPC:
             logger.error(f"touch_up error: {e}")
             self._conn = 0
             self._display_id = -1
-            self.device.exit()
 
     def finger_touch_down(self, finger_id: int, x: int, y: int):
         try:
@@ -466,7 +471,6 @@ class MuMu12IPC:
             logger.error(f"finger_touch_down error: {e}")
             self._conn = 0
             self._display_id = -1
-            self.device.exit()
 
     def finger_touch_up(self, finger_id: int):
         try:
@@ -480,7 +484,6 @@ class MuMu12IPC:
             logger.error(f"finger_touch_up error: {e}")
             self._conn = 0
             self._display_id = -1
-            self.device.exit()
 
     def tap(self, x: int, y: int, hold_time: float = 0.07):
         self.touch_down(x, y)

--- a/arknights_mower/utils/graph.py
+++ b/arknights_mower/utils/graph.py
@@ -2,10 +2,7 @@ import functools
 
 import networkx as nx
 
-from arknights_mower.utils import config
 from arknights_mower.utils.csleep import MowerExit
-from arknights_mower.utils.device.adb_client.session import Session
-from arknights_mower.utils.device.scrcpy import Scrcpy
 from arknights_mower.utils.log import logger
 from arknights_mower.utils.scene import Scene, SceneComment
 from arknights_mower.utils.simulator import restart_simulator
@@ -448,14 +445,8 @@ class SceneGraphSolver(BaseSolver):
             try:
                 sp = nx.shortest_path(DG, current, scene, weight="weight")
             except Exception as e:
+                # 纯图计算错误（如无路径），与设备无关：不重启模拟器，放弃本次导航
                 logger.exception(f"场景图路径计算异常：{e}")
-                restart_simulator()
-                self.device.client.check_server_alive()
-                Session().connect(config.conf.adb)
-                if config.conf.droidcast.enable:
-                    self.device.start_droidcast()
-                if config.conf.touch_method == "scrcpy":
-                    self.device.control.scrcpy = Scrcpy(self.device.client)
                 return
 
             logger.debug(sp)
@@ -475,12 +466,7 @@ class SceneGraphSolver(BaseSolver):
                     error_count += 1
                     continue
                 if restart_simulator():
-                    self.device.client.check_server_alive()
-                    Session().connect(config.conf.adb)
-                    if config.conf.droidcast.enable:
-                        self.device.start_droidcast()
-                    if config.conf.touch_method == "scrcpy":
-                        self.device.control.scrcpy = Scrcpy(self.device.client)
+                    self.device.reconnect()
                     self.check_current_focus()
                 else:
                     self.restart_game()

--- a/arknights_mower/utils/simulator.py
+++ b/arknights_mower/utils/simulator.py
@@ -1,11 +1,11 @@
 import subprocess
 from dataclasses import dataclass
 from enum import Enum
-from os import system
 
 from arknights_mower import __system__
 from arknights_mower.utils import config
 from arknights_mower.utils.csleep import MowerExit, csleep
+from arknights_mower.utils.device.adb_client.core import query_mumu_adb_port
 from arknights_mower.utils.device.adb_client.session import Session
 from arknights_mower.utils.log import logger
 
@@ -27,6 +27,28 @@ class SimulatorCommandSet:
     blocking: bool = False
 
 
+def _clear_mumu_adb_transport() -> None:
+    """关闭 MuMu12 时清理目标实例的 adb 传输，但不结束共享的 adb server。
+
+    此前 `taskkill /f /t /im adb.exe` 会杀掉 5037 上的全局 adb server，使共用它的
+    另一台模拟器一起掉线（双模拟器场景互相干扰）；改为仅断开当前实例的连接端点。
+    """
+    target = config.conf.adb
+    adb_bin = config.conf.maa_adb_path
+    if not target or not adb_bin:
+        return
+    try:
+        subprocess.run(
+            [adb_bin, "disconnect", target],
+            check=False,
+            capture_output=True,
+            creationflags=subprocess.CREATE_NO_WINDOW if __system__ == "windows" else 0,
+        )
+        logger.info("结束adb进程（仅断开当前实例端点）")
+    except (OSError, subprocess.SubprocessError):
+        logger.debug("断开 MuMu adb 端点失败", exc_info=True)
+
+
 def restart_simulator(stop: bool = True, start: bool = True) -> bool:
     return _restart_simulator(stop=stop, start=start, allow_retry=True)
 
@@ -40,6 +62,12 @@ def _restart_simulator(stop: bool, start: bool, allow_retry: bool) -> bool:
         csleep(10)
         return False
 
+    # 重启前先同步目标实例当前 adb 端点（端口可能漂移），供后续 wait_for_adb→adb_ready
+    # 探测，避免一直探测 config.conf.adb 里已失效的旧端口
+    discovered = query_mumu_adb_port(data)
+    if discovered is not None:
+        config.conf.adb = discovered
+
     commands = build_command_set(simulator_type, data.index)
 
     if stop:
@@ -49,8 +77,7 @@ def _restart_simulator(stop: bool, start: bool, allow_retry: bool) -> bool:
             simulator_type == Simulator_Type.MuMu12.value
             and config.conf.fix_mumu12_adb_disconnect
         ):
-            logger.info("结束adb进程")
-            system("taskkill /f /t /im adb.exe")
+            _clear_mumu_adb_transport()
 
     if not start:
         return True

--- a/arknights_mower/utils/solver.py
+++ b/arknights_mower/utils/solver.py
@@ -54,7 +54,7 @@ class BaseSolver:
         if device is not None:
             self.device = device
         else:
-            while True:
+            for _ in range(3):
                 try:
                     self.device = Device()
                     self.device.client.check_server_alive()
@@ -69,8 +69,22 @@ class BaseSolver:
                 except MowerExit:
                     raise
                 except Exception as e:
-                    logger.exception(e)
-                    restart_simulator()
+                    last_exc = e
+                    logger.warning(f"设备连接失败：{e}")
+                    # 启动时目标设备未注册到 adb=模拟器未启动，直接启动（只启动不关闭，
+                    # 误判也不会杀在跑的游戏）；已注册但瞬时故障才走重连重试
+                    try:
+                        registered = [d for d, _ in Session().devices_list()]
+                    except Exception:
+                        registered = []
+                    if config.conf.adb and config.conf.adb not in registered:
+                        restart_simulator(stop=False, start=True)
+                    elif hasattr(self, "device") and self.device.client:
+                        self.device._safe_reconnect()
+            else:
+                raise ConnectionError(
+                    "设备连接 3 次失败（判定设备无法连接，自动重启模拟器由上层处理）"
+                ) from last_exc
 
         self.recog = recog if recog is not None else Recognizer(self.device)
 

--- a/arknights_mower/views/task.py
+++ b/arknights_mower/views/task.py
@@ -80,7 +80,7 @@ def add_task():
                     return "添加任务成功！"
             raise Exception("添加任务失败！！请确保Mower正在运行")
         except Exception as e:
-            logger.exception(f"添加任务失败：{str(e)}")
+            logger.warning(f"添加任务失败：{str(e)}")
             return str(e)
     else:
         if base_scheduler and mower_thread and mower_thread.is_alive():

--- a/webview_ui.py
+++ b/webview_ui.py
@@ -384,6 +384,9 @@ if __name__ == "__main__":
                     )
                     config.webview_process.start()
             elif msg == "exit":
+                # 退出前先让 mower 线程停止：否则 daemon 线程仍在跑 adb 操作，
+                # 会占着 DroidCast/scrcpy 连接（需关模拟器才释放），且影响进程退出
+                config.stop_mower.set()
                 config.parent_conn.send("exit")
                 if config.webview_process.join(3) is None:
                     config.webview_process.terminate()


### PR DESCRIPTION
双模拟器场景下，运行中的游戏会被 mower 错误关闭，且退出后 adb 资源仍被占用，所以需要关闭模拟器才能释放。前一项来自用户日志「运行中的游戏无故退出」的反馈；后一项在双开时表现为端口漂移与退出后目录无法删除。根因在 mower 对 adb 连接与设备生命周期的处理：瞬时连接错误被当成设备死亡而触发重启模拟器，把正在运行的游戏连同模拟器一起关闭；连接始终连写死端口、从不重读真实端口，`kill-server` 与 `taskkill` 干扰共用 5037 server 的另一台模拟器；退出时不终止 DroidCast 子进程与 scrcpy 常驻 socket。

### 变更

- 游戏不再因瞬时连接错误被关闭：`run()` 与 `__run()` 把 `b'closed'` 纳入重连兜底；`is_app_running_in_background()` 在同一条持久 adb 会话内用 `ps` 与 `dumpsys package` 双查，无法判定时按运行中处理；`check_current_focus()` 按包名前缀判定前台，瞬时错误走 `recover()` 与 `reconnect()` 重连重试，只有确认设备无法连接才自动重启模拟器，且重启次数有上限。
- adb 连接改为按真实端口重连：新增 `query_mumu_adb_port()` 从 MuMuManager 读取目标实例当前 adb 端口；`refresh_target()` 据此更新 `device_id` 与 `config.conf.adb`，仅内存更新；`__check_adb` 只 `start-server`；`_clear_mumu_adb_transport()` 只断开当前实例的连接端点，不影响全局 adb server。
- 退出时释放 adb 资源：`Device.close()` 终止 DroidCast 子进程并关闭 scrcpy 连接，在 `__init__` 经 `atexit` 注册；托盘退出先设置 `config.stop_mower`，使 mower 线程停止。

### 验证

- `python -m pytest` 全部 `*_tests.py`：520 passed，10 skipped，2 subtests passed。
- `ruff check`：通过，无告警。
- 本 PR 的 diff 与已验证的树一致（合并前 squash 前后树相同），以上测试结果对合并后同样有效。

### 限制

- 本机只能跑单实例，真实双模拟器场景未实机验证；发现逻辑用 live MuMu 实测：运行实例返回真实端口、停止实例与 Nox 返回 `None`。
- 非 MuMu 模拟器与现有手工配置保持原行为。
