### PR TITLE
feat(depot): 新增手动添加仓库扫描任务

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -623,6 +623,8 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 elif self.task.type == TaskTypes.REFRESH_TIME:
                     self.plan_run_order(self.task.meta_data)
                     self.skip(["todo_task", "collect_notification"])
+                elif self.task.type == TaskTypes.DEPOT:
+                    self.仓库扫描()
                 elif self.task.type == TaskTypes.NOT_SPECIFIC:
                     pass
                 del self.tasks[0]

--- a/ui/src/components/TaskDialog.vue
+++ b/ui/src/components/TaskDialog.vue
@@ -27,6 +27,7 @@ const error = ref(false)
 const taskTypeOptions = [
   { label: '专精任务', value: '技能专精' },
   { label: '加工任务', value: '加工材料' },
+  { label: '仓库扫描', value: '仓库扫描' },
   { label: '空任务', value: '空任务' }
 ]
 const workshopOperatorOptions = computed(() => {
@@ -127,6 +128,9 @@ async function saveTasks() {
       return
     }
     task.meta_data = workshop_operator.value
+    task.plan = {}
+  } else if (task_type.value == '仓库扫描') {
+    // 仓库扫描任务无需房间 plan：到点由调度器触发基地仓库扫描
     task.plan = {}
   }
   msg.value = (await axios.post(`${import.meta.env.VITE_HTTP_URL}/task`, { task })).data


### PR DESCRIPTION
## 目标与结果

仓库扫描任务支持在任务界面手动添加，用户可自行创建"仓库扫描"任务，到达计划时间实际触发仓库扫描。

## 主要改动

- 任务界面：任务类型选项增加"仓库扫描"，用户可手动添加，保存时仓库扫描任务无需房间 `plan`。
- 到点执行：任务分发循环补充 `DEPOT` 分支，到计划时间调用 `仓库扫描()`。

## 验证与风险

- ruff 检查改动文件全部通过；相关单测（`base_scheduler` / `scheduler_task`）共 57 项通过。
- 仓库扫描任务的实机表现尚未充分验证。
