### PR TITLE
fix(recognition): 修复检测基建通知时在全暗过渡帧越界崩溃

### DIFF
--- a/arknights_mower/tests/detector_tests.py
+++ b/arknights_mower/tests/detector_tests.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+
+from arknights_mower.utils.detector import infra_notification
+
+
+class TestInfraNotification(unittest.TestCase):
+    """infra_notification 对全暗帧无边界保护——加 right 下限 + 全暗帧返回 None。"""
+
+    def _blue_notification(self, x0, x1, y0, y1, color=(30, 150, 220)):
+        """构造 1080p 画布，在 [x0, x1) × [y0, y1) 画一个蓝色通知，其余全暗。"""
+        img = np.zeros((1080, 1920, 3), dtype=np.uint8)
+        img[y0:y1, x0:x1] = color
+        return img
+
+    def test_all_dark_frame_returns_none(self):
+        # 场景切换过渡帧整屏全暗 → right-scan 扫到左边缘即停，返回 None，不再越界崩溃
+        img = np.zeros((1080, 1920, 3), dtype=np.uint8)
+        self.assertIsNone(infra_notification(img))
+
+    def test_normal_blue_notification_returns_point(self):
+        img = self._blue_notification(300, 400, 200, 300)
+        self.assertEqual(infra_notification(img), (389, 250))
+
+    def test_notification_at_left_edge_not_swallowed(self):
+        # 通知贴近 x=0：right-scan 在最右亮列（right=9）停下、不会扫到 right==0；
+        # 全暗哨兵（right==0）只对整帧全暗触发，不会误吞左侧的通知
+        img = self._blue_notification(0, 10, 200, 300)
+        self.assertIsNotNone(infra_notification(img))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/utils/detector.py
+++ b/arknights_mower/utils/detector.py
@@ -12,9 +12,13 @@ def infra_notification(img: tp.Image) -> tp.Coordinate:
     height, width, _ = img.shape
 
     # set a new scan line: right
+    # 场景切换过渡帧可能整屏全暗，right 无下限会越界（减到 -1921）；
+    # 加 left 边界，全暗帧直接返回 None（调用方按「无通知」重读跳过）。
     right = width
-    while np.max(img[:, right - 1]) < 100:
+    while right > 0 and np.max(img[:, right - 1]) < 100:
         right -= 1
+    if right == 0:
+        return None
     right -= 1
 
     # set a new scan line: up


### PR DESCRIPTION
## 目标

基建内蓝色通知的检测从右向左进行，原实现没有为循环设置左边界。场景切换的过渡帧出现整屏全暗时，`right` 会一路向左递减到 -1921，触及越界并抛出 `IndexError`，当前一轮任务因此中断、白白浪费一个读取周期。本次为检测补上左边界，让全暗帧直接返回「无通知」，通知存在的正常路径不受影响。

## 主要改动

- `arknights_mower/utils/detector.py`：`right` 从右往左检测蓝色通知时没有下限，全暗过渡帧会一路减到越界；给它加上左边界 `while right > 0 and np.max(img[:, right - 1]) < 100`，当 `right == 0` 时直接返回 `None`，调用方按「无通知」处理并重读跳过。
- `arknights_mower/tests/detector_tests.py`：新增 `TestInfraNotification` 测试类，覆盖三种情况——整屏全暗返回 `None`、正常蓝色通知返回坐标 `(389, 250)`、通知贴近左侧边缘时不会被全暗哨兵误吞。

## 验证与风险

- `ruff check .` 与 `ruff format --check .` 全部通过；`python -m compileall arknights_mower scripts` 通过。
- 全量测试 `python -m unittest discover -s arknights_mower/tests -p "*_tests.py"` 运行 763 个用例，结果 OK（skipped=10）。
- 改动仅在原有正常路径之外增加全暗帧的提前返回分支，不改变通知存在的识别路径；纯 Python，不涉及前端与 prettier。
