### PR TITLE
fix(depot): 修复仓库扫描在界面就绪前切标签导致误识别

### DIFF
--- a/arknights_mower/solvers/depotREC.py
+++ b/arknights_mower/solvers/depotREC.py
@@ -163,6 +163,12 @@ class depotREC(SceneGraphSolver):
             self.tap_index_element("warehouse")
             logger.info("仓库扫描: 从主界面点击仓库界面")
 
+            # 进仓库后等界面就绪再切 tab：先确认识别到仓库场景，再等画面稳定（物品网格渲染完）。
+            # 否则持续加载期间点击 tab 会被吞掉，导致在「全部物品」视图上误识别。
+            if not self.wait_for_scene_stable(Scene.DEPOT):
+                logger.warning("仓库扫描: 未识别到仓库场景，继续等待画面稳定")
+            self.wait_for_scene_stable(timeout_seconds=5, interval_seconds=0.2)
+
             starttime = datetime.now()
             任务组 = [
                 (1200, self.knn模型_CONSUME, "消耗物品"),


### PR DESCRIPTION
## 目标

修复仓库扫描在界面就绪前切标签导致的误识别。此前进入仓库后紧随其后的「消耗物品」标签点击会被游戏吞掉，实际是在默认的「全部物品」视图上做识别，把龙门币 1303.3 万读成应急理智浓缩液 13033911 一类的错值。

## 主要改动

`arknights_mower/solvers/depotREC.py`：进仓库后、切换标签前新增两层等待——

- `wait_for_scene_stable(Scene.DEPOT)`：先确认识别到仓库场景；
- `wait_for_scene_stable(timeout_seconds=5, interval_seconds=0.2)`：再等画面稳定（物品网格渲染完），保证点标签时界面已可交互，避免在默认视图上误识别。

## 验证与风险

- `ruff check .` 与 `ruff format --check .` 全绿；`python -m compileall` 通过。
- `python -m unittest discover -s arknights_mower/tests -p "*_tests.py"`：735 OK / 10 skip，无回归。
- 仓库扫描新增的 wait 分支依赖真实设备/场景识别，单元测试无法覆盖，宜实机验证读值正确。
- 额外等待最多约 5 秒（有 timeout 兜底），仅在进仓库入口触发、非每帧轮询，无日志刷屏风险。