### PR TITLE
fix(recognition): 修复场景图导航缓存不刷新导致空转刷日志的问题

### DIFF
--- a/arknights_mower/utils/graph.py
+++ b/arknights_mower/utils/graph.py
@@ -471,6 +471,9 @@ class SceneGraphSolver(BaseSolver):
                 else:
                     self.restart_game()
                 error_count = 0
+            # 每圈强制清场景缓存：转移静默失败（如 tap_element 找不到元素直接返回
+            # False）时缓存不失效，get_scene 一直返回陈旧场景导致死循环刷日志
+            self.recog.update()
 
     def back_to_index(self):
         logger.info("场景图导航：back_to_index")


### PR DESCRIPTION
## 目标

场景识别的缓存只在成功执行转移（点击或返回触发等待后再刷新）之后失效。转移静默失败时，例如 `index_nav` 在陈旧截图帧上找不到导航按钮直接返回 False，缓存不再失效，`get_scene` 每一圈都会返回同一个缓存场景。导航的 while 循环没有迭代上限，以每秒数千次的速度空转，并不断刷调试日志，日志文件可以达到上百 MB。

## 主要改动

在导航循环每一圈末尾调用 `recog.update()`，强制清除场景缓存，让下一圈 `get_scene` 重新截图识别，循环在一两圈之内恢复。空转期间 `stop_mower` 的检查也能及时执行。正常路径下，转移本身已经通过等待清除了缓存，这个改动只是重复清除一个已经清空的缓存，不改变截图频率与识别行为。

## 验证与风险

- `graph` 模块导入与编译通过，`ruff` 检查通过。
- 改动只在导航循环内增加一次刷新调用，不影响正常路径的判断与截图频率。
