### PR TITLE
feat(config): 配置文件改走原子写并挪到 config/ 目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,6 +199,9 @@ dmypy.json
 ### 命令行运行产生的/tmp/data.db
 /tmp/
 
+# 运行期配置文件（@app/config/，2026-08-21 由 @app/ 迁移而来）
+/config/
+
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode
 /*.json
 dist

--- a/arknights_mower/agent/tools/analyze_missed_order.py
+++ b/arknights_mower/agent/tools/analyze_missed_order.py
@@ -56,7 +56,8 @@ def _get_run_order_delay_minutes() -> float:
         return float(getattr(config.conf, "run_order_delay", 0) or 0)
     except Exception:
         try:
-            conf_path = get_path("@app/conf.yml")
+            from arknights_mower.utils.config import conf_path
+
             with conf_path.open("r", encoding="utf-8", errors="ignore") as handle:
                 for raw_line in handle:
                     line = raw_line.strip()

--- a/arknights_mower/solvers/cultivate_depot.py
+++ b/arknights_mower/solvers/cultivate_depot.py
@@ -3,6 +3,7 @@ import json
 import requests
 
 from arknights_mower.utils import config
+from arknights_mower.utils.config import atomic_write
 from arknights_mower.utils.path import get_path
 from arknights_mower.utils.skland import (
     get_binding_list,
@@ -34,9 +35,12 @@ class cultivate:
                     headers=get_sign_header(ingame, "get", body, self.sign_token),
                     timeout=30,
                 ).json()
-                self.record_path.parent.mkdir(parents=True, exist_ok=True)
-                with open(self.record_path, "w", encoding="utf-8") as file:
+
+                def dump(file):
                     json.dump(resp, file, ensure_ascii=False, indent=4)
+
+                # web 线程（views/mastery.py 刷新）与调度线程共用本写点，原子写防撕裂
+                atomic_write(self.record_path, dump)
 
     def save_param(self, cred_resp):
         header["cred"] = cred_resp["cred"]

--- a/arknights_mower/tests/config_tests.py
+++ b/arknights_mower/tests/config_tests.py
@@ -1,0 +1,199 @@
+import json
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from arknights_mower.utils import config as config_module
+from arknights_mower.utils.config import atomic_write, migrate_app_config_paths
+
+
+class TestAtomicWrite(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+        self.target = self.dir / "sub" / "target.json"
+
+    def _writer(self, f):
+        f.write("{}")
+
+    def test_writes_content_and_removes_temp(self):
+        atomic_write(self.target, self._writer)
+        self.assertTrue(self.target.is_file())
+        self.assertEqual(self.target.read_text(encoding="utf-8"), "{}")
+        leftovers = [p for p in self.dir.rglob(".*.tmp") if p.is_file()]
+        self.assertEqual(leftovers, [])
+
+    def test_creates_parent_dirs(self):
+        atomic_write(self.target, self._writer)
+        self.assertTrue(self.target.parent.is_dir())
+
+    def test_cleans_temp_on_writer_exception(self):
+        def bad_writer(f):
+            f.write("partial")
+            raise RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError):
+            atomic_write(self.target, bad_writer)
+        self.assertFalse(self.target.exists())
+        leftovers = [p for p in self.dir.rglob(".*.tmp") if p.is_file()]
+        self.assertEqual(leftovers, [])
+
+    def test_overwrites_existing_file(self):
+        self.target.parent.mkdir(parents=True, exist_ok=True)
+        self.target.write_text("old", encoding="utf-8")
+        atomic_write(self.target, self._writer)
+        self.assertEqual(self.target.read_text(encoding="utf-8"), "{}")
+
+    def test_concurrent_writes_same_path_succeed(self):
+        # web/调度线程可能并发写同一文件（如 cultivate.json）：每路径锁串行化，
+        # Windows 上不应再出现 os.replace PermissionError
+        target = self.dir / "shared.json"
+        errors = []
+
+        def worker(tag):
+            try:
+                for _ in range(20):
+                    atomic_write(target, lambda f: json.dump({"tag": tag}, f))
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+        self.assertTrue(target.is_file())
+
+
+class TestMigrateAppConfigPaths(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+        self.old = self.dir / "old.json"
+        self.new = self.dir / "new" / "new.json"
+
+    def _pairs(self):
+        return [(self.old, self.new)]
+
+    def test_moves_old_when_new_missing(self):
+        self.old.write_text("data", encoding="utf-8")
+        with patch.object(config_module, "_CONFIG_PATH_PAIRS", self._pairs()):
+            migrate_app_config_paths()
+        self.assertFalse(self.old.exists())
+        self.assertEqual(self.new.read_text(encoding="utf-8"), "data")
+
+    def test_keeps_both_when_both_exist(self):
+        self.old.write_text("old", encoding="utf-8")
+        self.new.parent.mkdir(parents=True, exist_ok=True)
+        self.new.write_text("new", encoding="utf-8")
+        with patch.object(config_module, "_CONFIG_PATH_PAIRS", self._pairs()):
+            migrate_app_config_paths()
+        self.assertEqual(self.old.read_text(encoding="utf-8"), "old")
+        self.assertEqual(self.new.read_text(encoding="utf-8"), "new")
+
+    def test_leaves_new_alone_when_only_new(self):
+        self.new.parent.mkdir(parents=True, exist_ok=True)
+        self.new.write_text("new", encoding="utf-8")
+        with patch.object(config_module, "_CONFIG_PATH_PAIRS", self._pairs()):
+            migrate_app_config_paths()
+        self.assertEqual(self.new.read_text(encoding="utf-8"), "new")
+        self.assertFalse(self.old.exists())
+
+    def test_noop_when_neither_exists(self):
+        with patch.object(config_module, "_CONFIG_PATH_PAIRS", self._pairs()):
+            migrate_app_config_paths()
+        self.assertFalse(self.old.exists())
+        self.assertFalse(self.new.exists())
+
+    def test_migrate_then_load_reads_legacy_conf(self):
+        # 核心事故防护：旧 conf 存在 → migrate → load_conf 读到旧值而非默认值
+        old = self.dir / "conf.yml"
+        new = self.dir / "config" / "conf.yml"
+        legacy = "webview:\n  port: 58001\n"
+        old.write_text(legacy, encoding="utf-8")
+        original_conf = config_module.conf
+        try:
+            with (
+                patch.object(config_module, "_CONFIG_PATH_PAIRS", [(old, new)]),
+                patch.object(config_module, "conf_path", new),
+            ):
+                migrate_app_config_paths()
+                config_module.load_conf()
+            self.assertEqual(config_module.conf.webview.port, 58001)
+            self.assertEqual(new.read_text(encoding="utf-8"), legacy)
+        finally:
+            config_module.conf = original_conf
+
+    def test_migration_failure_keeps_old_file_and_does_not_crash(self):
+        # Windows 上 os.replace 失败（锁住/TOCTOU）→ 跳过保留旧文件，不拖垮 import
+        old = self.dir / "conf.yml"
+        new = self.dir / "config" / "conf.yml"
+        old.write_text("legacy", encoding="utf-8")
+
+        def boom(*args, **kwargs):
+            raise PermissionError("locked")
+
+        with (
+            patch.object(config_module, "_CONFIG_PATH_PAIRS", [(old, new)]),
+            patch("arknights_mower.utils.config.os.replace", boom),
+        ):
+            migrate_app_config_paths()
+        self.assertTrue(old.exists())
+        self.assertFalse(new.exists())
+
+
+class TestPersistFunctionsWriteThrough(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+
+    def test_save_conf_writes_atomic(self):
+        target = self.dir / "conf.yml"
+        with patch.object(config_module, "conf_path", target):
+            config_module.save_conf()
+        self.assertTrue(target.is_file())
+        self.assertIn("webview", target.read_text(encoding="utf-8"))
+        leftovers = [p for p in self.dir.rglob(".*.tmp") if p.is_file()]
+        self.assertEqual(leftovers, [])
+
+    def test_save_plan_writes_atomic(self):
+        target = self.dir / "plan.json"
+        with patch.object(config_module, "plan_path", target):
+            config_module.save_plan()
+        self.assertTrue(target.is_file())
+        json_text = target.read_text(encoding="utf-8")
+        self.assertTrue(json_text.lstrip().startswith("{"))
+        leftovers = [p for p in self.dir.rglob(".*.tmp") if p.is_file()]
+        self.assertEqual(leftovers, [])
+
+    def test_write_app_state_writes_atomic(self):
+        import arknights_mower.utils.config.app_state as app_state_module
+
+        target = self.dir / "state.json"
+        with patch.object(app_state_module, "STATE_FILE", target):
+            app_state_module.write_app_state({"active_weekly_plan": "默认"})
+        self.assertTrue(target.is_file())
+        self.assertEqual(
+            target.read_text(encoding="utf-8"), '{\n  "active_weekly_plan": "默认"\n}'
+        )
+
+    def test_write_weekly_plans_writes_atomic(self):
+        from arknights_mower.utils.config.weekly_plan_loader import WeeklyPlanManager
+
+        target = self.dir / "weekly_plans.yml"
+        manager = object.__new__(WeeklyPlanManager)
+        with patch.object(WeeklyPlanManager, "WEEKLY_PLANS_FILE", target):
+            manager._write_weekly_plans({"plans": {"默认": []}})
+        self.assertTrue(target.is_file())
+        leftovers = [p for p in self.dir.rglob(".*.tmp") if p.is_file()]
+        self.assertEqual(leftovers, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/config_tests.py
+++ b/arknights_mower/tests/config_tests.py
@@ -146,6 +146,12 @@ class TestMigrateAppConfigPaths(unittest.TestCase):
         self.assertTrue(old.exists())
         self.assertFalse(new.exists())
 
+    def test_gui_pair_converges_to_config_dir(self):
+        # gui 窗口尺寸配置与其余应用配置一起收敛到 @app/config/，旧 @app/gui.yml 纳入迁移
+        pairs = dict(config_module._CONFIG_PATH_PAIRS)
+        self.assertEqual(pairs[config_module._LEGACY_GUI_PATH], config_module.gui_path)
+        self.assertEqual(config_module.gui_path.parent.name, "config")
+
 
 class TestPersistFunctionsWriteThrough(unittest.TestCase):
     def setUp(self):

--- a/arknights_mower/utils/config/__init__.py
+++ b/arknights_mower/utils/config/__init__.py
@@ -1,4 +1,9 @@
 import json
+import logging
+import os
+import tempfile
+import threading
+import time
 from datetime import datetime, timedelta
 from queue import Queue
 from threading import Event
@@ -13,12 +18,93 @@ from arknights_mower.utils.config.conf import Conf
 from arknights_mower.utils.config.plan import PlanModel
 from arknights_mower.utils.path import get_path
 
-conf_path = get_path("@app/conf.yml")
-plan_path = get_path("@app/plan.json")
+logger = logging.getLogger(__name__)
+
+# 应用配置文件统一收敛到 @app/config/。老路径（@app/xxx）由 migrate_app_config_paths
+# 在启动时搬一次——不搬会静默生成默认配置、把老配置弄丢。
+conf_path = get_path("@app/config/conf.yml")
+plan_path = get_path("@app/config/plan.json")
+app_state_path = get_path("@app/config/state.json")
+weekly_plans_path = get_path("@app/config/weekly_plans.yml")
+
+_LEGACY_CONF_PATH = get_path("@app/conf.yml")
+_LEGACY_PLAN_PATH = get_path("@app/plan.json")
+_LEGACY_APP_STATE_PATH = get_path("@app/state.json")
+_LEGACY_WEEKLY_PLANS_PATH = get_path("@app/weekly_plans.yml")
+
+_CONFIG_PATH_PAIRS = (
+    (_LEGACY_CONF_PATH, conf_path),
+    (_LEGACY_PLAN_PATH, plan_path),
+    (_LEGACY_APP_STATE_PATH, app_state_path),
+    (_LEGACY_WEEKLY_PLANS_PATH, weekly_plans_path),
+)
+
+
+_ATOMIC_WRITE_LOCKS = {}
+_ATOMIC_WRITE_LOCKS_GUARD = threading.Lock()
+
+
+def _path_write_lock(path):
+    key = os.path.normcase(str(path))
+    with _ATOMIC_WRITE_LOCKS_GUARD:
+        return _ATOMIC_WRITE_LOCKS.setdefault(key, threading.Lock())
+
+
+def atomic_write(path, writer, replace_retries=3):
+    """writer(f) 写入 path：先写同目录临时文件再 os.replace，读方永远看不到半截文件。
+
+    web/调度线程可能并发写同一文件（如 cultivate.json）——每路径锁串行化写方；
+    Windows 上读方持句柄时 os.replace 会瞬时 PermissionError，重试顶过去。
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _path_write_lock(path):
+        temporary = tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=path.parent,
+            delete=False,
+        )
+        try:
+            with temporary as f:
+                writer(f)
+            for attempt in range(replace_retries):
+                try:
+                    os.replace(temporary.name, path)
+                    break
+                except PermissionError:
+                    if attempt == replace_retries - 1:
+                        raise
+                    time.sleep(0.02 * (attempt + 1))
+        finally:
+            try:
+                os.unlink(temporary.name)
+            except FileNotFoundError:
+                pass
+
+
+def migrate_app_config_paths():
+    """新路径缺失且旧路径存在 → os.replace 搬过去；两边都在 → 不动。
+
+    os.replace 失败（Windows 上 AV/另一进程瞬时锁住旧文件，或双进程并发首次迁移
+    的 TOCTOU）时记 warning 跳过——旧文件保留在旧路径，不拖垮整个启动。
+    """
+    for old, new in _CONFIG_PATH_PAIRS:
+        if new.exists() or not old.exists():
+            continue
+        try:
+            new.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(old, new)
+        except (FileNotFoundError, PermissionError) as exc:
+            logger.warning("迁移配置 %s → %s 失败，保留旧文件：%s", old, new, exc)
+
+
+migrate_app_config_paths()
 
 
 def save_conf():
-    with conf_path.open("w", encoding="utf8") as f:
+    def dump(f):
         yaml.dump(
             conf.model_dump(),
             f,
@@ -27,6 +113,8 @@ def save_conf():
             default_flow_style=False,
             allow_unicode=True,
         )
+
+    atomic_write(conf_path, dump)
 
 
 def load_conf():
@@ -45,8 +133,10 @@ load_conf()
 
 
 def save_plan():
-    with plan_path.open("w", encoding="utf-8") as f:
+    def dump(f):
         json.dump(plan.model_dump(exclude_none=True), f, ensure_ascii=False, indent=2)
+
+    atomic_write(plan_path, dump)
 
 
 def load_plan():

--- a/arknights_mower/utils/config/__init__.py
+++ b/arknights_mower/utils/config/__init__.py
@@ -26,17 +26,20 @@ conf_path = get_path("@app/config/conf.yml")
 plan_path = get_path("@app/config/plan.json")
 app_state_path = get_path("@app/config/state.json")
 weekly_plans_path = get_path("@app/config/weekly_plans.yml")
+gui_path = get_path("@app/config/gui.yml")
 
 _LEGACY_CONF_PATH = get_path("@app/conf.yml")
 _LEGACY_PLAN_PATH = get_path("@app/plan.json")
 _LEGACY_APP_STATE_PATH = get_path("@app/state.json")
 _LEGACY_WEEKLY_PLANS_PATH = get_path("@app/weekly_plans.yml")
+_LEGACY_GUI_PATH = get_path("@app/gui.yml")
 
 _CONFIG_PATH_PAIRS = (
     (_LEGACY_CONF_PATH, conf_path),
     (_LEGACY_PLAN_PATH, plan_path),
     (_LEGACY_APP_STATE_PATH, app_state_path),
     (_LEGACY_WEEKLY_PLANS_PATH, weekly_plans_path),
+    (_LEGACY_GUI_PATH, gui_path),
 )
 
 

--- a/arknights_mower/utils/config/app_state.py
+++ b/arknights_mower/utils/config/app_state.py
@@ -1,9 +1,9 @@
 import json
 
+from arknights_mower.utils.config import app_state_path, atomic_write
 from arknights_mower.utils.log import logger
-from arknights_mower.utils.path import get_path
 
-STATE_FILE = get_path("@app/state.json")
+STATE_FILE = app_state_path
 
 
 def read_app_state() -> dict:
@@ -22,6 +22,7 @@ def read_app_state() -> dict:
 
 
 def write_app_state(data: dict):
-    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with STATE_FILE.open("w", encoding="utf-8") as file:
+    def dump(file):
         json.dump(data, file, ensure_ascii=False, indent=2)
+
+    atomic_write(STATE_FILE, dump)

--- a/arknights_mower/utils/config/gui.py
+++ b/arknights_mower/utils/config/gui.py
@@ -3,14 +3,15 @@
 窗口几何这类只属于界面进程的设置与共享的 conf.yml 分离——父进程（调度/服务）
 不读不写这里，避免两个进程同时管 conf.yml 时一方用旧值覆盖另一方的窗口尺寸，
 导致重开窗口尺寸不固定。
+
+持久化路径与原子写复用 config 模块的收敛方案：gui.yml 与其余应用配置一起落在
+@app/config/，走 atomic_write，旧 @app/gui.yml 由 migrate_app_config_paths 搬进来。
 """
 
 import yaml
 from yamlcore import CoreDumper, CoreLoader
 
-from arknights_mower.utils.path import get_path
-
-gui_path = get_path("@app/gui.yml")
+from arknights_mower.utils.config import atomic_write, gui_path
 
 
 def load_window_size():
@@ -28,8 +29,8 @@ def load_window_size():
 def save_window_size(size):
     """写入窗口尺寸（调用方已消毒，保证非法尺寸不进盘）。"""
     width, height = size
-    gui_path.parent.mkdir(exist_ok=True)
-    with gui_path.open("w", encoding="utf-8") as f:
+
+    def dump(f):
         yaml.dump(
             {"width": width, "height": height},
             f,
@@ -37,3 +38,5 @@ def save_window_size(size):
             encoding="utf-8",
             allow_unicode=True,
         )
+
+    atomic_write(gui_path, dump)

--- a/arknights_mower/utils/config/weekly_plan_loader.py
+++ b/arknights_mower/utils/config/weekly_plan_loader.py
@@ -2,15 +2,15 @@ from typing import Optional
 
 import yaml
 
+from arknights_mower.utils.config import atomic_write, weekly_plans_path
 from arknights_mower.utils.config.app_state import read_app_state, write_app_state
 from arknights_mower.utils.log import logger
-from arknights_mower.utils.path import get_path
 
 
 class WeeklyPlanManager:
     """Persist weekly plan presets and keep the active plan synced to runtime config."""
 
-    WEEKLY_PLANS_FILE = get_path("@app/weekly_plans.yml")
+    WEEKLY_PLANS_FILE = weekly_plans_path
     DEFAULT_PLAN_KEY = "默认"
 
     def __init__(self):
@@ -92,9 +92,10 @@ class WeeklyPlanManager:
             return yaml.safe_load(f) or {"plans": {}}
 
     def _write_weekly_plans(self, data: dict):
-        self.WEEKLY_PLANS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with self.WEEKLY_PLANS_FILE.open("w", encoding="utf-8") as f:
+        def dump(f):
             yaml.safe_dump(data, f, allow_unicode=True, sort_keys=False)
+
+        atomic_write(self.WEEKLY_PLANS_FILE, dump)
 
     def _read_state(self) -> dict:
         return read_app_state()

--- a/arknights_mower/utils/depot.py
+++ b/arknights_mower/utils/depot.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from arknights_mower.data import key_mapping, workshop_formula
 from arknights_mower.solvers.record import save_inventory_counts
+from arknights_mower.utils.config import atomic_write
 from arknights_mower.utils.csv_utils import read_csv_rows
 from arknights_mower.utils.path import get_path
 
@@ -247,5 +248,9 @@ def 创建json():
         "timestamp": "1719065002",
         "data": {"items": [{"id": "31063", "count": "0"}]},
     }
-    with open(path, "w", encoding="utf-8") as f:
+
+    def dump(f):
         json.dump(a, f)
+
+    # 与 cultivate_depot.py 共用写点，原子写防撕裂（web 刷新线程并发）
+    atomic_write(path, dump)


### PR DESCRIPTION
## 目标 / 结果

配置写盘一直是在原文件上覆盖着写，写到一半断电或崩溃，文件就坏了。这次改成先写同目录临时文件，写好后一次性替换成目标文件，读的人永远看不到半截内容。同时把应用的配置文件统一挪到 `config/` 子目录，启动时自动把老位置的文件搬过来，搬不动也不影响启动。顺带修了 `cultivate.json` 被两个线程同时写会写坏的问题。GUI 窗口尺寸配置也一并收敛到 `config/` 并改走原子写。

## 变更

- `utils/config/__init__.py`：新增 `atomic_write`，先写同目录临时文件再 `os.replace`；每路径一把锁串行化写方；Windows 上 `os.replace` 瞬时 `PermissionError` 按递增间隔重试。`conf` / `plan` / `app_state` / `weekly_plans` / `gui` 五个配置文件的路径统一收敛到 `@app/config/`。
- 新增 `migrate_app_config_paths`：启动时把老路径（`@app/xxx`）的文件搬到 `@app/config/xxx`；两边都在或搬不动就跳过，不拖垮启动。
- `save_conf` / `save_plan` / `write_app_state` / `WeeklyPlanManager._write_weekly_plans` 全部改走 `atomic_write`。
- `cultivate_depot.py` / `depot.py` 共用写点改走 `atomic_write`，避免 web 刷新线程与调度线程并发写坏 `cultivate.json`。
- `analyze_missed_order.py` 改从 `config.conf_path` 读取配置，跟上新路径。
- `utils/config/gui.py`：窗口尺寸配置从 `@app/gui.yml` 收敛到 `@app/config/gui.yml`，保存改走 `atomic_write`，旧路径登记进迁移。
- `tests/config_tests.py`：新增原子写、路径迁移、以及 gui.yml 收敛对应的测试。

## 验证

- `python -m unittest discover -s arknights_mower/tests -p "*_tests.py"`：560 个用例运行，10 个被跳过，其余全部通过。
- `ruff check .` 与 `ruff format --check .` 通过。
- 原子写与迁移只依赖 `os` / `tempfile` / `threading`，`os.replace` 在 POSIX 与 Windows 上都是原子替换，没有混入 fork 特有或平台绑定的代码。`prettier` 只针对 `ui/**`，本次未改 UI，不涉及。
- 交叉平台差异只在 `os.replace` 的 `PermissionError` 重试路径——这主要发生在 Windows 上读方持句柄时；Linux / macOS 基本不触发，不影响行为。

## 限制

- 升级后老配置文件由迁移自动搬进 `config/`；搬不动的情形（Windows 上被 AV 或另一进程锁住）保留旧文件并记 warning，不阻塞启动。
- GUI 窗口尺寸在首次运行（尚无 `gui.yml`）时以默认值打开一次，此后由窗口进程写入、尺寸固定。
