### PR TITLE
fix(ui): 修复基建报表悬停收益 NaN 与干员心情折线表图例重叠

### DIFF
--- a/ui/src/pages/RecordLine.vue
+++ b/ui/src/pages/RecordLine.vue
@@ -161,6 +161,8 @@ h2 {
   height: 300px;
   box-sizing: border-box;
   border-radius: 8px;
+  display: flex;
+  flex-direction: column;
 }
 
 .report-card-expand {
@@ -190,6 +192,7 @@ h2 {
   width: 100%;
   overflow-x: scroll;
   flex: 1;
+  min-height: 0;
 }
 
 .line-inner-container {

--- a/ui/src/pages/report.vue
+++ b/ui/src/pages/report.vue
@@ -289,25 +289,13 @@ const option_manufactor = computed(() => {
       },
 
       formatter: function (params) {
-        if (params[0].data['龙舌兰赤金'] || params[0].data['可露希尔赤金']) {
-          total_earnings.value =
-            (params[0].data['赤金'] +
-              params[0].data['龙舌兰赤金'] +
-              params[0].data['可露希尔赤金']) *
-              value_coefficient_gold.value +
-            params[0].data['龙门币订单'] * value_coefficient_lmb.value +
-            params[0].data['作战录像'] * value_coefficient_exp.value
-        } else {
-          params[0].data['龙舌兰赤金'] = 0
-          params[0].data['可露希尔赤金'] = 0
-          total_earnings.value =
-            (params[0].data['赤金'] +
-              params[0].data['龙舌兰赤金'] +
-              params[0].data['可露希尔赤金']) *
-              value_coefficient_gold.value +
-            params[0].data['龙门币订单'] * value_coefficient_lmb.value +
-            params[0].data['作战录像'] * value_coefficient_exp.value
-        }
+        total_earnings.value =
+          (params[0].data['赤金'] +
+            (params[0].data['龙舌兰赤金'] || 0) +
+            (params[0].data['可露希尔赤金'] || 0)) *
+            value_coefficient_gold.value +
+          params[0].data['龙门币订单'] * value_coefficient_lmb.value +
+          params[0].data['作战录像'] * value_coefficient_exp.value
         const tip = `<div style="font-size:1.4rem;">
                         <span style="font-size:15px">${params[0].data['日期']}</span>  <br>
                         ${params[0].marker}    <span style="font-size:14px">${params[0].seriesName}:${params[0].data['赤金']}</span>  <br>


### PR DESCRIPTION
## 目标

修复基建报表悬停含特殊赤金时的天时收益显示 NaN、以及干员心情折线表顶部图例与折线数据重叠两处 UI 显示问题。

## 主要改动

- 基建报表（report.vue）：悬停收益原用 if/else 区分是否出现龙舌兰赤金或可露希尔赤金，两条分支在其它字段存在时等价，而仅出现其中一种特殊赤金时另一字段为 undefined，参与加法得到 NaN。本次改为与 `item.收益` 既有一致的写法，用 `|| 0` 兜底，并把重复的 if/else 合并为一条计算，行为不再随字段是否缺失而分叉。
- 干员心情折线表（RecordLine.vue）：卡片图表 canvas 高度因容器高度链不确定（`.line-inner-container` 的 `height:100%` 解析到 auto 父级）而卡在 150px，多干员时顶部图例与接近 24 的数据线被挤在一起、图例部分被裁。本次让卡片成为 flex 列、图表容器弹性填满高度，使 canvas 填满卡片，图例完整显示并与数据线之间留出间隔。

## 验证与风险

- 均为纯前端显示层改动，不触碰数据与排班逻辑。
- report.vue：唯一行为变化是悬停不再出现 NaN。RecordLine.vue：多干员卡片图例不再被裁、数据线不再与图例重叠，干员数 1 与较多（如 8）的卡片均正常，图例多行完整显示，不改变 expand 与 adjust_width 交互。
- `prettier` 校验通过；针对这两处行为的专项测试不存在，前端全量测试应与基线持平、无回归。
