### PR TITLE
refactor(recognition): 精简识别热路径 DEBUG 日志

### DIFF
--- a/arknights_mower/solvers/reclamation_algorithm.py
+++ b/arknights_mower/solvers/reclamation_algorithm.py
@@ -32,7 +32,6 @@ class Map:
         return (round(y[0][0] / y[2][0]), round(y[1][0] / y[2][0]))
 
     def find(self, res: tp.Res) -> Optional[tp.Scope]:
-        logger.debug(f"find: {res}")
         if self.matcher is None:
             self.matcher = Matcher(self.map)
         res_img = loadres(f"ra/map/{res}", True)

--- a/arknights_mower/utils/device/adb_client/socket.py
+++ b/arknights_mower/utils/device/adb_client/socket.py
@@ -9,7 +9,6 @@ class Socket:
     """Connect ADB server with socket"""
 
     def __init__(self, server: tuple[str, int], timeout: int) -> None:
-        logger.debug(f"server: {server}, timeout: {timeout}")
         try:
             self.sock = None
             self.sock = socket.create_connection(server, timeout=timeout)

--- a/arknights_mower/utils/device/device.py
+++ b/arknights_mower/utils/device/device.py
@@ -308,7 +308,6 @@ class Device:
             def grab_droidcast() -> bytes:
                 port = config.droidcast.port
                 url = f"http://127.0.0.1:{port}/screenshot"
-                logger.debug(f"GET {url}")
                 return session.get(url).content
 
             img = bytes2img(self.recover(grab_droidcast))

--- a/arknights_mower/utils/image.py
+++ b/arknights_mower/utils/image.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from arknights_mower import __rootdir__
 from arknights_mower.utils import typealias as tp
-from arknights_mower.utils.log import logger, save_screenshot
+from arknights_mower.utils.log import save_screenshot
 from arknights_mower.utils.path import get_path
 
 
@@ -44,7 +44,6 @@ def loadres(res: tp.Res, gray: bool = False) -> Union[tp.Image, tp.GrayImage]:
 @lru_cache(maxsize=128)
 def loadimg(filename: str, gray: bool = False) -> Union[tp.Image, tp.GrayImage]:
     """load image from file"""
-    logger.debug(filename)
     img_data = np.fromfile(filename, dtype=np.uint8)
     if gray:
         return cv2.imdecode(img_data, cv2.IMREAD_GRAYSCALE)
@@ -112,7 +111,6 @@ def cmatch(
     cb = cv2.mean(img2)[:3]
     diff = np.array(ca).astype(int) - np.array(cb).astype(int)
     diff = np.max(np.maximum(diff, 0)) - np.min(np.minimum(diff, 0))
-    logger.debug(f"{ca=} {cb=} {diff=}")
 
     if draw:
         board = np.zeros([h + 5, w * 2, 3], dtype=np.uint8)

--- a/arknights_mower/utils/matcher.py
+++ b/arknights_mower/utils/matcher.py
@@ -68,7 +68,6 @@ class Matcher:
     """image matching module"""
 
     def __init__(self, origin: tp.GrayImage) -> None:
-        logger.debug(f"Matcher init: shape ({origin.shape})")
         self.origin = origin
         self.kp, self.des = keypoints(self.origin)
 
@@ -136,7 +135,6 @@ class Matcher:
                     ):
                         ori_kp.append(_kp)
                         ori_des.append(_des)
-                logger.debug(f"match crop: {scope}, {len(self.kp)} -> {len(ori_kp)}")
                 ori_kp, ori_des = np.array(ori_kp), np.array(ori_des)
             else:
                 ori_kp, ori_des = self.kp, self.des
@@ -194,8 +192,6 @@ class Matcher:
             if M is None:
                 logger.debug("calculated transformation matrix failed")
                 return None
-            else:
-                logger.debug(f"transform matrix: {M.tolist()}")
 
             M[0][1] = 0
             M[1][0] = 0
@@ -234,13 +230,11 @@ class Matcher:
                 rect[1][0] - rect[0][0] < min_width
                 or rect[1][1] - rect[0][1] < min_height
             ):
-                logger.debug(f"rectangle is too small: {rect}")
                 return None
 
             if not dpi_aware:
                 max_width = w * 1.25
                 if rect[1][0] - rect[0][0] > max_width:
-                    logger.debug(f"rectangle is too big: {rect}")
                     return None
 
             # measure the rate of good match within the rectangle (x-axis)

--- a/arknights_mower/utils/news_checker.py
+++ b/arknights_mower/utils/news_checker.py
@@ -71,7 +71,7 @@ class NewsChecker:
 
                 # 遍历 ANNOUNCEMENT
                 for item in news_data["ANNOUNCEMENT"]:
-                    logger.debug(item["title"], item["brief"])
+                    logger.debug(f"{item['title']} {item['brief']}")
                     m_time = time_pattern.search(item["brief"])
                     if not m_time:
                         continue

--- a/arknights_mower/utils/recognize.py
+++ b/arknights_mower/utils/recognize.py
@@ -712,7 +712,6 @@ class Recognizer:
 
         :return ret: 若匹配成功，则返回元素在游戏界面中出现的位置，否则返回 None
         """
-        logger.debug(f"find: {res}")
         normalized_res = str(res).replace("\\", "/")
         force_feature_match = "navigation/stage/" in normalized_res
 
@@ -832,11 +831,11 @@ class Recognizer:
                     gray = cropimg(self.gray, scope)
                     res_img = cv2.cvtColor(res_img, cv2.COLOR_RGB2GRAY)
                     ssim = vision_np.ssim(gray, res_img)
-                    logger.debug(f"{ssim=}")
                     threshold = 0.9
                     if res in template_matching_score:
                         threshold = template_matching_score[res]
                     if ssim >= threshold:
+                        logger.debug(f"find: {res} {scope=} {ssim=}")
                         return scope
 
             return None
@@ -926,6 +925,7 @@ class Recognizer:
                 threshold = template_matching_score[res]
 
             pos = template_matching[res]
+            res_name = res
             res = loadres(res, True)
             h, w = res.shape
 
@@ -938,8 +938,8 @@ class Recognizer:
             result = cv2.matchTemplate(img, res, cv2.TM_CCOEFF_NORMED)
             min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(result)
             top_left = va(max_loc, scope[0])
-            logger.debug(f"{top_left=} {max_val=}")
             if max_val >= threshold:
+                logger.debug(f"find: {res_name} {top_left=} {max_val=}")
                 return top_left, va(top_left, (w, h))
             return None
 
@@ -1014,8 +1014,6 @@ class Recognizer:
 
         :return ret: 若匹配成功，则返回元素在游戏界面中出现的位置，否则返回 None
         """
-        logger.debug(f"score: {res}")
-
         res_img = loadres(res, True)
         if thres is not None:
             # 对图像二值化处理


### PR DESCRIPTION
## 目标

识别热路径在每次轮询时都会打印 find/score 的尝试公告，以及匹配过程中的中间量（loadimg、cmatch、变换矩阵、矩形、特征点、截屏 URL、adb 连接地址）。runtime.log 被大量 DEBUG 行反复写入，日志体积迅速膨胀，关键行被挤占，难以定位。

本改动删除这些尝试公告与匹配中间量，识别命中时才打印结果详情（模板名、位置、分数），未命中时不打印；失败原因与命中详情保留。

## 主要改动

7 个文件，+5 / −18：

- `reclamation_algorithm.py`：删除 find 的尝试公告。
- `socket.py`：删除 server 连接公告。
- `device.py`：删除截屏请求的 GET URL 公告。
- `image.py`：删除 loadimg 文件名、cmatch 中间量，以及不再使用的 logger 引用。
- `matcher.py`：删除 Matcher 初始化、match crop、变换矩阵、矩形过小/过大的公告。
- `recognize.py`：删除 find/score 的尝试公告，命中时改打印结果详情，保留 ssim 命中详情。
- `news_checker.py`：修复日志调用把公告标题当日志格式串的问题，标题含 % 时不再丢日志。

## 验证

- `ruff check .` 通过。
- `ruff format --check .` 通过（199 个文件均已格式化）。
- `python -m unittest discover -s arknights_mower/tests -p "*_tests.py"`：735 项通过，10 项跳过（scipy、skimage、sklearn 未安装）。
- `python -m compileall arknights_mower scripts` 通过。

## 风险

- 识别日志改为命中时才打印后，调试时如需查看匹配中间量，需要临时改回。
- 仅涉及日志改动，不触碰识别逻辑本身。
