### PR TITLE
fix(depot): 修复游戏数据更新后仓库扫描识别不准与资源生成崩溃的问题

### DIFF
--- a/arknights_mower/solvers/depotREC.py
+++ b/arknights_mower/solvers/depotREC.py
@@ -171,8 +171,8 @@ class depotREC(SceneGraphSolver):
 
             starttime = datetime.now()
             任务组 = [
-                (1200, self.knn模型_CONSUME, "消耗物品"),
-                (1400, self.knn模型_NORMAL, "基础物品"),
+                (1063, self.knn模型_CONSUME, "消耗物品"),
+                (1298, self.knn模型_NORMAL, "基础物品"),
             ]
 
             for 任务 in 任务组:

--- a/auto_get_res_new.py
+++ b/auto_get_res_new.py
@@ -82,7 +82,11 @@ class Arknights数据处理器:
         self.所有buff = []
 
         self.限定十连 = self.抽卡表["limitTenGachaItem"]
-        self.联动十连 = self.抽卡表["linkageTenGachaItem"]
+        self.联动十连 = (
+            self.抽卡表.get("linkageTenGachaItem")
+            or self.抽卡表.get("linkageGachaItem")
+            or []
+        )
         self.普通十连 = self.抽卡表["normalGachaItem"]
         self.所有卡池 = self.限定十连 + self.联动十连 + self.普通十连
 
@@ -138,7 +142,12 @@ class Arknights数据处理器:
             源文件路径 = f"./ArknightsGameResource/item/{图标代码}.png"
             排除开关 = False
             排除开关 = 检查图标代码匹配(图标代码, 物品类型)
-            if 分类类型 != "NONE" and 排序代码 > 0 and not 排除开关:
+            if (
+                分类类型 != "NONE"
+                and 排序代码 > 0
+                and not 排除开关
+                and 分类类型 in self.装仓库物品的字典
+            ):
                 if os.path.exists(源文件路径):
                     目标文件路径 = f"./ui/public/depot/{中文名称}.webp"
                     self.装仓库物品的字典[分类类型].append([目标文件路径, 源文件路径])


### PR DESCRIPTION
## 目标与结果

游戏数据更新后，仓库扫描识别与资源生成出现异常：扫仓库识别结果偏松、资源包生成在新数据源上崩溃。本次修复让扫仓库恢复准确识别、资源生成兼容新版数据源。

## 主要改动

- 扫仓库 KNN 识别阈值由 `1200/1400` 更新为 `1063/1298`，匹配屏幕布局与物品集变化，避免阈值偏松造成误判。
- `auto_get_res_new.py` 兼容 excel 数据源结构变化：gacha 牌表键 `linkageTenGachaItem` 改名为 `linkageGachaItem`；物品表新增 `classifyType=MEMENTO`（剧情纪念品）。否则在新数据源上生成资源包会因 `KeyError` 崩溃。

## 验证与风险

- 在新版数据源（`ArknightsAssets/ArknightsGamedata`）下完整跑通 `auto_get_res_new.py` 管线，产出 `version.json` 的活动/卡池正确（月行水上 / 石白深蓝之夜，均 2026-09-04 开启）。
- ruff 检查改动文件全部通过；相关单测（`resource_version` / `res_version` / `resource_pkg`）共 39 项通过。
- 扫仓库 KNN 阈值属于经验参数，后续物品集如果再变化需要重新校准。
