### PR TITLE
fix(ui): 修复一键替换干员漏换主副表全部字段的问题

### DIFF
--- a/ui/src/components/PlanEditor.vue
+++ b/ui/src/components/PlanEditor.vue
@@ -3,6 +3,7 @@ import { storeToRefs } from 'pinia'
 import { useConfigStore } from '@/stores/config'
 import { usePlanStore } from '@/stores/plan'
 import { swap } from '@/utils/common'
+import { swapTask, updateTrigger } from '@/utils/plan_edit'
 import { ref, computed, nextTick, watch, inject } from 'vue'
 const config_store = useConfigStore()
 const plan_store = usePlanStore()
@@ -145,44 +146,6 @@ const color_map = computed(() => {
 function drag_facility(room, event) {
   event.dataTransfer.setData('text/plain', room)
   event.dataTransfer.dropEffect = 'move'
-}
-
-function updateTrigger(trigger, source, target) {
-  for (const key in trigger) {
-    if (key === 'left' || key === 'right') {
-      if (typeof trigger[key] === 'string') {
-        trigger[key] = swapSubstrings(trigger[key], source, target)
-      } else if (typeof trigger[key] === 'object' && trigger[key] !== null) {
-        updateTrigger(trigger[key], source, target)
-      }
-    }
-  }
-}
-
-function swapSubstrings(str, source, target) {
-  const placeholder = '__PLACEHOLDER__'
-  let newStr = str.replace(new RegExp(source, 'g'), placeholder)
-  newStr = newStr.replace(new RegExp(target, 'g'), source)
-  newStr = newStr.replace(new RegExp(placeholder, 'g'), target)
-  return newStr
-}
-
-function swapTask(tasks, source, target) {
-  if (tasks) {
-    const placeholder = '__PLACEHOLDER__'
-    if (tasks.hasOwnProperty(source)) {
-      tasks[placeholder] = tasks[source]
-      delete tasks[source]
-    }
-    if (tasks.hasOwnProperty(target)) {
-      tasks[source] = tasks[target]
-      delete tasks[target]
-    }
-    if (tasks.hasOwnProperty(placeholder)) {
-      tasks[target] = tasks[placeholder]
-      delete tasks[placeholder]
-    }
-  }
 }
 
 function drop_facility(target, event) {

--- a/ui/src/pages/Plan.vue
+++ b/ui/src/pages/Plan.vue
@@ -3,6 +3,7 @@ import { useConfigStore } from '@/stores/config'
 import { usePlanStore } from '@/stores/plan'
 import { storeToRefs } from 'pinia'
 import { swap } from '@/utils/common'
+import { apply_operator_replace, collect_plan_operators } from '@/utils/plan_edit'
 
 const config_store = useConfigStore()
 const { free_blacklist, theme } = storeToRefs(config_store)
@@ -24,7 +25,7 @@ const {
 } = storeToRefs(plan_store)
 const { load_plan, fill_empty } = plan_store
 
-import { computed, inject, provide, ref, watchEffect } from 'vue'
+import { computed, inject, provide, ref, watch, watchEffect } from 'vue'
 const axios = inject('axios')
 
 const facility = ref('')
@@ -38,13 +39,14 @@ const current_plan = computed(() => {
   }
 })
 
-import { useMessage, NAlert } from 'naive-ui'
+import { useDialog, useMessage, NAlert } from 'naive-ui'
 
 const plan_editor = ref(null)
 
 const generating_image = ref(false)
 
 const message = useMessage()
+const dialog = useDialog()
 
 import { sleep } from '@/utils/sleep'
 import { toBlob } from 'html-to-image'
@@ -201,6 +203,14 @@ provide('add_task', add_task)
 const replace_source = ref('')
 const replace_target = ref('')
 
+// 弹窗关闭（应用或取消）时清空选择，避免重开时旧 target 已进排班 → 误报重复守卫
+watch(show_replace_dialog, (open) => {
+  if (!open) {
+    replace_source.value = ''
+    replace_target.value = ''
+  }
+})
+
 async function validate_plan() {
   try {
     const { data } = await axios.post(
@@ -220,6 +230,43 @@ async function validate_plan() {
   }
 }
 
+function replace_main_conf() {
+  return {
+    rest_in_full: rest_in_full.value,
+    exhaust_require: exhaust_require.value,
+    workaholic: workaholic.value,
+    resting_priority: resting_priority.value,
+    refresh_trading: refresh_trading.value,
+    refresh_drained: refresh_drained.value,
+    free_blacklist: free_blacklist.value,
+    ope_resting_priority: ope_resting_priority.value
+  }
+}
+
+const replace_plan_state = () => ({
+  main_plan: plan.value,
+  main_conf: replace_main_conf(),
+  backup_plans: backup_plans.value
+})
+
+// 被替换侧只列排班里出现过的干员（防选了个不在排班里的干员变 no-op）
+const replace_source_options = computed(() =>
+  collect_plan_operators(replace_plan_state()).map((name) => ({ value: name, label: name }))
+)
+
+// 目标干员已在排班 → 提示（不硬禁：重复替换是合理需求，见 #168 修订）
+const target_already_in_plan = computed(() => {
+  const target = replace_target.value
+  if (!target) return false
+  return collect_plan_operators(replace_plan_state()).includes(target)
+})
+
+function do_replace() {
+  apply_operator_replace(replace_plan_state(), replace_source.value, replace_target.value)
+  message.success('替换完成')
+  show_replace_dialog.value = false
+}
+
 function apply_replace() {
   if (!replace_source.value || !replace_target.value) {
     message.error('请选择源干员和目标干员')
@@ -229,26 +276,18 @@ function apply_replace() {
     message.error('源干员和目标干员不能相同')
     return
   }
-  // 遍历所有计划，包括主表和副表
-  const allPlans = [plan.value, ...backup_plans.value.map((bp) => bp.plan)]
-  for (const currentPlan of allPlans) {
-    for (const facility in currentPlan) {
-      if (currentPlan[facility].plans) {
-        for (const planItem of currentPlan[facility].plans) {
-          if (planItem.agent === replace_source.value) {
-            planItem.agent = replace_target.value
-          }
-          if (planItem.replacement) {
-            planItem.replacement = planItem.replacement.map((r) =>
-              r === replace_source.value ? replace_target.value : r
-            )
-          }
-        }
-      }
-    }
+  if (target_already_in_plan.value) {
+    dialog.warning({
+      title: '目标干员已在排班中',
+      content:
+        '目标干员已存在于排班（可能来自之前的替换，如主表换过、副表没换）。仍要执行的话会继续把排班里的源干员全部换成目标干员。',
+      positiveText: '仍要替换',
+      negativeText: '取消',
+      onPositiveClick: do_replace
+    })
+    return
   }
-  message.success('替换完成')
-  show_replace_dialog.value = false
+  do_replace()
 }
 
 import DocumentExport from '@vicons/carbon/DocumentExport'
@@ -504,29 +543,59 @@ function movePlanForward() {
     v-model:show="show_replace_dialog"
     preset="card"
     title="一键替换干员"
-    :style="{ width: '500px' }"
+    :style="{ width: '560px' }"
   >
     <n-alert title="警告" type="warning">
       该操作会一键替换主表+副表所有干员名字，不可逆，使用前最好复制现有排班表，以防出错
     </n-alert>
-    <n-space>
-      <n-select
-        v-model:value="replace_source"
-        :options="operators"
-        placeholder="选择要替换的干员"
-        filterable
-        :filter="(p, o) => pinyin_match(o.label, p)"
-        :render-label="render_op_label"
-      />
-      <n-select
-        v-model:value="replace_target"
-        :options="operators"
-        placeholder="选择目标干员"
-        filterable
-        :filter="(p, o) => pinyin_match(o.label, p)"
-        :render-label="render_op_label"
-      />
-    </n-space>
+    <div class="replace-flow">
+      <div class="replace-side">
+        <div class="replace-side-label">被替换干员（排班中已有）</div>
+        <n-select
+          v-model:value="replace_source"
+          :options="replace_source_options"
+          placeholder="选择排班中的干员"
+          filterable
+          :filter="(p, o) => pinyin_match(o.label, p)"
+          :render-label="render_op_label"
+        />
+      </div>
+      <svg
+        class="replace-arrow"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        aria-hidden="true"
+      >
+        <path
+          d="M5 12h13m-5-5 5 5-5 5"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <div class="replace-side">
+        <div class="replace-side-label">替换为（全部干员池）</div>
+        <n-select
+          v-model:value="replace_target"
+          :options="operators"
+          placeholder="选择目标干员"
+          filterable
+          :filter="(p, o) => pinyin_match(o.label, p)"
+          :render-label="render_op_label"
+        />
+      </div>
+    </div>
+    <n-alert
+      v-if="target_already_in_plan"
+      title="目标干员已在排班中"
+      type="warning"
+      class="replace-duplicate"
+    >
+      目标干员已存在于排班（可能来自之前的替换，如主表换过、副表没换）。仍可替换：点「替换」后确认即可继续。
+    </n-alert>
     <template #footer>
       <n-space justify="end">
         <n-button @click="show_replace_dialog = false">取消</n-button>
@@ -568,5 +637,32 @@ function movePlanForward() {
   flex-grow: 0;
   gap: 6px;
   padding: 0 12px;
+}
+
+.replace-flow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.replace-side {
+  flex: 1;
+  min-width: 0;
+}
+
+.replace-side-label {
+  margin-bottom: 6px;
+  font-size: 13px;
+  color: rgb(153, 153, 153);
+}
+
+.replace-arrow {
+  flex-shrink: 0;
+  color: rgb(153, 153, 153);
+}
+
+.replace-duplicate {
+  margin-top: 12px;
 }
 </style>

--- a/ui/src/utils/plan_edit.js
+++ b/ui/src/utils/plan_edit.js
@@ -1,0 +1,156 @@
+// 排班表里的干员名单 conf 字段（主表 conf 与副表 conf 同构；ling_xi 是枚举不是名单）
+export const OPERATOR_CONF_FIELDS = [
+  'rest_in_full',
+  'exhaust_require',
+  'workaholic',
+  'resting_priority',
+  'refresh_trading',
+  'refresh_drained',
+  'free_blacklist',
+  'ope_resting_priority'
+]
+
+// ---- 以下三个复用于 PlanEditor.vue 的设施拖拽换位（swapSubstrings / swapTask / updateTrigger） ----
+
+function swapSubstrings(str, source, target) {
+  const placeholder = '__PLACEHOLDER__'
+  let newStr = str.replace(new RegExp(source, 'g'), placeholder)
+  newStr = newStr.replace(new RegExp(target, 'g'), source)
+  newStr = newStr.replace(new RegExp(placeholder, 'g'), target)
+  return newStr
+}
+
+function swapTask(tasks, source, target) {
+  if (tasks) {
+    const placeholder = '__PLACEHOLDER__'
+    const has = (key) => Object.prototype.hasOwnProperty.call(tasks, key)
+    if (has(source)) {
+      tasks[placeholder] = tasks[source]
+      delete tasks[source]
+    }
+    if (has(target)) {
+      tasks[source] = tasks[target]
+      delete tasks[target]
+    }
+    if (has(placeholder)) {
+      tasks[target] = tasks[placeholder]
+      delete tasks[placeholder]
+    }
+  }
+}
+
+function updateTrigger(trigger, source, target) {
+  for (const key in trigger) {
+    if (key === 'left' || key === 'right') {
+      if (typeof trigger[key] === 'string') {
+        trigger[key] = swapSubstrings(trigger[key], source, target)
+      } else if (typeof trigger[key] === 'object' && trigger[key] !== null) {
+        updateTrigger(trigger[key], source, target)
+      }
+    }
+  }
+}
+
+// ---- 一键替换干员：把「排班里的 A」替换成「新干员 B」（单向；B 不在排班里，去重守卫在调用方） ----
+
+function replace_in_list(list, source, target) {
+  if (!Array.isArray(list)) return
+  for (let i = 0; i < list.length; i++) {
+    if (list[i] === source) list[i] = target
+  }
+}
+
+export function replace_plan_operators(plan, source, target) {
+  if (!plan) return
+  for (const key in plan) {
+    const facility = plan[key]
+    if (!facility || !Array.isArray(facility.plans)) continue
+    for (const item of facility.plans) {
+      if (item.agent === source) item.agent = target
+      replace_in_list(item.replacement, source, target)
+    }
+  }
+}
+
+export function replace_conf_operators(conf, source, target) {
+  if (!conf) return
+  for (const field of OPERATOR_CONF_FIELDS) {
+    replace_in_list(conf[field], source, target)
+  }
+}
+
+export function replace_trigger_operators(trigger, source, target) {
+  if (!trigger) return
+  // 触发表达式里的干员名恒为 op_data.operators['NAME'] 单引号字面量（TriggerString.vue），
+  // 按带引号边界替换——避免裸子串替换误伤更长干员名（阿 ⊂ 阿米娅/阿消 等）
+  const quoted_source = `['${source}']`
+  const quoted_target = `['${target}']`
+  for (const key of ['left', 'right']) {
+    const value = trigger[key]
+    if (typeof value === 'string') {
+      trigger[key] = value.split(quoted_source).join(quoted_target)
+    } else if (value && typeof value === 'object') {
+      replace_trigger_operators(value, source, target)
+    }
+  }
+}
+
+export function replace_task_operators(task, source, target) {
+  if (!task) return
+  for (const room in task) {
+    replace_in_list(task[room], source, target)
+  }
+}
+
+export function apply_operator_replace({ main_plan, main_conf, backup_plans }, source, target) {
+  replace_plan_operators(main_plan, source, target)
+  replace_conf_operators(main_conf, source, target)
+  for (const backup of backup_plans || []) {
+    replace_plan_operators(backup.plan, source, target)
+    replace_conf_operators(backup.conf, source, target)
+    replace_trigger_operators(backup.trigger, source, target)
+    replace_task_operators(backup.task, source, target)
+  }
+}
+
+// 排班里出现过的全部干员（agent / replacement / conf 名单 / 副表 task 数组），
+// 用于「被替换侧」下拉选项与「目标干员已在排班」去重守卫
+export function collect_plan_operators({ main_plan, main_conf, backup_plans }) {
+  const seen = new Set()
+  const add = (name) => {
+    if (name) seen.add(name)
+  }
+  const collect_plan = (plan) => {
+    if (!plan) return
+    for (const key in plan) {
+      const facility = plan[key]
+      if (!facility || !Array.isArray(facility.plans)) continue
+      for (const item of facility.plans) {
+        add(item.agent)
+        for (const r of item.replacement || []) add(r)
+      }
+    }
+  }
+  const collect_conf = (conf) => {
+    if (!conf) return
+    for (const field of OPERATOR_CONF_FIELDS) {
+      for (const name of conf[field] || []) add(name)
+    }
+  }
+  const collect_task = (task) => {
+    if (!task) return
+    for (const room in task) {
+      for (const name of task[room] || []) add(name)
+    }
+  }
+  collect_plan(main_plan)
+  collect_conf(main_conf)
+  for (const backup of backup_plans || []) {
+    collect_plan(backup.plan)
+    collect_conf(backup.conf)
+    collect_task(backup.task)
+  }
+  return [...seen]
+}
+
+export { swapSubstrings, swapTask, updateTrigger }

--- a/ui/src/utils/plan_edit.test.js
+++ b/ui/src/utils/plan_edit.test.js
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  apply_operator_replace,
+  collect_plan_operators,
+  swapSubstrings,
+  swapTask,
+  updateTrigger
+} from './plan_edit.js'
+
+const empty_conf = {
+  rest_in_full: [],
+  exhaust_require: [],
+  workaholic: [],
+  resting_priority: [],
+  refresh_trading: [],
+  refresh_drained: [],
+  free_blacklist: [],
+  ope_resting_priority: []
+}
+
+function make_state() {
+  return {
+    main_plan: {
+      room_1_1: {
+        name: '贸易站',
+        plans: [
+          { agent: '能天使', group: '', replacement: ['德克萨斯'] },
+          { agent: '德克萨斯', group: '', replacement: [] }
+        ]
+      }
+    },
+    main_conf: {
+      ...empty_conf,
+      rest_in_full: ['能天使', '德克萨斯'],
+      workaholic: ['能天使'],
+      free_blacklist: ['德克萨斯']
+    },
+    backup_plans: [
+      {
+        name: 'plan1',
+        plan: {
+          room_1_1: {
+            name: '制造站',
+            plans: [{ agent: '能天使', group: '', replacement: [] }]
+          }
+        },
+        conf: { ...empty_conf, rest_in_full: ['能天使'] },
+        trigger: {
+          left: "op_data.operators['能天使'].is_working()",
+          operator: 'and',
+          right: { left: '', operator: '', right: "op_data.operators['德克萨斯'].current_mood()" }
+        },
+        task: { room_1_1: ['能天使', '德克萨斯'], train: [] }
+      }
+    ]
+  }
+}
+
+describe('apply_operator_replace 覆盖范围', () => {
+  it('替换主表 agent + replacement', () => {
+    const state = make_state()
+    apply_operator_replace(state, '能天使', '风笛')
+    expect(state.main_plan.room_1_1.plans[0].agent).toBe('风笛')
+    expect(state.main_plan.room_1_1.plans[0].replacement).toEqual(['德克萨斯'])
+    expect(state.main_plan.room_1_1.plans[1].agent).toBe('德克萨斯')
+  })
+
+  it('替换主表 conf 8 处', () => {
+    const state = make_state()
+    apply_operator_replace(state, '能天使', '风笛')
+    expect(state.main_conf.rest_in_full).toEqual(['风笛', '德克萨斯'])
+    expect(state.main_conf.workaholic).toEqual(['风笛'])
+    expect(state.main_conf.free_blacklist).toEqual(['德克萨斯'])
+    expect(state.main_conf.exhaust_require).toEqual([])
+  })
+
+  it('替换副表 plan + conf', () => {
+    const state = make_state()
+    apply_operator_replace(state, '能天使', '风笛')
+    const backup = state.backup_plans[0]
+    expect(backup.plan.room_1_1.plans[0].agent).toBe('风笛')
+    expect(backup.conf.rest_in_full).toEqual(['风笛'])
+  })
+
+  it('替换副表 trigger（含嵌套表达式）', () => {
+    const state = make_state()
+    apply_operator_replace(state, '能天使', '风笛')
+    const trigger = state.backup_plans[0].trigger
+    expect(trigger.left).toBe("op_data.operators['风笛'].is_working()")
+    expect(trigger.right.right).toBe("op_data.operators['德克萨斯'].current_mood()")
+  })
+
+  it('替换副表 task 数组', () => {
+    const state = make_state()
+    apply_operator_replace(state, '能天使', '风笛')
+    expect(state.backup_plans[0].task.room_1_1).toEqual(['风笛', '德克萨斯'])
+  })
+
+  it('单向替换：target 若出现在表达式里保持不变', () => {
+    const state = make_state()
+    state.backup_plans[0].trigger.left = "op_data.operators['风笛'].is_resting()"
+    apply_operator_replace(state, '能天使', '风笛')
+    expect(state.backup_plans[0].trigger.left).toBe("op_data.operators['风笛'].is_resting()")
+  })
+
+  it('子串碰撞：source 是更长干员名前缀时不误伤', () => {
+    // 阿 ⊂ 阿米娅；按引号边界替换 ['阿'] 不得命中 ['阿米娅']
+    const state = make_state()
+    state.backup_plans[0].trigger.left = "op_data.operators['阿米娅'].is_resting()"
+    apply_operator_replace(state, '阿', '风笛')
+    expect(state.backup_plans[0].trigger.left).toBe("op_data.operators['阿米娅'].is_resting()")
+    expect(state.backup_plans[0].trigger.left).not.toContain('风笛米娅')
+  })
+
+  it('backup 缺 conf/task 不崩', () => {
+    const state = make_state()
+    state.backup_plans[0].conf = undefined
+    state.backup_plans[0].task = undefined
+    expect(() => apply_operator_replace(state, '能天使', '风笛')).not.toThrow()
+  })
+})
+
+describe('collect_plan_operators', () => {
+  it('收集主表+副表的 agent/replacement/conf/task 干员并去重', () => {
+    const ops = collect_plan_operators(make_state())
+    expect(ops).toEqual(expect.arrayContaining(['能天使', '德克萨斯']))
+    expect(new Set(ops).size).toBe(ops.length)
+    expect(ops).not.toContain('风笛')
+  })
+
+  it('source 下拉只含排班里出现过的干员', () => {
+    const ops = collect_plan_operators(make_state())
+    expect(ops).toEqual(['能天使', '德克萨斯'])
+  })
+})
+
+describe('复用自 PlanEditor 的换位工具', () => {
+  it('swapSubstrings 双向交换', () => {
+    expect(swapSubstrings('a-b-a-c', 'a', 'b')).toBe('b-a-b-c')
+  })
+
+  it('swapTask 交换对象键', () => {
+    const tasks = { a: 1, b: 2 }
+    swapTask(tasks, 'a', 'b')
+    expect(tasks).toEqual({ a: 2, b: 1 })
+  })
+
+  it('updateTrigger 递归替换嵌套表达式', () => {
+    const trigger = {
+      left: '能天使',
+      operator: 'and',
+      right: { left: '', operator: '', right: '能天使' }
+    }
+    updateTrigger(trigger, '能天使', '德克萨斯')
+    expect(trigger.left).toBe('德克萨斯')
+    expect(trigger.right.right).toBe('德克萨斯')
+  })
+})


### PR DESCRIPTION
## 目标

排班页的「一键替换干员」原本只替换排班格子里的名字，主表 8 份名单、每份副表的名单、触发条件和任务都没有覆盖到，替换之后主副表里仍会残留旧的干员名。

**结果：** 现在把排班里涉及干员的全部字段一次替换干净，主表和每份副表都覆盖到。

## 变更

- 替换逻辑抽取到新增的 `ui/src/utils/plan_edit.js`：排班格子、conf 名单、触发条件、任务分别提供替换入口，再用一个编排函数一次跑完主表与所有副表。
- 触发条件里的名字按 `op_data.operators[名字]` 的带引号边界精确替换，避免把「阿米娅」误伤成「阿米娅米娅」这类子串碰撞。
- 弹窗补齐说明标签和方向箭头；被替换一侧只列排班里出现过的干员，避免选了个不在排班里的干员变成无效操作。
- 目标干员已经在排班时不再禁用替换按钮，改为点「替换」后弹确认框（仍要替换/取消）再执行；「主表先替换过、副表想再替换一次」的场景不再被堵死。
- 弹窗关闭（应用或取消）时清空选择，避免重开时旧目标干员已经进排班而误报重复守卫。

## 验证

- `npx --yes prettier@latest --check "ui/**/*.js" "ui/**/*.vue"` 通过。
- `ruff check .` 与 `ruff format --check .` 通过。
- `npm --prefix ui test`（vitest）通过，新增的 `ui/src/utils/plan_edit.test.js` 覆盖替换逻辑。
- `npm --prefix ui run lint`（eslint）有历史存量告警，本次改动未新增。

## 限制

- 改动只涉及前端 4 个文件（`PlanEditor.vue`、`Plan.vue`、新增的 `plan_edit.js` 与 `plan_edit.test.js`），不含后端。
- 未改动排班数据结构，替换语义以现有排班数据为准，按各自字段进行替换、不改变字段本身含义。
