### PR TITLE
fix(skland): 修复森空岛签到失败与导入崩溃

### DIFF
--- a/arknights_mower/tests/skland_tests.py
+++ b/arknights_mower/tests/skland_tests.py
@@ -1,0 +1,209 @@
+import datetime
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+# mastery_view_tests 等模块收集期会先往 sys.modules 塞 skland 的 MagicMock 桩
+# （历史原因：skland 导入时 get_d_id 会联网）。本测试需要真实模块：删桩后导入
+# （导入已惰性化、不再联网），测试结束恢复桩，避免影响后续依赖该桩的测试。
+_saved_skland = sys.modules.get("arknights_mower.utils.skland")
+sys.modules.pop("arknights_mower.utils.skland", None)
+from arknights_mower.utils import skland  # noqa: E402
+
+
+def tearDownModule():
+    sys.modules["arknights_mower.utils.skland"] = _saved_skland
+
+
+# 服务器 Date 头 / 错误响应 timestamp 用的服务器时刻；SERVER_EPOCH 由其派生，
+# 二者共用同一来源，避免手写成对之后改一个漏一个
+SERVER_DATE = "Fri, 28 Aug 2026 23:43:24 GMT"
+SERVER_EPOCH = int(
+    datetime.datetime.strptime(SERVER_DATE, "%a, %d %b %Y %H:%M:%S GMT")
+    .replace(tzinfo=datetime.timezone.utc)
+    .timestamp()
+)
+# 测试里 mock 的本机 epoch（比服务器快 10 秒，对应真实偏差）
+LOCAL_EPOCH = SERVER_EPOCH + 10
+
+
+class TestSyncServerTime(unittest.TestCase):
+    def setUp(self):
+        skland.server_time_offset = 0
+
+    def test_sync_from_date_header(self):
+        resp = Mock()
+        resp.headers = {"Date": SERVER_DATE}
+        resp.json = Mock(return_value={})
+        with patch("time.time", return_value=LOCAL_EPOCH):
+            skland._sync_server_time(resp)
+        self.assertEqual(skland.server_time_offset, SERVER_EPOCH - LOCAL_EPOCH)
+
+    def test_sync_from_body_timestamp(self):
+        resp = Mock()
+        resp.headers = {}
+        resp.json = Mock(return_value={"timestamp": str(SERVER_EPOCH)})
+        with patch("time.time", return_value=LOCAL_EPOCH):
+            skland._sync_server_time(resp)
+        self.assertEqual(skland.server_time_offset, SERVER_EPOCH - LOCAL_EPOCH)
+
+    def test_sync_no_source_keeps_offset(self):
+        skland.server_time_offset = 7
+        resp = Mock()
+        resp.headers = {}
+        resp.json = Mock(return_value={})
+        skland._sync_server_time(resp)
+        self.assertEqual(skland.server_time_offset, 7)
+
+
+class TestGenerateSignatureTimestamp(unittest.TestCase):
+    def setUp(self):
+        skland.server_time_offset = 0
+
+    def test_timestamp_uses_server_offset(self):
+        skland.server_time_offset = 10
+        with (
+            patch("time.time", return_value=LOCAL_EPOCH),
+            patch.object(skland, "_ensure_device_id", return_value="B123"),
+        ):
+            _, header_ca = skland.generate_signature("tok", "/api/path", "a=1")
+        self.assertEqual(header_ca["timestamp"], str(LOCAL_EPOCH + 10 - 2))
+        # 签名输入携带真实平台/设备/版本字段，与请求头一致
+        self.assertEqual(header_ca["platform"], "1")
+        self.assertEqual(header_ca["vName"], "1.62.0")
+        self.assertEqual(header_ca["dId"], "B123")
+
+    def test_zero_offset_keeps_minus_two(self):
+        # 偏移为 0（本机时钟准）时保持原 -2 秒行为，零回归
+        with (
+            patch("time.time", return_value=1000000000),
+            patch.object(skland, "_ensure_device_id", return_value="B123"),
+        ):
+            _, header_ca = skland.generate_signature("tok", "/api/path", "")
+        self.assertEqual(header_ca["timestamp"], "999999998")
+
+
+class TestGetBindingList(unittest.TestCase):
+    def setUp(self):
+        skland.server_time_offset = 0
+        # get_sign_header 走 generate_signature，会调 _ensure_device_id，隔离设备指纹网络
+        self._did = patch.object(skland, "_ensure_device_id", return_value="B123")
+        self._did.start()
+
+    def tearDown(self):
+        self._did.stop()
+
+    def _resp(self, body):
+        fake = Mock()
+        fake.headers = {}
+        fake.json = Mock(return_value=body)
+        return fake
+
+    def test_error_without_data_returns_empty(self):
+        # 非 0 code 的错误响应没有 data 字段，原代码掉进 resp["data"]["list"] 崩 KeyError
+        fake = self._resp({"code": 1000, "message": "请勿修改设备本地时间"})
+        with patch("requests.get", return_value=fake):
+            self.assertEqual(skland.get_binding_list("tok"), [])
+
+    def test_not_logged_in_returns_empty(self):
+        fake = self._resp({"code": 1000, "message": "用户未登录"})
+        with patch("requests.get", return_value=fake):
+            self.assertEqual(skland.get_binding_list("tok"), [])
+
+    def test_success_returns_binding_list(self):
+        body = {
+            "code": 0,
+            "data": {
+                "list": [
+                    {
+                        "appCode": "arknights",
+                        "bindingList": [{"gameId": 1, "uid": "u1"}],
+                    },
+                    {
+                        "appCode": "endfield",
+                        "bindingList": [{"gameId": 3, "uid": "u3"}],
+                    },
+                    {"appCode": "other", "bindingList": [{"gameId": 9, "uid": "u9"}]},
+                ]
+            },
+        }
+        fake = self._resp(body)
+        with patch("requests.get", return_value=fake):
+            result = skland.get_binding_list("tok")
+        self.assertEqual(
+            result, [{"gameId": 1, "uid": "u1"}, {"gameId": 3, "uid": "u3"}]
+        )
+
+
+class TestLoginSyncsServerTime(unittest.TestCase):
+    def setUp(self):
+        skland.server_time_offset = 0
+
+    def test_login_calibrates_offset_and_wires_did(self):
+        fake = Mock()
+        fake.headers = {"Date": SERVER_DATE}
+        fake.json = Mock(return_value={"status": 0, "data": {"token": "abc"}})
+        account = Mock(account="13800000000", password="pw")
+        fake_did = "B" + "0" * 16
+        with (
+            patch("requests.post", return_value=fake),
+            patch("time.time", return_value=LOCAL_EPOCH),
+            patch.object(skland, "_ensure_device_id", return_value=fake_did),
+        ):
+            token = skland.log(account)
+        self.assertEqual(token, "abc")
+        self.assertEqual(skland.server_time_offset, SERVER_EPOCH - LOCAL_EPOCH)
+        self.assertEqual(skland.header_login["dId"], fake_did)
+
+
+class TestEnsureDeviceId(unittest.TestCase):
+    def setUp(self):
+        skland._device_id = ""
+        skland._device_id_failed = False
+
+    def test_degraded_to_empty_on_failure(self):
+        # 设备信息服务不可达 → 降级为空串，不抛异常；且失败一次后不再重试
+        with patch.object(
+            skland, "get_d_id", side_effect=Exception("fp-it down")
+        ) as get_d:
+            self.assertEqual(skland._ensure_device_id(), "")
+            self.assertEqual(get_d.call_count, 1)
+            # 再次触发：应为惰性短路，不再访问设备信息服务
+            self.assertEqual(skland._ensure_device_id(), "")
+            self.assertEqual(get_d.call_count, 1)
+
+    def test_returns_device_id(self):
+        with patch.object(skland, "get_d_id", return_value="B123"):
+            self.assertEqual(skland._ensure_device_id(), "B123")
+
+
+class TestSignHeaderFields(unittest.TestCase):
+    def setUp(self):
+        skland.server_time_offset = 0
+
+    def test_sign_header_carries_real_fields(self):
+        # 请求头带上的签名字段与签名输入一致（真实平台/设备/版本，而非空串）
+        with patch.object(skland, "_ensure_device_id", return_value="B123"):
+            h = skland.get_sign_header(skland.binding_url, "get", None, "tok")
+        self.assertEqual(h["platform"], "1")
+        self.assertEqual(h["vName"], "1.62.0")
+        self.assertEqual(h["dId"], "B123")
+        self.assertTrue(h["sign"])
+
+    def test_signature_reproducible_with_same_fields(self):
+        # dId 稳定时，同一路径与时间戳下签名可复现，字段自洽不引入随机性
+        with (
+            patch("time.time", return_value=LOCAL_EPOCH),
+            patch.object(skland, "_ensure_device_id", return_value="B123"),
+        ):
+            s1, _ = skland.generate_signature("tok", "/api/path", "a=1")
+        with (
+            patch("time.time", return_value=LOCAL_EPOCH),
+            patch.object(skland, "_ensure_device_id", return_value="B123"),
+        ):
+            s2, _ = skland.generate_signature("tok", "/api/path", "a=1")
+        self.assertEqual(s1, s2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/utils/skland.py
+++ b/arknights_mower/utils/skland.py
@@ -32,19 +32,88 @@ token_password_url = "https://as.hypergryph.com/user/auth/v1/token_by_phone_pass
 grant_code_url = "https://as.hypergryph.com/user/oauth2/v2/grant"
 # 使用认证代码获得cred
 cred_code_url = "https://zonai.skland.com/web/v1/user/auth/generate_cred_by_code"
+SKLAND_VERSION = "1.62.0"
+SKLAND_BUILD = "106200040"
+SKLAND_ANDROID = "36"
+# UA 由上面三值拼出，避免版本号/构建号/系统版本在多处重复、漏改漂移
+SKLAND_UA = (
+    f"Skland/{SKLAND_VERSION} (com.hypergryph.skland; build:{SKLAND_BUILD}; "
+    f"Android {SKLAND_ANDROID}; ) Okhttp/4.11.0"
+)
 header = {
     "cred": "",
-    "User-Agent": "Skland/1.53.0 (com.hypergryph.skland; build:105300018; Android 31; ) Okhttp/4.11.0",
+    "User-Agent": SKLAND_UA,
     "Accept-Encoding": "gzip",
     "Connection": "close",
 }
 header_login = {
-    "User-Agent": "Skland/1.53.0 (com.hypergryph.skland; build:105300018; Android 31; ) Okhttp/4.11.0",
+    "User-Agent": SKLAND_UA,
     "Accept-Encoding": "gzip",
     "Connection": "close",
-    "dId": get_d_id(),
+    "dId": "",
 }
-header_for_sign = {"platform": "", "timestamp": "", "dId": "", "vName": ""}
+# 签名携带的四个参数：platform 固定为 1（Android），vName 与 UA 版本号一致，
+# dId 在 generate_signature 中惰性填充（与登录请求共用 _ensure_device_id 缓存）。
+# 请求头发送的字段与签名输入保持自洽，避免服务器未来对字段做非空校验时被拒
+header_for_sign = {"platform": "1", "timestamp": "", "dId": "", "vName": SKLAND_VERSION}
+
+# 模块级状态：设备指纹与服务器时钟偏移，均由下列函数惰性维护。
+# 设备指纹导入时不联网（fp-it 服务不可达也不会导致导入崩溃），首次登录前取、失败降级为空串，
+# 且失败一次后本程序不再重试（_device_id_failed 短路），避免反复捶打不可达服务、重复刷警告；
+# 时钟偏移由 _sync_server_time 从每次响应校准，签名时间戳用它落在服务器时间上。
+_device_id = ""
+_device_id_failed = False
+server_time_offset = 0
+
+
+def _ensure_device_id() -> str:
+    """取森空岛设备指纹；设备信息服务不可达时降级为空串，不抛异常。
+
+    失败一次后本程序运行期间不再尝试取（_device_id_failed 短路），
+    避免每次生成签名都重打一次不可达的设备信息服务、重复刷警告。
+    """
+    global _device_id, _device_id_failed
+    if _device_id_failed:
+        return _device_id
+    if not _device_id:
+        try:
+            _device_id = get_d_id()
+        except Exception:
+            _device_id_failed = True
+            logger.warning("设备指纹获取失败（设备信息服务不可达），设备校验可能被拒")
+    return _device_id
+
+
+def _offset_from_server_epoch(server_epoch) -> int | None:
+    """服务器 epoch 与本机时间的偏移（秒）；epoch 非法时返回 None。"""
+    try:
+        return int(server_epoch) - int(time.time())
+    except (TypeError, ValueError):
+        return None
+
+
+def _sync_server_time(resp):
+    """从响应刷新服务器时间偏移：优先 HTTP Date 头，其次错误响应 body 的 timestamp 字段。"""
+    global server_time_offset
+    date = resp.headers.get("Date")
+    if date:
+        try:
+            srv = datetime.datetime.strptime(date, "%a, %d %b %Y %H:%M:%S GMT").replace(
+                tzinfo=datetime.timezone.utc
+            )
+            server_time_offset = _offset_from_server_epoch(srv.timestamp())
+            return
+        except ValueError:
+            pass
+    try:
+        body = resp.json()
+    except Exception:
+        return
+    ts = body.get("timestamp") if isinstance(body, dict) else None
+    if ts:
+        offset = _offset_from_server_epoch(ts)
+        if offset is not None:
+            server_time_offset = offset
 
 
 def generate_signature(token: str, path, body_or_query):
@@ -58,12 +127,16 @@ def generate_signature(token: str, path, body_or_query):
     :param body_or_query: 如果是GET，则是它的query。POST则为它的body
     :return: 计算完毕的sign
     """
-    # 总是说请勿修改设备时间，怕不是yj你的服务器有问题吧，所以这里特地-2
+    # 服务器对本机时钟偏差敏感：签名时间戳用服务器时间校准（_sync_server_time
+    # 算出的偏移），再减 2 秒落在过去窗口内，避免「请勿修改设备本地时间」
 
-    t = str(int(time.time()) - 2)
+    t = str(int(time.time()) + server_time_offset - 2)
     token = token.encode("utf-8")
     header_ca = json.loads(json.dumps(header_for_sign))
     header_ca["timestamp"] = t
+    if not header_ca["dId"]:
+        # dId 惰性取：与 header_login 共用 _device_id 缓存，保证登录与签名自洽
+        header_ca["dId"] = _ensure_device_id()
     header_ca_str = json.dumps(header_ca, separators=(",", ":"))
     s = path + body_or_query + t + header_ca_str
     hex_s = hmac.new(token, s.encode("utf-8"), hashlib.sha256).hexdigest()
@@ -126,14 +199,16 @@ def get_binding_list(sign_token):
             sign_token,
         ),
         timeout=30,
-    ).json()
+    )
+    _sync_server_time(resp)
+    body = resp.json()
 
-    if resp["code"] != 0:
-        logger.info(f"请求角色列表出现问题：{resp['message']}")
-        if resp.get("message") == "用户未登录":
+    if body["code"] != 0:
+        logger.info(f"请求角色列表出现问题：{body['message']}")
+        if body.get("message") == "用户未登录":
             logger.warning("用户登录可能失效了，请重新运行此程序！")
-            return []
-    for i in resp["data"]["list"]:
+        return []
+    for i in body["data"]["list"]:
         if i.get("appCode") not in ("arknights", "endfield"):
             continue
         v.extend(i.get("bindingList"))
@@ -145,12 +220,15 @@ def get_cred_by_token(token):
 
 
 def log(account):
-    r = requests.post(
+    header_login["dId"] = _ensure_device_id()
+    resp = requests.post(
         token_password_url,
         json={"phone": account.account, "password": account.password},
         headers=header_login,
         timeout=30,
-    ).json()
+    )
+    _sync_server_time(resp)
+    r = resp.json()
     if r.get("status") != 0:
         raise Exception(f"获得token失败：{r['msg']}")
     logger.info("森空岛登陆成功")


### PR DESCRIPTION
## 变更

森空岛签到（以及仓库扫描等调用）此前会失败或崩溃，原因集中在这几处：本机时钟若比服务器略快，签名时间戳会落在未来而被服务器拒绝（提示「请勿修改设备本地时间」）；绑定角色接口遇到非「用户未登录」的错误时，响应缺少 data 字段，程序掉进 KeyError；设备指纹在模块导入时就联网，指纹服务不可达会让启动直接崩溃；签名输入带着空的 platform/dId/vName，若服务器收紧校验也可能被拒。

本次改动针对这四类问题做了处理，让签到不再失败与崩溃：
- 签名时间戳改用服务器时间偏移（从响应的 Date 头或错误响应的 timestamp 校准），偏移为 0 时维持原本减 2 秒的行为，做到零回归
- 绑定角色接口对任意非 0 code 都返回空列表，不再因缺 data 字段崩溃
- 设备指纹改为惰性获取：导入时不联网，失败降级为空串，且失败一次后本程序不再重试
- UA 构建号与系统版本对齐到 1.62.0，签名输入补上真实的 platform=1、vName=1.62.0、dId，与请求头保持一致

## 限制

- 设备指纹服务长时间不可达时，签名会以空 dId 降级；这比之前导入即联网崩溃更安全，正常路径会拿到真实指纹

## 验证

- 13 个 skland 测试通过，全量 805 个测试通过，ruff 检查与格式检查通过
