### PR TITLE
fix(build): 修复 macOS 应用启动并改用 DMG 发布

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -12,11 +12,11 @@
 # 平台矩阵：
 #   Windows x64        windows-latest        webui_zip.spec                 .zip
 #   Linux x64/arm64    ubuntu-24.04(-arm)     webui_zip_for_linux.spec      .tar.gz
-#   macOS x64/arm64    macos-15-intel/15      webui_zip_for_macos.spec      .zip
+#   macOS x64/arm64    macos-15-intel/15      webui_zip_for_macos.spec      .dmg
 # Windows ARM64 暂缓：锁定的核心原生依赖（opencv-python、rjieba 等）在 PyPI
 # 上没有 win_arm64 wheel，当前矩阵不包含该平台。见 doc/release-platforms.md。
-# macOS 与 Linux 一样依赖宿主机系统库（libzbar 等）；macOS 产物为 unsigned
-# experimental build（PyInstaller 仅做 ad-hoc 签名，非 Developer ID）。
+# macOS 与 Linux 一样依赖宿主机系统库（libzbar 等）；macOS 的 .app 仅有
+# PyInstaller ad-hoc 签名，没有 Developer ID 签名或 notarization。
 #
 # 权限说明：GITHUB_TOKEN 只保留 contents 作用域即可——artifact 上传/下载用的是
 # runner 注入的 ACTIONS_RUNTIME_TOKEN，不受 permissions 限制；只有创建 Release
@@ -131,10 +131,10 @@ jobs:
         run: |
           cat >> body.md <<EOF
 
-          > 产物均为未签名构建，并附带统一 SHA-256 清单（SHA256SUMS）。Windows
-          > 首次运行可能出现 SmartScreen 提示；macOS 为 unsigned experimental
-          > build，若被系统拦截需在「隐私与安全性」中手动允许。建议先核对
-          > SHA256SUMS 再使用。
+          > 产物未使用受信任发行证书，并附带统一 SHA-256 清单（SHA256SUMS）。
+          > Windows 首次运行可能出现 SmartScreen 提示；macOS DMG 内的 .app
+          > 仅有 ad-hoc 签名且未 notarize，若被系统拦截需在「隐私与安全性」中
+          > 手动允许。建议先核对 SHA256SUMS 再使用。
           EOF
 
       - name: Upload release metadata
@@ -441,39 +441,89 @@ jobs:
       - name: Build with PyInstaller
         run: python -m PyInstaller webui_zip_for_macos.spec
 
-      - name: Verify app bundle structure
+      - name: Smoke launch bundled entry points
+        env:
+          MOWER_DATA_DIR: ${{ runner.temp }}/mower-smoke-data-${{ matrix.arch }}
         run: |
-          python scripts/check_macos_app.py dist/mower.app --arch ${{ matrix.macho }}
-
-      - name: Smoke launch
-        run: |
+          mkdir -p "${MOWER_DATA_DIR}"
           python - <<'PYEOF'
+          import os
+          import signal
           import subprocess
           import time
 
-          binary = "./mower.app/Contents/MacOS/mower"
-          process = subprocess.Popen([binary], cwd="dist")
-          time.sleep(20)
-          status = process.poll()
-          if status is None:
-              print("GUI 进程成功拉起并存活 20s")
-              process.terminate()
-          else:
-              print(f"::error::GUI 进程在 20s 内以 {status} 退出")
-              raise SystemExit(1)
+          def smoke(executable, seconds):
+              binary = f"./mower.app/Contents/MacOS/{executable}"
+              process = subprocess.Popen(
+                  [binary],
+                  cwd="dist",
+                  start_new_session=True,
+              )
+              try:
+                  time.sleep(seconds)
+                  status = process.poll()
+                  if status is not None:
+                      print(
+                          f"::error::{executable} GUI 进程在 {seconds}s 内以 {status} 退出"
+                      )
+                      raise SystemExit(1)
+                  print(f"{executable} GUI 进程成功拉起并存活 {seconds}s")
+              finally:
+                  try:
+                      os.killpg(process.pid, signal.SIGTERM)
+                  except ProcessLookupError:
+                      pass
+                  try:
+                      process.wait(timeout=10)
+                  except subprocess.TimeoutExpired:
+                      try:
+                          os.killpg(process.pid, signal.SIGKILL)
+                      except ProcessLookupError:
+                          pass
+                      process.wait(timeout=10)
+
+          # manager 是 Info.plist 中双击 .app 时真正执行的入口；mower 是其拉起的
+          # 主程序。两者都要冒烟，避免只测内部二进制却漏掉默认入口。
+          smoke("manager", 10)
+          smoke("mower", 20)
           PYEOF
 
-      - name: Package into zip with ditto
+      - name: Verify app bundle after smoke launch
         run: |
+          set -euo pipefail
+
+          for path in config log screenshot tmp instances.json; do
+            if [[ -e "dist/mower.app/Contents/${path}" ]]; then
+              echo "::error::smoke launch wrote runtime data into the signed app bundle: ${path}" >&2
+              exit 1
+            fi
+          done
+
+          python scripts/check_macos_app.py dist/mower.app --arch ${{ matrix.macho }}
+
+      - name: Package into DMG
+        run: |
+          set -euo pipefail
+
           version="${{ needs.prepare.outputs.version }}"
-          ditto -c -k --sequesterRsrc --keepParent \
-            dist/mower.app "dist/arknights-mower_${version}_macos_${{ matrix.arch }}.zip"
+          dmg_path="dist/arknights-mower_${version}_macos_${{ matrix.arch }}.dmg"
+          dmg_root="$(mktemp -d "${RUNNER_TEMP}/mower-dmg.XXXXXX")"
+
+          ditto dist/mower.app "${dmg_root}/mower.app"
+          ln -s /Applications "${dmg_root}/Applications"
+          hdiutil create \
+            -volname "arknights-mower ${version}" \
+            -srcfolder "${dmg_root}" \
+            -ov \
+            -format UDZO \
+            "${dmg_path}"
+          hdiutil verify "${dmg_path}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: arknights-mower_${{ needs.prepare.outputs.version }}_macos_${{ matrix.arch }}
-          path: dist/arknights-mower_${{ needs.prepare.outputs.version }}_macos_${{ matrix.arch }}.zip
+          path: dist/arknights-mower_${{ needs.prepare.outputs.version }}_macos_${{ matrix.arch }}.dmg
 
   release:
     name: Publish GitHub Release

--- a/arknights_mower/data/__init__.py
+++ b/arknights_mower/data/__init__.py
@@ -7,7 +7,7 @@ from ..utils.resource_pkg import resource_pkg_path
 
 
 def _data_path(name: str) -> Path:
-    """资源包 overlay 优先（@install/tmp/resource），回退内置 data/。"""
+    """资源包 overlay 优先（@app/tmp/resource），回退内置 data/。"""
     return resource_pkg_path(f"arknights_mower/data/{name}")
 
 
@@ -18,7 +18,7 @@ def stage_data_path() -> Path:
 
 def stage_data_overlay_path() -> Path:
     """热更的活动关卡层（只含 ACTIVITY），运行时读，热更落地即生效。"""
-    return get_path("@install/tmp/hot_update/stage_data.json")
+    return get_path("@app/tmp/hot_update/stage_data.json")
 
 
 # 全量基线：启动读一次进内存，之后不变（常驻关卡只在基线，不随热更改）。

--- a/arknights_mower/solvers/navigation.py
+++ b/arknights_mower/solvers/navigation.py
@@ -1075,7 +1075,7 @@ class NavigationSolver(SceneGraphSolver, BaseMixin):
     def _official_paths(self) -> tuple:
         """官方层候选路径：热更目录优先，自带打包兜底。"""
         return (
-            get_path("@install/tmp/hot_update/nav_steps.json"),
+            get_path("@app/tmp/hot_update/nav_steps.json"),
             Path(__rootdir__) / "data" / "nav_steps.json",
         )
 

--- a/arknights_mower/tests/manager_tests.py
+++ b/arknights_mower/tests/manager_tests.py
@@ -1,0 +1,24 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from manager import Api
+
+
+class ManagerApiTests(unittest.TestCase):
+    def test_instances_are_stored_at_explicit_writable_path(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            storage_path = Path(temporary_dir) / "nested" / "instances.json"
+            api = Api(storage_path)
+
+            api.add("default", "/tmp/mower-data")
+
+            reloaded = Api(storage_path)
+            self.assertEqual(
+                reloaded.get_instances(),
+                [{"name": "default", "path": "/tmp/mower-data"}],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/path_tests.py
+++ b/arknights_mower/tests/path_tests.py
@@ -1,0 +1,30 @@
+import unittest
+from pathlib import Path
+
+from arknights_mower.utils.path import _default_frozen_data_dir
+
+
+class FrozenDataDirTests(unittest.TestCase):
+    def test_macos_uses_application_support(self):
+        result = _default_frozen_data_dir(
+            Path("/Applications/mower.app/Contents/Frameworks"),
+            platform_name="darwin",
+            home_dir=Path("/Users/tester"),
+        )
+
+        self.assertEqual(
+            result,
+            Path("/Users/tester/Library/Application Support/arknights_mower"),
+        )
+
+    def test_other_platforms_keep_portable_bundle_layout(self):
+        internal_dir = Path("/opt/mower/_internal")
+
+        self.assertEqual(
+            _default_frozen_data_dir(internal_dir, platform_name="linux"),
+            Path("/opt/mower"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/utils/hot_update.py
+++ b/arknights_mower/utils/hot_update.py
@@ -12,8 +12,8 @@ from arknights_mower.utils.path import get_path
 from arknights_mower.utils.res_version import version_newer
 from arknights_mower.utils.zip_safe import is_unsafe_zip_member
 
-extract_path = get_path("@install/tmp/hot_update")
-version_state = get_path("@install/tmp/hot_update_version.json")
+extract_path = get_path("@app/tmp/hot_update")
+version_state = get_path("@app/tmp/hot_update_version.json")
 HOT_UPDATE_REPO = "ArkMowers/MowerHotUpdate"
 
 last_update = None

--- a/arknights_mower/utils/image.py
+++ b/arknights_mower/utils/image.py
@@ -32,7 +32,7 @@ def img2bytes(img: tp.Image) -> bytes:
 
 def loadres(res: tp.Res, gray: bool = False) -> Union[tp.Image, tp.GrayImage]:
     if res.startswith("@hot"):
-        res_name = res.replace("@hot", "@install/tmp/hot_update", 1)
+        res_name = res.replace("@hot", "@app/tmp/hot_update", 1)
     else:
         res_name = f"{__rootdir__}/resources/{res}"
     if not res.endswith(".jpg"):

--- a/arknights_mower/utils/path.py
+++ b/arknights_mower/utils/path.py
@@ -16,11 +16,30 @@ def find_git_root(directory: Path) -> Path:
         return find_git_root(directory.parent)
 
 
+def _default_frozen_data_dir(
+    internal_dir: Path,
+    platform_name: str | None = None,
+    home_dir: Path | None = None,
+) -> Path:
+    """Return the writable data root used by a frozen application.
+
+    A macOS ``.app`` bundle is signed and can also be launched from a read-only
+    DMG, so runtime state must not be written below ``Contents``. Windows and
+    Linux keep their existing portable layout next to PyInstaller's internal
+    directory.
+    """
+    platform_name = sys.platform if platform_name is None else platform_name
+    if platform_name == "darwin":
+        home_dir = Path.home() if home_dir is None else Path(home_dir)
+        return home_dir / "Library" / "Application Support" / appname
+    return internal_dir.parent
+
+
 # define _app_dir
 if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
     _internal_dir = Path(sys._MEIPASS).resolve()
     _install_dir = _internal_dir.parent.resolve()
-    _app_dir = _internal_dir.parent
+    _app_dir = _default_frozen_data_dir(_internal_dir)
 else:
     _app_dir = find_git_root(Path(os.getcwd()).resolve())
     if not _app_dir:

--- a/arknights_mower/utils/resource_pkg.py
+++ b/arknights_mower/utils/resource_pkg.py
@@ -1,6 +1,6 @@
 """资源包 overlay：文件解析 + 下载 + 原子安装（#191）。
 
-- 资源包解压到可写 ``@install/tmp/resource/``（冻结 exe 下 ``__rootdir__`` 只读，原位替换不成立），
+- 资源包解压到可写 ``@app/tmp/resource/``（冻结 exe 下 ``__rootdir__`` 只读，原位替换不成立），
   各加载器经 ``resource_pkg_path`` 先查 overlay、回退内置 ``__rootdir__``。
 - zip 内路径相对仓库根（``arknights_mower/data/X.json``、``ui/public/depot/X.webp``）。
 - 安装走「原子换目录」：staging → resource，旧目录先挪走，失败回滚；version.json 随 zip
@@ -20,9 +20,9 @@ from arknights_mower.utils.log import logger
 from arknights_mower.utils.path import get_path
 from arknights_mower.utils.zip_safe import is_unsafe_zip_member
 
-RESOURCE_OVERLAY = get_path("@install/tmp/resource")
-_STAGING = get_path("@install/tmp/resource_staging")
-_OLD = get_path("@install/tmp/resource_old")
+RESOURCE_OVERLAY = get_path("@app/tmp/resource")
+_STAGING = get_path("@app/tmp/resource_staging")
+_OLD = get_path("@app/tmp/resource_old")
 RESOURCE_REPO = "ArkMowers/MowerResource"
 RESOURCE_ZIP_URL = (
     f"https://github.com/{RESOURCE_REPO}/releases/latest/download/resource.zip"

--- a/arknights_mower/utils/resource_version.py
+++ b/arknights_mower/utils/resource_version.py
@@ -18,7 +18,7 @@ from arknights_mower.utils.resource_pkg import resource_pkg_path
 RESOURCE_VERSION_URL = (
     "https://raw.githubusercontent.com/ArkMowers/MowerResource/main/version.json"
 )
-TMP_VERSION_PATH = get_path("@install/tmp/resource_version.json")
+TMP_VERSION_PATH = get_path("@app/tmp/resource_version.json")
 
 
 def _read_json(path: Path) -> dict | None:

--- a/doc/release-platforms.md
+++ b/doc/release-platforms.md
@@ -55,8 +55,8 @@ Release 正文和带当前版本块的 `CHANGELOG.md`，并将后者放入打包
 | Windows x64 | `windows-latest` | `webui_zip.spec` | `.zip` | PE x64 |
 | Linux x64 | `ubuntu-24.04` | `webui_zip_for_linux.spec` | `.tar.gz` | `file` x86-64、`ldd`、GUI 冒烟 |
 | Linux ARM64 | `ubuntu-24.04-arm` | `webui_zip_for_linux.spec` | `.tar.gz` | `file` aarch64、`ldd`、GUI 冒烟 |
-| macOS x64 | `macos-15-intel` | `webui_zip_for_macos.spec` | `.zip` | `file`、`lipo`、`otool`、`codesign --verify`、GUI 冒烟 |
-| macOS ARM64 | `macos-15` | `webui_zip_for_macos.spec` | `.zip` | 同上 |
+| macOS x64 | `macos-15-intel` | `webui_zip_for_macos.spec` | `.dmg` | `file`、`lipo`、`otool`、`codesign --verify`、GUI 冒烟 |
+| macOS ARM64 | `macos-15` | `webui_zip_for_macos.spec` | `.dmg` | 同上 |
 
 产物统一使用以下名称：
 
@@ -64,8 +64,8 @@ Release 正文和带当前版本块的 `CHANGELOG.md`，并将后者放入打包
 arknights-mower_<version>_windows_x64.zip
 arknights-mower_<version>_linux_x64.tar.gz
 arknights-mower_<version>_linux_arm64.tar.gz
-arknights-mower_<version>_macos_x64.zip
-arknights-mower_<version>_macos_arm64.zip
+arknights-mower_<version>_macos_x64.dmg
+arknights-mower_<version>_macos_arm64.dmg
 ```
 
 Release 任务在全部平台构建成功后附加五个产物，并生成统一的 SHA-256 清单
@@ -83,8 +83,10 @@ Release 任务在全部平台构建成功后附加五个产物，并生成统一
   解析结果，再通过 Xvfb 运行 30 秒 GUI 冒烟。
 - macOS spec 显式收集 pywebview Cocoa 后端依赖和当前 wheel 中存在的
   onnxruntime 动态库，并将主程序与多开管理器放入 `.app/Contents/MacOS`。
-  构建任务检查应用目录结构、Mach-O 架构、外部动态库和 ad-hoc 签名，再运行
-  20 秒 GUI 冒烟，最后使用 `ditto` 保留应用目录结构。
+  构建任务分别检查多开管理器与主程序 GUI，并通过 `MOWER_DATA_DIR` 将冒烟产生的
+  配置、日志和数据库隔离到 runner 临时目录。冒烟后再次检查应用目录结构、
+  Mach-O 架构、外部动态库和 ad-hoc 签名，最后生成包含 `.app` 与
+  `Applications` 快捷方式的压缩 DMG。
 
 任意架构、动态库或冒烟检查失败时，对应构建任务失败，Release 任务不会执行。
 PyInstaller 只在 Windows 使用 UPX；Linux 不执行 UPX 压缩，macOS spec 也显式
@@ -92,13 +94,15 @@ PyInstaller 只在 Windows 使用 UPX；Linux 不执行 UPX 压缩，macOS spec 
 
 ## 签名与系统依赖
 
-所有产物均为未签名构建：
+产物均未使用受信任发行证书：
 
 - Windows 不使用商业证书、SignPath、MSIX 或自签证书。首次运行可能出现
   SmartScreen 提示。
 - macOS 不使用 Developer ID、notarization 或 stapling。PyInstaller 只进行
   ad-hoc 签名，首次运行可能被 Gatekeeper 拦截，需要在「隐私与安全性」中手动
-  允许。
+  允许。冻结版运行数据默认写入
+  `~/Library/Application Support/arknights_mower`，不会修改 DMG 中只读的应用包
+  或破坏应用包的资源签名。
 - Linux 产物在 Ubuntu 24.04 上构建，要求运行环境提供兼容的 glibc、`libzbar0`、
   `libgl1`、`libglib2.0-0`、`libgtk-3-0` 与
   `libwebkit2gtk-4.1-0`。

--- a/manager.py
+++ b/manager.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python3
 
 import json
+from pathlib import Path
 
 import webview
 
+from arknights_mower.utils.path import get_path
+
 
 class Api:
-    def __init__(self):
+    def __init__(self, storage_path=None):
+        self.storage_path = (
+            Path(storage_path)
+            if storage_path is not None
+            else get_path("@app/instances.json", space="")
+        )
         try:
-            with open("instances.json", "r", encoding="utf-8") as f:
+            with self.storage_path.open("r", encoding="utf-8") as f:
                 self.instances = json.load(f)
         except Exception:
             self.instances = []
             self.save()
 
     def save(self):
-        with open("instances.json", "w", encoding="utf-8") as f:
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.storage_path.open("w", encoding="utf-8") as f:
             json.dump(self.instances, f, ensure_ascii=False)
 
     def get_instances(self):
@@ -47,7 +56,6 @@ class Api:
     def start(self, idx):
         import platform
         import sys
-        from pathlib import Path
         from subprocess import Popen
 
         is_win = platform.system() == "Windows"

--- a/scripts/tests/release_workflow_tests.py
+++ b/scripts/tests/release_workflow_tests.py
@@ -180,14 +180,16 @@ class CrossPlatformReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("sha256sum", manifest["run"])
         self.assertIn("SHA256SUMS", manifest["run"])
 
-    def test_prepare_appends_unsigned_notes_without_download_list(self):
+    def test_prepare_appends_signing_notes_without_download_list(self):
         append = find_step(self.jobs["prepare"], "Append signing notes to body")
         run = append["run"]
         self.assertNotIn("## 下载", run)
         self.assertNotIn("arknights-mower_", run)
         self.assertIn("SHA256SUMS", run)
         self.assertIn("SmartScreen", run)
-        self.assertIn("unsigned experimental", run)
+        self.assertIn("macOS DMG", run)
+        self.assertIn("ad-hoc", run)
+        self.assertIn("notarize", run)
 
     def test_builds_share_version_injection(self):
         command = f'python scripts/inject_version.py "{VERSION}"'
@@ -243,26 +245,48 @@ class CrossPlatformReleaseWorkflowTests(unittest.TestCase):
         step = find_step(self.jobs["build-windows"], "Verify PE architecture")
         self.assertEqual(step["env"]["PYTHONUTF8"], "1")
 
-    def test_macos_spec_bundle_check_and_ditto(self):
+    def test_macos_smoke_verifies_bundle_and_packages_dmg(self):
         job = self.jobs["build-macos"]
         names = [step.get("name") for step in job["steps"]]
         build = names.index("Build with PyInstaller")
-        verify = names.index("Verify app bundle structure")
-        package = names.index("Package into zip with ditto")
-        self.assertLess(build, verify)
+        smoke = names.index("Smoke launch bundled entry points")
+        verify = names.index("Verify app bundle after smoke launch")
+        package = names.index("Package into DMG")
+        upload = names.index("Upload artifact")
+        self.assertLess(build, smoke)
+        self.assertLess(smoke, verify)
         self.assertLess(verify, package)
+        self.assertLess(package, upload)
+
+        smoke_step = job["steps"][smoke]
+        self.assertEqual(
+            smoke_step["env"]["MOWER_DATA_DIR"],
+            "${{ runner.temp }}/mower-smoke-data-${{ matrix.arch }}",
+        )
+        smoke_run = smoke_step["run"]
+        self.assertIn('cwd="dist"', smoke_run)
+        self.assertIn('smoke("manager", 10)', smoke_run)
+        self.assertIn('smoke("mower", 20)', smoke_run)
+
         verify_run = job["steps"][verify]["run"]
         self.assertIn("check_macos_app.py", verify_run)
         self.assertIn("${{ matrix.macho }}", verify_run)
         self.assertIn("dist/mower.app", verify_run)
         self.assertNotIn("dist/mower/mower.app", verify_run)
+        self.assertIn("config log screenshot tmp instances.json", verify_run)
+
         package_run = job["steps"][package]["run"]
-        self.assertIn("ditto", package_run)
-        self.assertIn("--keepParent", package_run)
-        self.assertIn("dist/mower.app", package_run)
-        smoke = job["steps"][names.index("Smoke launch")]["run"]
-        self.assertIn('cwd="dist"', smoke)
-        self.assertIn("./mower.app/Contents/MacOS/mower", smoke)
+        self.assertIn('ditto dist/mower.app "${dmg_root}/mower.app"', package_run)
+        self.assertIn('ln -s /Applications "${dmg_root}/Applications"', package_run)
+        self.assertIn("hdiutil create", package_run)
+        self.assertIn("hdiutil verify", package_run)
+
+        upload_path = job["steps"][upload]["with"]["path"]
+        self.assertEqual(
+            upload_path,
+            "dist/arknights-mower_${{ needs.prepare.outputs.version }}_macos_"
+            "${{ matrix.arch }}.dmg",
+        )
 
     def test_macos_keeps_zbar_system_dependency(self):
         job = self.jobs["build-macos"]

--- a/server.py
+++ b/server.py
@@ -177,7 +177,7 @@ def serve_resource_overlay():
     """资源包 webp（depot/avatar/building_skill）overlay 优先，刷新即生效。"""
     path = request.path.lstrip("/")
     if path.startswith(("depot/", "avatar/", "building_skill/")):
-        base = Path(get_path("@install/tmp/resource/ui/public"))
+        base = Path(get_path("@app/tmp/resource/ui/public"))
         p = (base / path).resolve()
         if base.resolve() in p.parents and p.is_file():
             return send_file(p)


### PR DESCRIPTION
## 背景

macOS 发布流程在 PyInstaller 完成 ad-hoc 签名后执行 GUI 冒烟。程序运行时会把配置、日志和数据库写进 `mower.app/Contents`，使发布包的资源封印失效，`codesign --verify --strict` 报 `a sealed resource is missing or invalid`。

此外，双击 `.app` 实际启动的是 `manager`，原流程只冒烟测试内部的 `mower`；运行数据保存在应用包内部也不适合只读 DMG。

## 改动

- macOS 冻结版运行数据迁移至 `~/Library/Application Support/arknights_mower`。
- 多开管理器将 `instances.json` 保存到统一的可写数据目录。
- 热更新、资源包和版本缓存统一改走 `@app/tmp`，避免修改应用包。
- macOS CI 同时冒烟测试 `manager` 与 `mower`，并通过 `MOWER_DATA_DIR` 隔离测试数据。
- 冒烟结束后检查应用包内是否出现运行数据，并再次校验 Mach-O 架构、动态库及 ad-hoc 签名。
- macOS x64/arm64 发布产物改为压缩 DMG，包含 `mower.app` 与 `Applications` 快捷方式。
- 更新发布文档并补充路径与管理器持久化测试。

## 验证

- Ruff 检查与格式检查通过。
- 相关 122 项单元测试通过。
- Actionlint 与 `git diff --check` 通过。
- 本地完成 DMG 创建、`hdiutil verify`、挂载及 `Applications` 链接检查。
