### PR TITLE
fix(ui): 修复窗口尺寸配置不生效

### DIFF
--- a/arknights_mower/tests/webview_ui_tests.py
+++ b/arknights_mower/tests/webview_ui_tests.py
@@ -1,9 +1,16 @@
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
+from arknights_mower.utils.config import gui
 from webview_ui import (
     _LINUX_WEBVIEW_INSTALL_HINT,
+    DEFAULT_WINDOW_SIZE,
+    MIN_WINDOW_SIZE,
     linux_webview_backend_error,
+    resolve_window_size,
+    sanitize_window_size,
 )
 
 
@@ -37,6 +44,75 @@ class TestLinuxWebviewBackendError(unittest.TestCase):
         self.assertIn("sudo apt install", hint)
         self.assertIn("sudo dnf install", hint)
         self.assertIn("sudo pacman -S", hint)
+
+
+class TestSanitizeWindowSize(unittest.TestCase):
+    def test_valid_size_kept(self):
+        self.assertEqual(sanitize_window_size(1450, 850), (1450, 850))
+
+    def test_zero_size_ignored(self):
+        # WebView2 销毁路径的残留事件：0x0 不得进入窗口尺寸
+        self.assertIsNone(sanitize_window_size(0, 0))
+
+    def test_tiny_width_ignored(self):
+        self.assertIsNone(sanitize_window_size(50, 850))
+
+    def test_tiny_height_ignored(self):
+        self.assertIsNone(sanitize_window_size(1450, 30))
+
+    def test_boundary_min_kept(self):
+        self.assertEqual(
+            sanitize_window_size(MIN_WINDOW_SIZE, MIN_WINDOW_SIZE),
+            (MIN_WINDOW_SIZE, MIN_WINDOW_SIZE),
+        )
+
+    def test_below_min_ignored(self):
+        self.assertIsNone(sanitize_window_size(MIN_WINDOW_SIZE - 1, 850))
+
+    def test_non_numeric_ignored(self):
+        self.assertIsNone(sanitize_window_size("tiny", 850))
+
+    def test_non_finite_ignored(self):
+        # int(inf) 抛 OverflowError，同样视为损坏尺寸
+        self.assertIsNone(sanitize_window_size(float("inf"), 850))
+        self.assertIsNone(sanitize_window_size(float("-inf"), 850))
+
+
+class TestResolveWindowSize(unittest.TestCase):
+    def test_valid_conf_size_kept(self):
+        self.assertEqual(resolve_window_size(1450, 850), (1450, 850))
+
+    def test_broken_conf_falls_back_to_default(self):
+        # conf.yml 已被旧 bug 写坏（极小/零尺寸）时兜底到默认启动尺寸
+        self.assertEqual(resolve_window_size(0, 0), DEFAULT_WINDOW_SIZE)
+        self.assertEqual(resolve_window_size(50, 850), DEFAULT_WINDOW_SIZE)
+        self.assertEqual(resolve_window_size("tiny", 850), DEFAULT_WINDOW_SIZE)
+
+    def test_non_finite_conf_falls_back_to_default(self):
+        self.assertEqual(resolve_window_size(float("inf"), 850), DEFAULT_WINDOW_SIZE)
+
+
+class TestGuiWindowSize(unittest.TestCase):
+    def test_missing_file_returns_none(self):
+        # gui.yml 还不存在（首次运行）→ 返回 None，由调用方兜底默认尺寸。
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(gui, "gui_path", Path(d) / "gui.yml"):
+                self.assertIsNone(gui.load_window_size())
+
+    def test_save_then_load_roundtrip(self):
+        # 存进去的尺寸能原样读回，验证读写都落在 gui.yml 上。
+        with tempfile.TemporaryDirectory() as d:
+            with mock.patch.object(gui, "gui_path", Path(d) / "gui.yml"):
+                gui.save_window_size((1600, 900))
+                self.assertEqual(gui.load_window_size(), (1600, 900))
+
+    def test_corrupt_content_returns_none(self):
+        # 内容非法（宽为非数字）→ 返回 None，不把坏值传出去。
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "gui.yml"
+            p.write_text("width: abc\nheight: 900\n", encoding="utf-8")
+            with mock.patch.object(gui, "gui_path", p):
+                self.assertIsNone(gui.load_window_size())
 
 
 if __name__ == "__main__":

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -87,10 +87,6 @@ class ExtraPart(ConfModel):
     class WebViewConf(ConfModel):
         port: int = 58000
         "端口号"
-        width: int = 1450
-        "窗口宽度"
-        height: int = 850
-        "窗口高度"
         token: str = ""
         "远程连接密钥"
         scale: float = 1

--- a/arknights_mower/utils/config/gui.py
+++ b/arknights_mower/utils/config/gui.py
@@ -1,0 +1,39 @@
+"""GUI 进程专属配置。
+
+窗口几何这类只属于界面进程的设置与共享的 conf.yml 分离——父进程（调度/服务）
+不读不写这里，避免两个进程同时管 conf.yml 时一方用旧值覆盖另一方的窗口尺寸，
+导致重开窗口尺寸不固定。
+"""
+
+import yaml
+from yamlcore import CoreDumper, CoreLoader
+
+from arknights_mower.utils.path import get_path
+
+gui_path = get_path("@app/gui.yml")
+
+
+def load_window_size():
+    """读取窗口尺寸；文件缺失或内容非法时返回 None，由调用方兜底默认值。"""
+    if not gui_path.is_file():
+        return None
+    try:
+        with gui_path.open("r", encoding="utf-8") as f:
+            data = yaml.load(f, Loader=CoreLoader) or {}
+        return (int(data["width"]), int(data["height"]))
+    except (OSError, TypeError, KeyError, ValueError):
+        return None
+
+
+def save_window_size(size):
+    """写入窗口尺寸（调用方已消毒，保证非法尺寸不进盘）。"""
+    width, height = size
+    gui_path.parent.mkdir(exist_ok=True)
+    with gui_path.open("w", encoding="utf-8") as f:
+        yaml.dump(
+            {"width": width, "height": height},
+            f,
+            Dumper=CoreDumper,
+            encoding="utf-8",
+            allow_unicode=True,
+        )

--- a/webview_ui.py
+++ b/webview_ui.py
@@ -69,6 +69,32 @@ def exit_if_webview_backend_missing():
     sys.exit(1)
 
 
+# 托盘开关窗口是杀进程重建（见 webview_window / start_tray），新窗口尺寸读
+# gui.yml。Windows WebView2 在窗口初始化/销毁路径会触发极小/零尺寸 resized，
+# 若当成立即写回配置，下次打开就缩成一团——下限钳制挡住这些残留事件。
+MIN_WINDOW_SIZE = 100
+# 仅在 gui.yml 缺失或内容损坏（极小/零/非数字）时兜底，避免坏尺寸被读进创建
+# 并再次持久化。窗口尺寸唯一落在 GUI 进程专属的 gui.yml，不再进共享的 conf.yml。
+DEFAULT_WINDOW_SIZE = (1450, 850)
+
+
+def sanitize_window_size(width, height, min_size=MIN_WINDOW_SIZE):
+    """返回合法的窗口尺寸；极小/零/非数字视为销毁路径的残留事件，返回 None。"""
+    try:
+        w = int(width)
+        h = int(height)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if w < min_size or h < min_size:
+        return None
+    return (w, h)
+
+
+def resolve_window_size(width, height, min_size=MIN_WINDOW_SIZE):
+    """校验并返回合法的初始尺寸；损坏（极小/零/非数字）时兜底到默认启动尺寸。"""
+    return sanitize_window_size(width, height, min_size) or DEFAULT_WINDOW_SIZE
+
+
 def splash_screen(queue: mp.Queue):
     import tkinter as tk
     from tkinter.font import Font
@@ -196,22 +222,24 @@ def webview_window(child_conn, global_space, instance_name, host, port, url, tra
     webview.settings["ALLOW_DOWNLOADS"] = True
 
     from arknights_mower.__init__ import __version__
-    from arknights_mower.utils import config, path
+    from arknights_mower.utils import path
 
     path.global_space = global_space
+
+    from arknights_mower.utils.config.gui import load_window_size, save_window_size
 
     global width
     global height
 
-    config.load_conf()
-    width = config.conf.webview.width
-    height = config.conf.webview.height
+    size = load_window_size()
+    width, height = resolve_window_size(*size) if size else DEFAULT_WINDOW_SIZE
 
     def window_size(w, h):
         global width
         global height
-        width = w
-        height = h
+        size = sanitize_window_size(w, h)
+        if size is not None:
+            width, height = size
 
     window = webview.create_window(
         f"arknights-mower {__version__} - {build_window_title(instance_name, port)}",
@@ -252,10 +280,9 @@ def webview_window(child_conn, global_space, instance_name, host, port, url, tra
     try:
         webview.start()
 
-        config.load_conf()
-        config.conf.webview.width = width
-        config.conf.webview.height = height
-        config.save_conf()
+        size = sanitize_window_size(width, height)
+        if size is not None:
+            save_window_size(size)
         sys.exit()
     except Exception:
         import webbrowser


### PR DESCRIPTION
修复窗口尺寸配置不生效

## 目标 / 结果

托盘关窗再开窗时，窗口尺寸回到旧值，而不是用户本次会话设置的尺寸。这个改动把窗口尺寸从共享的 `conf.yml` 移到 GUI 进程专属的 `gui.yml`，由窗口进程独占读写，配置能够真正生效。

## 变更

- 新增 `arknights_mower/utils/config/gui.py`，窗口尺寸存放在 `@app/gui.yml`，只由窗口进程读写；父进程（调度/服务）不再读取或写入这个值。
- `arknights_mower/utils/config/conf.py` 的 `WebViewConf` 移除 `width` 与 `height` 字段，父进程保存 `conf.yml` 时不再携带窗口尺寸。
- `webview_ui.py` 的 `webview_window` 改为用 `gui.load_window_size()` 读取初始尺寸，关窗时用 `gui.save_window_size()` 保存到 `gui.yml`。保留 `MIN_WINDOW_SIZE` 与 `sanitize_window_size` 对 WebView2 初始化、销毁路径上瞬态小尺寸（小于 100 像素、非数字、非有限值）的下限钳制；`gui.yml` 缺失或内容非法时回退默认 `1450x850`。
- 配置文件命名参照 MAA 的 GUI 配置（`gui.json` → `gui.yml`）。

## 验证

- 实机日志（复现 X 关窗、托盘重开）：窗口子进程每次都能把尺寸正确保存，记为 `[close-save] wrote (1792, 1028)`；但下一会话启动时读取到 `[startup] conf.webview=1000x500`，说明尺寸在两次会话之间被父进程内存里冻结的旧值覆盖，窗口设置没有生效。同一条日志也确认了 WebView2 初始化路径的瞬态 `237x39` 被下限钳制判定为无效（`[resized] w=237 h=39 -> None`）。
- `webview_ui_tests` 17 个用例通过，包含新增的 `TestGuiWindowSize`；全仓 `python -m unittest discover -s arknights_mower/tests -p "*_tests.py"` 544 个用例通过。
- `ruff check .` 与 `ruff format --check .` 通过。
- 父进程用旧值覆盖的触发点已经在日志确认。修复后需要实机复验「拖拽、X 关窗、托盘重开」这一遍尺寸是否保留，整体行为待实机确认。

## 限制

首次运行升级后 `gui.yml` 尚不存在，窗口以默认 `1450x850` 打开一次，此后由窗口进程写入、尺寸固定。旧 `conf.yml` 里的 `webview.width` 与 `webview.height` 会被 pydantic 忽略，不做迁移；这个值本身已被父进程覆盖过，不可靠。
