### PR TITLE
chore(mastery): 医疗和重装专三协助位改为望并优化专精推荐展示

### DIFF
--- a/arknights_mower/solvers/mastery.py
+++ b/arknights_mower/solvers/mastery.py
@@ -85,8 +85,8 @@ DEFAULT_ROUTES = {
             "swap_target": "逻各斯",
         },
         "level_3": {
-            "operator": "星熊",
-            "efficiency": 60,
+            "operator": "望",
+            "efficiency": 70,
             "job_match": False,
             "swap_target": None,
         },
@@ -145,8 +145,8 @@ DEFAULT_ROUTES = {
             "swap_target": "逻各斯",
         },
         "level_3": {
-            "operator": "阿",
-            "efficiency": 60,
+            "operator": "望",
+            "efficiency": 70,
             "job_match": False,
             "swap_target": None,
         },

--- a/ui/src/pages/MasteryRecommendation.vue
+++ b/ui/src/pages/MasteryRecommendation.vue
@@ -165,9 +165,9 @@
               <template #header>
                 <n-space align="center" justify="space-between" style="width: 100%">
                   <n-space align="center" :size="8">
-                    <n-text strong>{{ rec.skill_name }} → M3</n-text>
+                    <n-text strong>{{ rec.skill_name }}</n-text>
                     <n-text depth="3" style="font-size: 12px"
-                      >Lv{{ rec.current_level + 7 }}→10</n-text
+                      >Lv{{ rec.current_level + 7 }} → 专精3级</n-text
                     >
                   </n-space>
                   <n-space :size="4">
@@ -255,7 +255,7 @@
           <n-tag size="small">{{ professionName(cd.op?.profession) }}</n-tag></n-text
         >
         <n-text
-          >技能: <n-text strong>{{ cd.rec?.skill_name }}</n-text> → M3 |
+          >技能: <n-text strong>{{ cd.rec?.skill_name }}</n-text> → 专精3级 |
           {{ formatTime(cd.rec?.total_time || 0) }}</n-text
         >
         <n-divider />
@@ -1408,7 +1408,7 @@ async function doAddTask() {
   const { op, rec } = cd
   try {
     // #71：一键专精走 DB 计划创建 API（POST /mastery-plan），不再发原始 /task「技能专精」
-    // （死流：server 只认 DB 计划）。target_level 由服务端默认专三，与确认弹窗「→ M3」一致。
+    // （死流：server 只认 DB 计划）。target_level 由服务端默认专三，与确认弹窗「→ 专精3级」一致。
     const r = await axios.post(`${import.meta.env.VITE_HTTP_URL}/mastery-plan`, {
       items: [{ name: op.name, skill_index: rec.skill_index }]
     })


### PR DESCRIPTION
## 目标

本次调整专精默认路线中医疗与重装两个职业的专三协助干员，提升协助位效率；同时整理专精推荐卡片头部与确认弹窗的目标表达，避免重复显示同一目标。

## 主要改动

- 后端：在 DEFAULT_ROUTES 中，医疗的 level_3 协助位由阿改为望、重装的由星熊改为望，效率均由 60 改为 70。level_3 的 swap_target 保持 None，因为专三不更换减半对象。改动文件为 arknights_mower/solvers/mastery.py。

- 前端：专精推荐卡片头部原先同时显示「→ M3」和「Lv7→10」，二者重复表达同一个目标，因为 M3 即专精三，对应技能等级 10；现在标题只显示技能名，副标题采用「Lv{当前有效等级} → 专精3级」单箭头，从当前等级指向目标，只表达一次。确认弹窗去掉 M 记号，改用「专精3级」。数字统一使用阿拉伯数字，与全站 E2、Lv90 等写法保持一致。改动文件为 ui/src/pages/MasteryRecommendation.vue。

## 验证与风险

- 后端：ruff check、ruff format --check、compileall 全部通过；unittest 763 通过、10 跳过，与基线一致，没有回归。
- 前端：prettier 通过；masteryRoute.test.js 的 4 个测试全部通过。
- 改动集中在默认路线的协助干员数据与专精推荐卡片的展示层，不涉及训练室排班逻辑，影响范围较小。
