### PR TITLE
fix(schedule): 修复低优替班轮休时重复占用床位导致大组无法下班的问题

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -232,11 +232,9 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             ]
         logger.debug(f"更新下班小组信息为{candidates}")
         # 在candidate 中，计算出需要的high free 和 Low free 数量
-        current_resting = (
-            len(self.op_data.dorm)
-            - self.op_data.available_free()
-            - self.op_data.available_free("low")
-        )
+        # 只计算无法直接接管的主力床位。低优、替班和临时休息干员会让床，
+        # 不能在这里阻止整个大组尝试下班。
+        current_resting = self.op_data.active_high_resting_count()
         plan = {}
         self.get_resting_plan(candidates, [], plan, current_resting)
         if len(plan.items()) > 0:
@@ -1587,8 +1585,9 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         # 根据剩余心情排序
         self.total_agent = list(
             v
-            for k, v in self.op_data.operators.items()
-            if v.is_high() and not v.room.startswith("dorm")
+            for v in self.op_data.operators.values()
+            if (v.is_high() or (v.current_room == "" and v.room == ""))
+            and not v.room.startswith("dorm")
         )
         self.total_agent.sort(key=lambda x: x.current_mood(), reverse=False)
         # 目前有换班的计划后面改
@@ -1627,14 +1626,16 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
 
     def resting(self):
         self.total_agent.sort(
-            key=lambda x: x.current_mood() - x.lower_limit, reverse=False
+            key=lambda x: (
+                self._resting_tier(x),
+                x.current_mood() - x.lower_limit,
+            ),
+            reverse=False,
         )
         self.plan_metadata()
-        current_resting = (
-            len(self.op_data.dorm)
-            - self.op_data.available_free()
-            - self.op_data.available_free("low")
-        )
+        # 理想休息人数只描述主力轮休；低优占床另由 available_free("low")
+        # 管理，不能抬高这里的当前人数或挡住可接管床位上的大组。
+        current_resting = self.op_data.active_high_resting_count()
         # 阈值暂定为 0.5
         self.ideal_resting_count = (
             4
@@ -1657,11 +1658,19 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             has_active_mastery = False
         _replacement = []
         _plan = {}
+        _high_done = False
+        _low_used = set()
         for op in self.total_agent:
-            if (
-                current_resting + len(_replacement) >= self.ideal_resting_count
-                and self.op_data.available_free() == 0
-            ):
+            if op.is_high():
+                if _high_done:
+                    continue
+                if (
+                    current_resting + len(_replacement) >= self.ideal_resting_count
+                    and self.op_data.available_free() == 0
+                ):
+                    _high_done = True
+                    continue
+            elif self.op_data.available_free("low") == 0:
                 break
             if op.name in self.op_data.workaholic_agent:
                 continue
@@ -1686,6 +1695,11 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 + op.lower_limit
             ):
                 continue
+            if not op.is_high():
+                _dorm = self.op_data.assign_dorm(op.name, True, used=_low_used)
+                if _dorm is not None:
+                    logger.debug(f"安排低优{op.name}休息 -> {_dorm.position}")
+                continue
             if op.group != "":
                 if op.group in self.op_data.exhaust_group:
                     # 忽略掉用尽心情的分组
@@ -1702,6 +1716,18 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             )
             logger.info(f"生成{_plan}的下班任务")
         return _plan
+
+    _REST_TIER_HIGH = 0
+    _REST_TIER_MARKED_LOW = 1
+    _REST_TIER_REPLACEMENT = 2
+
+    @staticmethod
+    def _resting_tier(op):
+        if op.is_high() and op.resting_priority == "high":
+            return BaseSchedulerSolver._REST_TIER_HIGH
+        if op.is_high():
+            return BaseSchedulerSolver._REST_TIER_MARKED_LOW
+        return BaseSchedulerSolver._REST_TIER_REPLACEMENT
 
     def backup_plan_solver(self, timing=None, append_empty_task=True):
         if timing is None:
@@ -1789,8 +1815,6 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         logger.debug(f"需求:{required}宿舍空位")
         logger.debug(f"需求:{exist_replacement} 当前安排")
         logger.debug(f"当前计划{plan}")
-        if current_resting + required + len(exist_replacement) > len(self.op_data.dorm):
-            return
         success = True
 
         fia_plan, fia_room = self.check_fia()
@@ -1841,15 +1865,17 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             else:
                 success = False
         if success:
-            # 记录替换组
+            resting_agents = [
+                x for x in agents if not self.op_data.operators[x].workaholic
+            ]
+            # 床位判断和分配使用同一套规则。先为整组模拟预留，避免低优占床
+            # 提前挡住大组，也避免分到一半才失败留下脏状态。
+            dorms = self.op_data.assign_dorm_group(resting_agents)
+            if dorms is None:
+                return
             logger.debug(f"当前替换{__replacement}")
             exist_replacement.extend(__replacement)
-            for idx, x in enumerate(agents):
-                # 0心情不需要宿舍位
-                if self.op_data.operators[x].workaholic:
-                    continue
-                _dorm = self.op_data.assign_dorm(x, True)
-            logger.debug(_dorm)
+            logger.debug(dorms)
             for k, v in __plan.items():
                 if k not in plan.keys():
                     plan[k] = __plan[k]

--- a/arknights_mower/tests/base_scheduler_tests.py
+++ b/arknights_mower/tests/base_scheduler_tests.py
@@ -436,6 +436,172 @@ class TestBaseScheduler(unittest.TestCase):
 
         return read_room
 
+    def _build_resting_solver(self):
+        plan_config = {
+            # 会客室真实容量为 2，办公室为 1。大组 = 会客室 2 名主力 + 办公室 1 名主力。
+            "meeting": [Room("伊内丝", "大组", ["陈"]), Room("银灰", "大组", ["初雪"])],
+            "contact": [Room("讯使", "大组", ["红"])],
+            "dormitory_1": [
+                Room("塑心", "", []),
+                Room("冰酿", "", []),
+                Room("Free", "", []),
+                Room("Free", "", []),
+                Room("Free", "", []),
+            ],
+        }
+        plan = {
+            "default_plan": Plan(plan_config, PlanConfig("", "", "")),
+            "backup_plans": [],
+        }
+        solver = BaseSchedulerSolver()
+        solver.global_plan = plan
+        solver.initialize_operators()
+        solver.tasks = []
+        return solver
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
+    def test_low_resting_occupants_do_not_block_takable_group_beds(self):
+        """低优占床消耗低优配额，但可被接管的床不能挡住主力大组下班。"""
+        solver = self._build_resting_solver()
+        for name, index in [("泥岩", 3), ("能天使", 4)]:
+            solver.op_data.add(Operator(name, ""))
+            op = solver.op_data.operators[name]
+            op.current_room = "dormitory_1"
+            op.current_index = index
+            dorm = next(
+                d for d in solver.op_data.dorm if d.position == ("dormitory_1", index)
+            )
+            dorm.name = name
+
+        current_resting = (
+            len(solver.op_data.dorm)
+            - solver.op_data.available_free()
+            - solver.op_data.available_free("low")
+        )
+        self.assertEqual(2, current_resting)
+        self.assertEqual(0, solver.op_data.available_free("low"))
+
+        plan = {}
+        solver.get_resting_plan(
+            solver.op_data.groups["大组"], [], plan, current_resting
+        )
+
+        self.assertEqual(["陈", "初雪"], plan["meeting"])
+        self.assertEqual(["红"], plan["contact"])
+        resting_names = {d.name for d in solver.op_data.dorm}
+        self.assertIn("伊内丝", resting_names)
+        self.assertIn("银灰", resting_names)
+        self.assertIn("讯使", resting_names)
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
+    def test_resting_assigns_idle_low_replacement_to_dorm(self):
+        solver = self._build_resting_solver()
+        op = solver.op_data.operators["陈"]
+        op.mood = 5
+        op.current_room = ""
+        op.room = ""
+        solver.total_agent = [op]
+        with (
+            patch.object(base_schedule.config.conf, "enable_mastery", False),
+            patch.object(BaseSchedulerSolver, "plan_metadata", lambda self: None),
+        ):
+            solver.resting()
+        self.assertIn("陈", [d.name for d in solver.op_data.dorm])
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
+    def test_resting_low_replacements_get_distinct_slots(self):
+        solver = self._build_resting_solver()
+        for name in ["陈", "红"]:
+            op = solver.op_data.operators[name]
+            op.mood = 5
+            op.current_room = ""
+            op.room = ""
+        solver.total_agent = [solver.op_data.operators[n] for n in ["陈", "红"]]
+        with (
+            patch.object(base_schedule.config.conf, "enable_mastery", False),
+            patch.object(BaseSchedulerSolver, "plan_metadata", lambda self: None),
+        ):
+            solver.resting()
+        dorm_names = [d.name for d in solver.op_data.dorm]
+        self.assertEqual(1, dorm_names.count("陈"))
+        self.assertEqual(1, dorm_names.count("红"))
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
+    def test_resting_does_not_evict_resting_low_replacement(self):
+        """生产日志中的低优互踢活锁：新低优不能覆盖正在休息的低优。"""
+        solver = self._build_resting_solver()
+        chen = solver.op_data.operators["陈"]
+        chen.mood = 5
+        chen.current_room = "dormitory_1"
+        chen.current_index = 3
+        occupied = next(
+            d for d in solver.op_data.dorm if d.position == ("dormitory_1", 3)
+        )
+        occupied.name = "陈"
+
+        hong = solver.op_data.operators["红"]
+        hong.mood = 5
+        hong.current_room = ""
+        hong.room = ""
+        solver.total_agent = [hong]
+        with (
+            patch.object(base_schedule.config.conf, "enable_mastery", False),
+            patch.object(BaseSchedulerSolver, "plan_metadata", lambda self: None),
+        ):
+            solver.resting()
+
+        dorm = {d.position: d.name for d in solver.op_data.dorm}
+        self.assertEqual("陈", dorm[("dormitory_1", 3)])
+        self.assertIn("红", dorm.values())
+        self.assertNotEqual(
+            ("dormitory_1", 3),
+            next(d.position for d in solver.op_data.dorm if d.name == "红"),
+        )
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
+    def test_assign_dorm_returns_none_when_low_beds_are_occupied(self):
+        solver = self._build_resting_solver()
+        for name, index in [("陈", 3), ("红", 4)]:
+            op = solver.op_data.operators[name]
+            op.current_room = "dormitory_1"
+            op.current_index = index
+            next(
+                d for d in solver.op_data.dorm if d.position == ("dormitory_1", index)
+            ).name = name
+        high = solver.op_data.operators["伊内丝"]
+        high.current_room = "dormitory_1"
+        high.current_index = 2
+        next(
+            d for d in solver.op_data.dorm if d.position == ("dormitory_1", 2)
+        ).name = "伊内丝"
+
+        self.assertIsNone(solver.op_data.assign_dorm("红", True))
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
+    def test_group_dorm_assignment_rolls_back_when_capacity_is_insufficient(self):
+        solver = self._build_resting_solver()
+        for name, index in [("泥岩", 3), ("能天使", 4)]:
+            solver.op_data.add(Operator(name, ""))
+            op = solver.op_data.operators[name]
+            op.current_room = "dormitory_1"
+            op.current_index = index
+            next(
+                d for d in solver.op_data.dorm if d.position == ("dormitory_1", index)
+            ).name = name
+        high = solver.op_data.operators["伊内丝"]
+        high.current_room = "dormitory_1"
+        high.current_index = 2
+        next(
+            d for d in solver.op_data.dorm if d.position == ("dormitory_1", 2)
+        ).name = "伊内丝"
+        before = [(d.name, d.time) for d in solver.op_data.dorm]
+
+        plan = {}
+        solver.get_resting_plan(solver.op_data.groups["大组"], [], plan, 3)
+
+        self.assertEqual({}, plan)
+        self.assertEqual(before, [(d.name, d.time) for d in solver.op_data.dorm])
+
     @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
     def test_get_agent_from_room_uses_train_slots_without_train_plan(self):
         solver = self._create_no_train_plan_solver()

--- a/arknights_mower/utils/operators.py
+++ b/arknights_mower/utils/operators.py
@@ -685,22 +685,20 @@ class Operators:
         count_low = 0
         free_name = []
 
-        # 一次性遍历 dorm
-        for idx, dorm in enumerate(self.dorm):
-            if dorm.name == "" or (
-                dorm.name in self.operators.keys()
-                and not self.operators[dorm.name].is_high()
-            ):
+        # 一次性遍历 dorm。低优占位也必须消耗 low 配额，否则调度器会持续把
+        # 已占用床位误判为空位；但它仍可被高优主力接管，不能据此阻止大组下班。
+        for dorm in self.dorm:
+            if dorm.name == "" or dorm.name not in self.operators:
                 continue
-            elif dorm.time is not None and dorm.time < time:
-                free_name.append(dorm.name)
+            op = self.operators[dorm.name]
+            if dorm.time is not None and dorm.time < time:
+                if op.is_high():
+                    free_name.append(dorm.name)
                 continue
-            if dorm.name in self.operators:
-                op = self.operators[dorm.name]
-                if op.resting_priority == "high":
-                    count_high += 1
-                else:
-                    count_low += 1
+            if op.resting_priority == "high":
+                count_high += 1
+            else:
+                count_low += 1
         available_high = max(0, dorm_count - count_high)
         available_low = total - count_low - max(count_high, dorm_count)
 
@@ -713,33 +711,84 @@ class Operators:
                     self.operators[name].time_stamp = time
         return available_high if free_type == "high" else available_low
 
-    def assign_dorm(self, name, is_new=False):
+    def active_high_resting_count(self, time=None):
+        """当前不能被其他主力直接接管的主力床位数。"""
+        if time is None:
+            time = datetime.now()
+        return sum(
+            1
+            for dorm in self.dorm
+            if dorm.name in self.operators
+            and self.operators[dorm.name].is_high()
+            and not (dorm.time is not None and dorm.time < time)
+        )
+
+    def _slot_takable(self, dorm, protect_resting):
+        """床位能否被接管；低优之间保护正在休息者，高优可接管低优床位。"""
+        name = dorm.name
+        if name == "" or name not in self.operators:
+            return True
+        op = self.operators[name]
+        if dorm.time is not None and dorm.time < datetime.now():
+            return True
+        if not op.is_high():
+            return not (protect_resting and op.is_resting())
+        return False
+
+    def _find_dorm_slot(self, name, used):
         is_high = self.operators[name].resting_priority == "high"
-        _room = None
         max_count = sum(1 for key in self.plan if key.startswith("dorm"))
         if not is_high:
             for i in range(max_count, len(self.dorm)):
-                _name = self.dorm[i].name
-                if (
-                    _name == ""
-                    or not self.operators[_name].is_high()
-                    or (
-                        self.dorm[i].time is not None
-                        and self.dorm[i].time < datetime.now()
-                    )
+                if i not in used and self._slot_takable(
+                    self.dorm[i], protect_resting=True
                 ):
-                    _room = self.dorm[i]
-                    break
-        if is_high or _room is None:
-            if not is_high:
-                logger.warning("弹性模式下请勿设置过多低优先")
-            _room = next(
-                obj
-                for obj in self.dorm
-                if obj.name not in self.operators.keys()
-                or not self.operators[obj.name].is_high()
-                or (obj.time is not None and obj.time < datetime.now())
-            )
+                    return i
+        return next(
+            (
+                i
+                for i, dorm in enumerate(self.dorm)
+                if i not in used
+                and self._slot_takable(dorm, protect_resting=not is_high)
+            ),
+            None,
+        )
+
+    def assign_dorm_group(self, names):
+        """先为整组模拟预留互不重复的床位；全部成功后才一次性写入。"""
+        used = set()
+        assignments = []
+        # 低优可选床位更受限，先为低优预留；高优随后可使用剩余空位或接管低优。
+        ordered_names = sorted(
+            names,
+            key=lambda name: self.operators[name].resting_priority == "high",
+        )
+        for name in ordered_names:
+            index = self._find_dorm_slot(name, used)
+            if index is None:
+                logger.debug(f"没有足够宿舍位可安排整组{names}")
+                return None
+            used.add(index)
+            assignments.append((name, index))
+
+        rooms = []
+        for name, index in assignments:
+            room = self.dorm[index]
+            logger.debug(f"安排{name}去{room.position}")
+            room.name = name
+            room.time = None
+            rooms.append(room)
+        return rooms
+
+    def assign_dorm(self, name, is_new=False, used=None):
+        if used is None:
+            used = set()
+        index = self._find_dorm_slot(name, used)
+        if index is None:
+            logger.debug(f"没有空闲宿舍位可安排{name}")
+            return None
+        used.add(index)
+        _room = self.dorm[index]
         logger.debug(f"安排{name}去{_room.position}")
         _room.name = name
         _room.time = None


### PR DESCRIPTION
## 目标

低优替班的干员和临时休息的干员会继续计入低优床位配额，但大组容量只统计不能被接管的主力床位。这样低优占用的床位不会挡住整个大组尝试下班，也避免低优干员彼此覆盖、重复占用床位。

## 主要改动

- 扩大轮休候选到空闲的低优干员，并阻止低优干员覆盖正在休息的低优占位。
- 整组分床改为先完整预留再写入，床位不足时不再保留部分分配。
- 高优主力可以接管低优床位，避免低优占用导致整个大组跳过轮休。

## 验证与风险

- `base_scheduler_tests` 通过（49 项）、`operator_room_tests` 通过（3 项），`ruff` 检查与格式检查通过。
- 改动集中在床位分配与 `operators.py` 的 dorm 分配，未触碰识别与界面逻辑。
