### PR TITLE
fix(mastery): 修复专精换人任务档位错误显示为计划最终目标

### DIFF
--- a/arknights_mower/solvers/mastery.py
+++ b/arknights_mower/solvers/mastery.py
@@ -1036,13 +1036,19 @@ def _schedule_swap_if_needed(
 
     from arknights_mower.utils.scheduler_task import SchedulerTask, TaskTypes
 
+    # #230：档位显示当前步（当前级 → 步目标级，与收取标签同式），不写死计划最终
+    # 目标 target_level；step_level 读不到时只留换入对象、不显示档位（不回退
+    # target_level，避免任务列表误导为计划目标级）。
+    if isinstance(step_level, int) and step_level >= 1:
+        level_text = (
+            f"{_target_label(max(0, step_level - 1))} → {_target_label(step_level)} "
+        )
+    else:
+        level_text = ""
     task = SchedulerTask(
         time=swap_time,
         task_type=TaskTypes.SWAP_SUPPORT,
-        meta_data=(
-            f"{_plan_label(plan)} → {_target_label(plan['target_level'])} "
-            f"换入{route['swap_target']}"
-        ),
+        meta_data=f"{_plan_label(plan)} {level_text}换入{route['swap_target']}",
     )
     # #77 补排去重键（与 SKILL_UPGRADE 同形）：reconcile 恢复 / 重试都按 plan_key 去重
     task.plan_key = str(plan["id"])

--- a/arknights_mower/tests/mastery_arranging_tests.py
+++ b/arknights_mower/tests/mastery_arranging_tests.py
@@ -1938,6 +1938,69 @@ class TestRouteStepLevel(unittest.TestCase):
             )
         self.assertIsNone(scheduled, "专三步路线无 swap_target → 不换人")
 
+    def test_schedule_swap_meta_data_shows_step_level(self):
+        # #230：换人任务档位显示当前步（当前级 → 步目标级，与收取标签同式），
+        # 不写死计划最终目标 target_level。step_level=2 → 「专一 → 专二」。
+        solver = self._solver()
+        plan = make_plan(target_level=3)
+        with (
+            patch.object(
+                mastery,
+                "_get_plan_route",
+                return_value={
+                    "swap_target": "艾丽妮",
+                    "central_bonus": 5,
+                    "efficiency": 75,
+                    "job_match": True,
+                },
+            ),
+            patch.object(mastery, "calc_swap_threshold", return_value=(True, 100.0)),
+            patch.object(config_mod.conf, "assistant_follows_schedule", False),
+            patch.object(mastery, "datetime", FixedDateTime),
+        ):
+            scheduled = mastery._schedule_swap_if_needed(
+                solver, plan, START + timedelta(hours=2), step_level=2
+            )
+        self.assertIsNotNone(scheduled)
+        self.assertEqual(
+            solver.tasks[0].meta_data,
+            "测试干员 测试技能 专一 → 专二 换入艾丽妮",
+            "换人任务档位用当前步（专一→专二），不是计划目标专三",
+        )
+
+    def test_schedule_swap_meta_data_hides_level_when_step_unknown(self):
+        # #230：step_level 读不到（None）→ 不显示档位（不回退 target_level，避免
+        # 任务列表误导为专三）；只留换入对象。与纠错/补位任务文案同风格。
+        solver = self._solver()
+        plan = make_plan(target_level=2)
+        route_calls = []
+
+        def fake_route(p, step_level=None):
+            route_calls.append(step_level)
+            return {
+                "swap_target": "逻各斯",
+                "central_bonus": 5,
+                "efficiency": 75,
+                "job_match": True,
+            }
+
+        with (
+            patch.object(mastery, "_get_plan_route", side_effect=fake_route),
+            patch.object(mastery, "calc_swap_threshold", return_value=(True, 100.0)),
+            patch.object(config_mod.conf, "assistant_follows_schedule", False),
+            patch.object(mastery, "datetime", FixedDateTime),
+        ):
+            scheduled = mastery._schedule_swap_if_needed(
+                solver, plan, START + timedelta(hours=2), step_level=None
+            )
+        self.assertIsNotNone(scheduled)
+        self.assertEqual(route_calls, [None], "step_level 缺省应原样传给路线加载")
+        self.assertEqual(
+            solver.tasks[0].meta_data,
+            "测试干员 测试技能 换入逻各斯",
+            "step_level 读不到时不显示档位，只留换入对象",
+        )
+
     # --- _confirm_training_started：确认后读图标当前步级，传给协助位/换人安排 ---
     def test_confirm_passes_step_level_to_arrange_and_swap(self):
         solver = self._lit_solver(lit=2)


### PR DESCRIPTION
## 目标

开始训练时排定的换人（SWAP_SUPPORT）任务，任务列表显示的档位固定为计划最终目标等级。专三计划在进行到专二这一步时，任务列表会显示「专三」，看起来像是已经完成计划目标，造成误导。

## 主要改动

换人任务的档位显示改为与收取任务一致的样式，按当前步级显示「当前级 → 步目标级」。当 step_level 读取不到时，只显示换入对象、不显示档位，也不回退到计划目标等级，避免任务列表出现误导信息。

## 验证与风险

- 新增两条用例，分别覆盖 step_level 已知与读取不到两种档位显示情况。
- 全量单元测试通过（752 条，含新增两条），无回归。
- 改动只涉及任务档位文案显示，换人判定与触发时间不受影响。
