### PR TITLE
fix(ui): 修复 WebView 启动失败时异常被静默吞掉无法记录

### DIFF
--- a/webview_ui.py
+++ b/webview_ui.py
@@ -285,6 +285,9 @@ def webview_window(child_conn, global_space, instance_name, host, port, url, tra
             save_window_size(size)
         sys.exit()
     except Exception:
+        from arknights_mower.utils.log import logger
+
+        logger.exception("WebView 窗口启动失败，回退为浏览器打开")
         import webbrowser
 
         webbrowser.open(url)


### PR DESCRIPTION
**变更**

`webview_ui.py` 中负责启动 WebView 的 `webview_window`：当 `webview.start()` 抛出异常时，原来的实现会直接打开浏览器作为降级，异常本身则被静默丢弃，用户无法得知真正的失败原因。此次改动先在异常分支里使用项目 logger 把完整堆栈写入 `runtime.log`，随后再降级为浏览器打开。

**限制**

- 改动仅在 WebView 启动失败时生效，正常的启动路径不受影响。
- 日志写入应用自身的日志目录：源码运行时为仓库根下的 `log/runtime.log`，打包产物为 `mower.exe` 所在目录下的 `log/runtime.log`。

**验证**

- `ruff check`、`ruff format --check` 与语法检查均通过。
- 以真实 `mp.Process` 子进程模拟失败后立即退出的场景（`os._exit` 加约 50ms 缓冲），连续测试 3 次，`logger.exception` 每次都能完整写入 `runtime.log` 并附带 Traceback。
