### PR TITLE
fix(update): 修复手动更新包在浏览器与桌面端导入失败

### DIFF
--- a/arknights_mower/tests/manual_update_tests.py
+++ b/arknights_mower/tests/manual_update_tests.py
@@ -1,0 +1,56 @@
+import io
+import unittest
+from unittest.mock import patch
+from zipfile import ZipFile
+
+from arknights_mower.utils import manual_update
+
+
+def _zip_bytes(entries: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with ZipFile(buf, "w") as z:
+        for name, content in entries.items():
+            z.writestr(name, content)
+    return buf.getvalue()
+
+
+class TestApplyManualUpdate(unittest.TestCase):
+    def test_applies_resource_package(self):
+        data = _zip_bytes({"arknights_mower/data/version.json": '{"res_version":"v1"}'})
+        with patch.object(manual_update, "install_resource_pkg", return_value=True):
+            got = manual_update.apply_manual_update(data)
+        self.assertEqual(got["kind"], "resource")
+        self.assertTrue(got["ok"])
+
+    def test_resource_package_honors_busy_response(self):
+        data = _zip_bytes({"arknights_mower/data/version.json": '{"res_version":"v1"}'})
+
+        def busy():
+            return {"ok": False, "message": "busy"}
+
+        with patch.object(
+            manual_update,
+            "install_resource_pkg",
+            side_effect=AssertionError("busy 时不应安装"),
+        ):
+            got = manual_update.apply_manual_update(data, busy)
+        self.assertEqual(got, {"ok": False, "message": "busy", "kind": "resource"})
+
+    def test_applies_hot_update_package(self):
+        data = _zip_bytes({"nav_steps.json": "{}"})
+        with patch.object(
+            manual_update.hot_update, "apply_manual_zip", return_value=True
+        ):
+            got = manual_update.apply_manual_update(data)
+        self.assertEqual(
+            got, {"ok": True, "kind": "hot_update", "message": "热更包已应用"}
+        )
+
+    def test_invalid_zip_is_rejected(self):
+        got = manual_update.apply_manual_update(b"not a zip")
+        self.assertFalse(got["ok"])
+        self.assertEqual(got["kind"], "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/resource_version_tests.py
+++ b/arknights_mower/tests/resource_version_tests.py
@@ -1,5 +1,8 @@
+import json
+import tempfile
 import unittest
 from contextlib import ExitStack
+from pathlib import Path
 from unittest.mock import patch
 
 from arknights_mower.utils import resource_version as rv
@@ -154,6 +157,25 @@ class TestCheckResourceUpdate(unittest.TestCase):
         self.assertEqual(got["remote_version"], "")
         self.assertEqual(got["update_available"], None)
         self.assertEqual(got["error"], None)
+
+
+class TestReadLocalVersion(unittest.TestCase):
+    def test_resolves_overlay_path_on_every_read(self):
+        with tempfile.TemporaryDirectory() as d:
+            first = Path(d) / "builtin.json"
+            second = Path(d) / "overlay.json"
+            first.write_text(json.dumps(_version("2026.08.22-aaaaaaa")), "utf-8")
+            second.write_text(json.dumps(_version("2026.08.23-bbbbbbb")), "utf-8")
+
+            with patch.object(rv, "resource_pkg_path", side_effect=[first, second]):
+                self.assertEqual(
+                    rv._read_local_version_json()["res_version"],
+                    "2026.08.22-aaaaaaa",
+                )
+                self.assertEqual(
+                    rv._read_local_version_json()["res_version"],
+                    "2026.08.23-bbbbbbb",
+                )
 
 
 if __name__ == "__main__":

--- a/arknights_mower/utils/manual_update.py
+++ b/arknights_mower/utils/manual_update.py
@@ -1,0 +1,52 @@
+"""手动更新包识别与应用。"""
+
+from collections.abc import Callable
+from io import BytesIO
+from zipfile import ZipFile
+
+from arknights_mower.utils import hot_update
+from arknights_mower.utils.resource_pkg import (
+    _RESOURCE_MARKER,
+    install_resource_pkg,
+)
+
+BusyCheck = Callable[[], dict | None]
+
+
+def apply_manual_update(data: bytes, busy_check: BusyCheck | None = None) -> dict:
+    """识别并应用热更包或资源包，返回可直接作为接口响应的字典。"""
+    try:
+        with ZipFile(BytesIO(data)) as z:
+            names = z.namelist()
+    except Exception:
+        return {"ok": False, "kind": "unknown", "message": "不是有效的 zip 包"}
+
+    if hot_update._has_hotupdate_marker(names):
+        if hot_update.apply_manual_zip(data):
+            return {"ok": True, "kind": "hot_update", "message": "热更包已应用"}
+        return {
+            "ok": False,
+            "kind": "hot_update",
+            "message": "热更包应用失败（请确认是有效的 hot_update.zip）",
+        }
+
+    if _RESOURCE_MARKER in names:
+        if busy_check is not None and (busy := busy_check()):
+            return {**busy, "kind": "resource"}
+        if install_resource_pkg(data):
+            return {
+                "ok": True,
+                "kind": "resource",
+                "message": "资源包安装成功，重启后完全生效",
+            }
+        return {
+            "ok": False,
+            "kind": "resource",
+            "message": "资源包安装失败（已回滚）",
+        }
+
+    return {
+        "ok": False,
+        "kind": "unknown",
+        "message": "无法识别的更新包（热更包需 nav_steps.json，资源包需 version.json）",
+    }

--- a/arknights_mower/utils/resource_version.py
+++ b/arknights_mower/utils/resource_version.py
@@ -18,7 +18,6 @@ from arknights_mower.utils.resource_pkg import resource_pkg_path
 RESOURCE_VERSION_URL = (
     "https://raw.githubusercontent.com/ArkMowers/MowerResource/main/version.json"
 )
-LOCAL_VERSION_PATH = resource_pkg_path("arknights_mower/data/version.json")
 TMP_VERSION_PATH = get_path("@install/tmp/resource_version.json")
 
 
@@ -31,7 +30,9 @@ def _read_json(path: Path) -> dict | None:
 
 
 def _read_local_version_json() -> dict | None:
-    return _read_json(LOCAL_VERSION_PATH)
+    # 资源包目录会在运行期间被原子替换。每次读取都重新解析 overlay，避免首次启动
+    # 尚未安装资源包时把内置 version.json 路径永久缓存到进程结束。
+    return _read_json(resource_pkg_path("arknights_mower/data/version.json"))
 
 
 def _read_tmp_cache() -> dict | None:

--- a/server.py
+++ b/server.py
@@ -571,41 +571,12 @@ def hot_update_manual():
 
     用于国内直连 GitHub 不稳时的人工兜底：热更走 apply_manual_zip，资源包走 overlay 原子安装。
     """
-    from zipfile import ZipFile
-
-    from arknights_mower.utils import hot_update as hu
-    from arknights_mower.utils.resource_pkg import (
-        _RESOURCE_MARKER,
-        install_resource_pkg,
-    )
+    from arknights_mower.utils.manual_update import apply_manual_update
 
     update_file = request.files.get("update")
     if update_file is None:
         return {"ok": False, "message": "没有收到更新包文件"}
-    raw = update_file.read()
-    try:
-        with ZipFile(BytesIO(raw)) as z:
-            names = z.namelist()
-    except Exception:
-        return {"ok": False, "message": "不是有效的 zip 包"}
-    if hu._has_hotupdate_marker(names):
-        if hu.apply_manual_zip(raw):
-            return {"ok": True, "message": "热更包已应用"}
-        return {
-            "ok": False,
-            "message": "热更包应用失败（请确认是有效的 hot_update.zip）",
-        }
-    if _RESOURCE_MARKER in names:
-        busy = _mower_busy_response()
-        if busy:
-            return busy
-        if install_resource_pkg(raw):
-            return {"ok": True, "message": "资源包安装成功，重启后完全生效"}
-        return {"ok": False, "message": "资源包安装失败（已回滚）"}
-    return {
-        "ok": False,
-        "message": "无法识别的更新包（热更包需 nav_steps.json，资源包需 version.json）",
-    }
+    return apply_manual_update(update_file.read(), _mower_busy_response)
 
 
 @app.route("/dialog/save/img", methods=["POST"])

--- a/ui/src/components/ResourceUpdate.vue
+++ b/ui/src/components/ResourceUpdate.vue
@@ -1,10 +1,11 @@
 <script setup>
-import { inject, onMounted, ref } from 'vue'
+import axios from 'axios'
+import { onMounted, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useConfigStore } from '@/stores/config'
 import { useResourceVersionStore } from '@/stores/resourceVersion'
+import { getDroppedFile, postManualUpdate } from '@/utils/manualUpdate'
 
-const token = inject('token')
 const manual_url = `${import.meta.env.VITE_HTTP_URL}/hot-update/manual`
 
 const config_store = useConfigStore()
@@ -15,6 +16,7 @@ const { info, loading, installing, install_message } = storeToRefs(resource_stor
 const { loadResourceVersion, loadResourceVersionLocal, installResource } = resource_store
 
 const manual_result = ref('')
+const manual_installing = ref(false)
 
 onMounted(() => {
   // 当前版本常驻显示；开启「启动时检查更新」时才顺带拉远端最新版本。
@@ -25,17 +27,48 @@ onMounted(() => {
   }
 })
 
-function on_manual_finish({ event }) {
-  let text = '更新包应用失败'
-  try {
-    const data = JSON.parse(event.target.response)
-    if (data && typeof data.message === 'string') {
-      text = data.message
+async function show_manual_result(data) {
+  manual_result.value = data && typeof data.message === 'string' ? data.message : '更新包应用失败'
+  if (data?.ok && data.kind === 'resource') {
+    if (hot_update_enable.value) {
+      await loadResourceVersion(true)
+    } else {
+      await loadResourceVersionLocal()
     }
-  } catch (e) {
-    // keep default failure text
   }
-  manual_result.value = text
+}
+
+async function upload_manual_file(file, onProgress) {
+  if (!file || manual_installing.value) return false
+  manual_installing.value = true
+  manual_result.value = '正在应用更新包…'
+  try {
+    const data = await postManualUpdate(axios, manual_url, file, onProgress)
+    await show_manual_result(data)
+    return data?.ok === true
+  } catch (error) {
+    await show_manual_result(error.response?.data)
+    return false
+  } finally {
+    manual_installing.value = false
+  }
+}
+
+async function request_manual_update({ file, onProgress, onFinish, onError }) {
+  const ok = await upload_manual_file(file.file, onProgress)
+  if (ok) {
+    onFinish()
+  } else {
+    onError()
+  }
+}
+
+function drop_manual_update(event) {
+  // 直接读取标准 FileList，兼容未实现 webkitGetAsEntry 的浏览器与桌面 WebView。
+  const file = getDroppedFile(event)
+  if (file) {
+    void upload_manual_file(file)
+  }
 }
 </script>
 
@@ -79,14 +112,12 @@ function on_manual_finish({ event }) {
       <n-form-item label="手动应用">
         <n-upload
           style="width: 100%"
-          :action="manual_url"
-          :headers="{ token: token }"
-          name="update"
+          accept=".zip"
+          :custom-request="request_manual_update"
+          :disabled="manual_installing"
           :show-file-list="false"
-          @finish="on_manual_finish"
-          @error="on_manual_finish"
         >
-          <n-upload-dragger>
+          <n-upload-dragger @dragover.prevent @drop.capture.stop.prevent="drop_manual_update">
             <div>点击或拖入更新包</div>
             <div class="hint">自动识别热更包 / 资源包，用于直连 GitHub 不稳时的兜底</div>
           </n-upload-dragger>

--- a/ui/src/utils/manualUpdate.js
+++ b/ui/src/utils/manualUpdate.js
@@ -1,0 +1,20 @@
+export function getDroppedFile(event) {
+  const files = event?.dataTransfer?.files
+  if (!files?.length) return null
+  if (typeof files.item === 'function') {
+    return files.item(0)
+  }
+  return files[0] || null
+}
+
+export async function postManualUpdate(client, url, file, onProgress = () => {}) {
+  const formData = new FormData()
+  formData.append('update', file)
+  const response = await client.post(url, formData, {
+    onUploadProgress(event) {
+      if (!event.total) return
+      onProgress({ percent: Math.min(100, Math.round((event.loaded / event.total) * 100)) })
+    }
+  })
+  return response.data
+}

--- a/ui/src/utils/manualUpdate.test.js
+++ b/ui/src/utils/manualUpdate.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { getDroppedFile, postManualUpdate } from './manualUpdate.js'
+
+describe('manual update helpers', () => {
+  it('reads the first file from a standard drop event', () => {
+    const file = { name: 'resource.zip' }
+    expect(getDroppedFile({ dataTransfer: { files: [file] } })).toBe(file)
+    expect(getDroppedFile({ dataTransfer: { files: [] } })).toBeNull()
+    expect(getDroppedFile(undefined)).toBeNull()
+  })
+
+  it('posts the selected file as update form data and reports progress', async () => {
+    const file = new Blob(['resource'], { type: 'application/zip' })
+    const progress = []
+    const client = {
+      async post(url, body, config) {
+        expect(url).toBe('/hot-update/manual')
+        expect(body.get('update')).toBeInstanceOf(Blob)
+        config.onUploadProgress({ loaded: 1, total: 4 })
+        return { data: { ok: true, kind: 'resource' } }
+      }
+    }
+
+    await expect(
+      postManualUpdate(client, '/hot-update/manual', file, (event) => progress.push(event))
+    ).resolves.toEqual({ ok: true, kind: 'resource' })
+    expect(progress).toEqual([{ percent: 25 }])
+  })
+})


### PR DESCRIPTION
## 目标

修复资源更新的手动导入入口：浏览器访问以及 Windows、macOS、Linux 桌面端中，点击选择或拖入资源包后应能稳定上传、安装并立即刷新当前资源版本。

## 主要改动

- 手动上传改用项目共用 Axios 发送 `FormData`，复用现有 token 请求头，并统一处理上传中、成功和失败状态，不再依赖 `n-upload` 自建 XHR 的响应事件。
- 拖拽入口直接读取标准 `DataTransfer.files`，避开部分浏览器/WebView 未实现 `webkitGetAsEntry` 时拖入无响应的问题；点击选择仍保留 `alpha` 原有上传框交互。
- 抽出手动更新包识别与应用逻辑，统一返回 `hot_update` / `resource` 类型，资源包成功后前端主动刷新版本信息。
- 本地资源版本每次读取时重新解析 overlay 路径，修复进程首次读取内置 `version.json` 后，即使手动安装资源包仍持续显示旧版本的问题。
- 新增后端分发、overlay 路径重解析、标准拖拽取文件和 Axios `FormData` 上传测试。

上传链路只使用浏览器标准 `File`、`FileList`、`FormData` 与 Axios，不读取客户端平台路径，Windows WebView2、macOS WKWebView、Linux WebKitGTK/浏览器共用同一实现。

## 验证与风险

- 使用用户提供的 `resource.zip` 验证，SHA-256：`afbd6520bdf0e5ee0a8d879c8366e9529d0325bcd4e387bdf1caedb31f1c435b`，资源版本 `v2026.09.03-eb223ac`。
- Chromium 实测点击选择与拖拽各产生一次 `POST /hot-update/manual`，均携带 token、返回 `200` 与 `ok: true, kind: resource`；随后请求 `/resource-version?local=1`，页面显示安装成功。
- `arknights_mower/tests`：755 项通过。
- `scripts/tests`：85 项通过，1 项按环境跳过。
- UI Vitest：3 个文件、19 项通过；Vite production build 通过。
- `ruff check .`、`ruff format --check .`、`compileall` 通过。
- 本次修改的前端文件通过 ESLint 与 Prettier 检查。

风险集中在手动更新入口；热更包和资源包最终仍调用原有 `apply_manual_zip` 与 `install_resource_pkg`，自动更新流程未改动。

