### PR TITLE
fix(schedule): 修复干员安排确认循环因识别失败抛错导致排班中断

### DIFF
--- a/arknights_mower/tests/solver_tests.py
+++ b/arknights_mower/tests/solver_tests.py
@@ -43,5 +43,30 @@ class TestSolverStartupLaunch(unittest.TestCase):
         self.restart_mock.assert_not_called()
 
 
+class TestTapElement(unittest.TestCase):
+    """tap_element：find 返回空时不 tap、不抛错、返回 False；找到时 tap 中心、返回 True。"""
+
+    def setUp(self):
+        self.solver = BaseSolver.__new__(BaseSolver)
+        self.find_patch = patch.object(BaseSolver, "find")
+        self.tap_patch = patch.object(BaseSolver, "tap")
+        self.find_mock = self.find_patch.start()
+        self.tap_mock = self.tap_patch.start()
+        self.addCleanup(self.find_patch.stop)
+        self.addCleanup(self.tap_patch.stop)
+
+    def test_missing_element_no_tap_returns_false(self):
+        self.find_mock.return_value = None
+        result = self.solver.tap_element("confirm_blue")
+        self.assertFalse(result)
+        self.tap_mock.assert_not_called()
+
+    def test_found_element_taps_center_returns_true(self):
+        self.find_mock.return_value = [[100, 200], [300, 400]]
+        result = self.solver.tap_element("confirm_blue")
+        self.assertTrue(result)
+        self.tap_mock.assert_called_once_with([[100, 200], [300, 400]], 0.5, 0.5, 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/arknights_mower/utils/solver.py
+++ b/arknights_mower/utils/solver.py
@@ -228,14 +228,13 @@ class BaseSolver:
         draw: bool = False,
         scope: tp.Scope = None,
         judge: bool = True,
-        detected: bool = False,
         thres: Optional[int] = None,
     ) -> bool:
-        """tap element"""
+        """tap element，找不到时返回 False 而不报错"""
         element = self.find(
             element_name, draw, scope, judge=judge, score=score, thres=thres
         )
-        if detected and element is None:
+        if element is None:
             return False
         self.tap(element, x_rate, y_rate, interval)
         return True
@@ -630,7 +629,7 @@ class BaseSolver:
         while retry_times:
             if self.scene() == Scene.NAVIGATION_BAR:
                 return True
-            elif not self.tap_element("nav_button", detected=True):
+            elif not self.tap_element("nav_button"):
                 return False
             retry_times -= 1
 


### PR DESCRIPTION
## 目标

修复基建排班与训练室换人共用的确认循环，在识别失败时抛错、导致排班中断的问题。

## 主要改动

确认循环 `while self.find("confirm_blue"): tap_element("confirm_blue")` 是双重查找：`tap_element` 内部再次 `find` 失败时，对空结果调用 `tap` 会抛出 `RecognizeError`。

`tap_element` 调整了处理方式：`find` 返回空时直接返回 `False`、不点击、不抛错，确认循环自动进入下一轮重试。同时删除因此冗余的 `detected` 参数，唯一用到该参数的 `nav_button` 调用修改为直接 `tap_element("nav_button")`。其余调用方找不到元素时同样静默跳过并返回 `False`，无调用方依赖原异常。

新增 `TestTapElement` 覆盖「找不到 → 不点击并返回 `False`」与「找到 → 点击中心并返回 `True`」两条路径。

## 验证与风险

- `ruff check .` 与 `ruff format --check .` 通过。
- `python -m compileall arknights_mower scripts` 通过。
- `python -m unittest discover -s arknights_mower/tests -p "*_tests.py"`：750 OK / 10 skip，无回归。

行为变更为：`tap_element` 由「找不到抛异常」调整为「找不到返回 `False`」，属于共享路径，影响面较大但改动极简。已确认无调用方依赖原异常，且无残留 `detected=` 调用。
