### PR TITLE
fix(schedule): 修复排班组纠错把已在岗成员计入纠错任务导致反复重排

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -91,6 +91,22 @@ def _is_mastery_busy(operator_name: str) -> bool:
         return False
 
 
+def _add_group_to_fix_plan(fix_plan: dict, op_data: Operators, group: str) -> None:
+    """把组内真正不在岗的成员写进 fix_plan；已在静态槽位的成员跳过。
+
+    已在岗成员写进去只是 no-op：arrange 逐房间对比后「任务与当前房间相同，
+    跳过」。当唯一真实修复项（如训练室）被 _suppress_train_correction 抑制时，
+    no-op 项撑起 fix_plan 永不收敛 → 排班死循环（#229）。
+    """
+    for name in op_data.groups[group]:
+        agent = op_data.operators[name]
+        if agent.room == agent.current_room and agent.index == agent.current_index:
+            continue
+        if agent.room not in fix_plan:
+            fix_plan[agent.room] = ["Current"] * len(op_data.plan[agent.room])
+        fix_plan[agent.room][agent.index] = name
+
+
 class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
     """
     收集基建的产物：物资、赤金、信赖
@@ -911,15 +927,8 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     logger.debug(f"跳过检查{_agent}")
                     continue
                 elif _agent.group != "":
-                    # 把所有小组成员都移到工作站
-                    agents = self.op_data.groups[_agent.group]
-                    for a in agents:
-                        __agent = self.op_data.operators[a]
-                        if __agent.room not in fix_plan.keys():
-                            fix_plan[__agent.room] = ["Current"] * len(
-                                self.op_data.plan[__agent.room]
-                            )
-                        fix_plan[__agent.room][__agent.index] = a
+                    # 把所有小组成员都移到工作站（已在岗成员跳过，避免 no-op 假任务）
+                    _add_group_to_fix_plan(fix_plan, self.op_data, _agent.group)
                 if _agent.room not in fix_plan.keys():
                     fix_plan[_agent.room] = ["Current"] * len(
                         self.op_data.plan[_agent.room]

--- a/arknights_mower/tests/base_scheduler_tests.py
+++ b/arknights_mower/tests/base_scheduler_tests.py
@@ -10,7 +10,10 @@ sys.modules.setdefault("arknights_mower.utils.skland", MagicMock())
 
 import arknights_mower.solvers.base_schedule as base_schedule  # noqa: E402
 from arknights_mower.solvers import mastery_reader  # noqa: E402
-from arknights_mower.solvers.base_schedule import BaseSchedulerSolver  # noqa: E402
+from arknights_mower.solvers.base_schedule import (  # noqa: E402
+    BaseSchedulerSolver,
+    _add_group_to_fix_plan,
+)
 from arknights_mower.utils.logic_expression import LogicExpression  # noqa: E402
 from arknights_mower.utils.operators import Operator  # noqa: E402
 from arknights_mower.utils.plan import Plan, PlanConfig, Room  # noqa: E402
@@ -1475,6 +1478,56 @@ class TestScanDispatchMastery(unittest.TestCase):
             solver._auto_schedule_mastery_after_scan()
         self.assertEqual(len(solver.tasks), 1)
         self.assertEqual(solver.tasks[0].type, TaskTypes.SKILL_UPGRADE)
+
+
+class TestGroupToFixPlan(unittest.TestCase):
+    """#229：组逻辑把已在岗成员塞进 fix_plan 是 no-op；叠加训练室纠错被抑制时
+    fix_plan 永不收敛 → 排班死循环。已在岗成员应跳过，只写真正缺位的。"""
+
+    @staticmethod
+    def _op(room, index, current_room=None, current_index=None):
+        o = MagicMock()
+        o.room = room
+        o.index = index
+        o.current_room = current_room if current_room is not None else room
+        o.current_index = current_index if current_index is not None else index
+        return o
+
+    def test_skips_members_already_in_static_slot(self):
+        # 自动化组：褐果/桃金娘 被专精拉走（current_room=''），森蚺已在岗
+        op_data = MagicMock()
+        op_data.groups = {"自动化": ["褐果", "桃金娘", "森蚺"]}
+        op_data.operators = {
+            "褐果": self._op("train", 0, current_room="", current_index=-1),
+            "桃金娘": self._op("train", 1, current_room="", current_index=-1),
+            "森蚺": self._op("central", 2),
+        }
+        op_data.plan = {
+            "train": [MagicMock(), MagicMock()],
+            "central": [MagicMock(), MagicMock(), MagicMock()],
+        }
+        fix_plan = {}
+        _add_group_to_fix_plan(fix_plan, op_data, "自动化")
+        # 森蚺已在岗 → 不写进 fix_plan；缺位的训练室成员写入
+        self.assertEqual(fix_plan, {"train": ["褐果", "桃金娘"]})
+
+    def test_adds_member_not_in_static_slot(self):
+        # 不在静态槽位（如在宿舍）的成员仍被拉回
+        op_data = MagicMock()
+        op_data.groups = {"自动化": ["褐果", "森蚺"]}
+        op_data.operators = {
+            "褐果": self._op("train", 0, current_room="dormitory_1", current_index=2),
+            "森蚺": self._op("central", 2),
+        }
+        op_data.plan = {
+            "train": [MagicMock()],
+            "central": [MagicMock(), MagicMock(), MagicMock()],
+        }
+        fix_plan = {}
+        _add_group_to_fix_plan(fix_plan, op_data, "自动化")
+        self.assertIn("train", fix_plan)
+        self.assertEqual(fix_plan["train"][0], "褐果")
+        self.assertNotIn("central", fix_plan)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 目标

排班的组纠错逻辑会把组内所有成员的原静态槽位无条件写进纠错任务。已经上班、位置没变的成员写进去是空操作，对结果没有影响；但当唯一真实需要纠错的项目（例如训练室）被专精管理抑制时，这些空操作条目撑起了 fix_plan，让它一直不收敛，排班反复重排，无法结束（实测循环了 27 轮）。

## 主要改动

把组逻辑抽成 `_add_group_to_fix_plan`，写入纠错任务前先判断成员是否已经停在静态槽位上（房间、位置与计划一致），已到岗的成员跳过，只写入真正缺位的成员。训练室被抑制之后，fix_plan 变成空列表，不再生成纠错。真正缺位或错位的成员仍会被拉回；同组同岗的一致性由既有的「同时上班检查」负责，行为不变。

## 验证与风险

- `base_scheduler_tests` 通过（45 项），`ruff` 检查与格式检查通过。
- 改动只影响纠错任务的生成，不改变排班的匹配与移动判定。
