### PR TITLE
fix(mastery): 修复训练位已是计划干员时保护逻辑仍阻止开始训练

### DIFF
--- a/arknights_mower/solvers/mastery_reader.py
+++ b/arknights_mower/solvers/mastery_reader.py
@@ -1398,6 +1398,14 @@ def _reconcile(
             )
             update_plan_status(active["id"], "idle")
         if room.protected:
+            # §16.5 保护挡「移动协助位/训练位」。训练位已是计划干员时，开始训练
+            # 不动训练位（只按路线补协助位），保护不适用 → 放行 mower 开始。
+            if (
+                scan_plan is not None
+                and scan_plan["status"] == "idle"
+                and _plan_operator_matches(scan_plan, room.train_slot)
+            ):
+                return scan_plan, True
             idle = _next_idle_to_start(solver)
             if idle is not None:
                 # §16.5 保护挡住 mower 自己开始训练 → 通知⑤ + 保持 idle。

--- a/arknights_mower/tests/mastery_reader_tests.py
+++ b/arknights_mower/tests/mastery_reader_tests.py
@@ -1552,7 +1552,8 @@ class TestReconcileMatrix(unittest.TestCase):
         self.assertIsNone(start, "计划已不在 idle 不得开始")
 
     def test_empty_room_scan_driven_protected_skips(self):
-        # 受保护优先：扫描任务指定的计划在受保护空房也不开始（⑤ 通知）
+        # 受保护优先：训练位不是计划干员时，扫描任务指定的计划在受保护空房也不开始
+        # （⑤ 通知）；训练位=计划干员时放行（见 TestReconcileProtectedRelease）
         solver = MagicMock()
         solver.tasks = []
         room = make_room("empty", support_slot="逻各斯", train_slot="能天使")
@@ -2682,6 +2683,64 @@ class TestRefreshTrainingHalfOverlap(unittest.TestCase):
         ):
             reader._refresh_training_plan(solver, plan, self._room())
         sc.assert_not_called()
+
+
+class TestReconcileProtectedRelease(unittest.TestCase):
+    """§16.5 保护：训练位已是计划干员时放行 mower 开始训练。
+
+    保护挡「移动协助位/训练位」；训练位 = 计划干员时开始训练不动训练位
+    （只按路线补协助位）→ 保护不适用，放行 scan_plan；训练位空/坐别人
+    或 scan_plan 非 idle 时保留保护。
+    """
+
+    def _call(self, room, scan_plan):
+        solver = MagicMock()
+        with (
+            patch.object(reader, "_next_idle_to_start", return_value=None) as ni,
+            patch.object(reader, "_notify_protected") as np,
+        ):
+            result = reader._reconcile(solver, room, None, [], scan_plan=scan_plan)
+        return result, ni, np
+
+    def test_release_when_train_slot_is_plan_operator(self):
+        room = make_room(state="empty", train_slot="Miss.Christine")
+        room.protected = True
+        plan = make_plan(char_id="char_4198_christ", char_name="Miss.Christine")
+        (result, _, np) = self._call(room, plan)
+        self.assertIs(result[0], plan)
+        self.assertTrue(result[1])
+        np.assert_not_called()
+
+    def test_keep_protected_when_train_slot_not_plan_operator(self):
+        room = make_room(state="empty", train_slot="焰狐龙梓兰")
+        room.protected = True
+        plan = make_plan(char_id="char_4198_christ", char_name="Miss.Christine")
+        (result, ni, _) = self._call(room, plan)
+        self.assertIsNone(result[0])
+        ni.assert_called_once()
+
+    def test_keep_protected_when_train_slot_empty(self):
+        # 空训练位读不出计划干员匹配，不放行（防御性：实际 protected 时空位不会到）
+        room = make_room(state="empty", train_slot="")
+        room.protected = True
+        plan = make_plan(char_id="char_4198_christ", char_name="Miss.Christine")
+        (result, _, _) = self._call(room, plan)
+        self.assertIsNone(result[0])
+
+    def test_keep_protected_when_scan_plan_none(self):
+        room = make_room(state="empty", train_slot="Miss.Christine")
+        room.protected = True
+        (result, _, _) = self._call(room, None)
+        self.assertIsNone(result[0])
+
+    def test_keep_protected_when_scan_plan_not_idle(self):
+        room = make_room(state="empty", train_slot="Miss.Christine")
+        room.protected = True
+        plan = make_plan(
+            char_id="char_4198_christ", char_name="Miss.Christine", status="training"
+        )
+        (result, _, _) = self._call(room, plan)
+        self.assertIsNone(result[0])
 
 
 if __name__ == "__main__":

--- a/doc/mastery-constraints.md
+++ b/doc/mastery-constraints.md
@@ -458,7 +458,7 @@ python -m ruff check arknights_mower/solvers/ arknights_mower/utils/ arknights_m
 - 未开跟随排班 + 不匹配（其他情况）→ 不动房间 + 通知① blocked 一次（按倒计时结束时刻去重，PRD #64 保留；通知≠动房间）→ **排一条未来重检**（倒计时结束 + 2min，`_upsert_skill_upgrade_task` 按 plan_key 去重恒 ≤1 条）。重检到点再进房，若占用已结束走待收取动作（16.3）。（#66/B1：原「下次排班再看」若无排班事件会一直不重检 → 每 ~4s 进出训练室死循环；排未来重检让队列不空。keepalive 已删，#74 第3段。）
 
 **空闲（倒计时空 / 读失败）**
-- **开始训练由带 plan_key 的 SKILL_UPGRADE dispatch**（#74 第3段「都去掉」）：`_reconcile` 空闲×未保护格在 `scan_plan`（任务 plan_key 指定计划）非 None 且仍 idle 时返回该计划开始；`plan_key=None`（占用重检）与排班顺路（`reconcile_short`）在空闲格不开始。
+- **开始训练由带 plan_key 的 SKILL_UPGRADE dispatch**（#74 第3段「都去掉」）：`_reconcile` 空闲格在 `scan_plan`（任务 plan_key 指定计划）非 None 且仍 idle 时返回该计划开始（受保护格需训练位=计划干员，见 §16.5 例外）；`plan_key=None`（占用重检）与排班顺路（`reconcile_short`）在空闲格不开始。
 - 协助位不是逻各斯/艾丽妮 → 可排班。
 - 协助位是逻各斯/艾丽妮 + 训练位有人 → 进技能选择页读该干员**所有**技能：**有专一/专二 → 不能动**（保护）；全专三或专0 → 可动。
 - 协助位是逻各斯/艾丽妮 + 训练位没人 → 可排班。
@@ -468,6 +468,7 @@ python -m ruff check arknights_mower/solvers/ arknights_mower/utils/ arknights_m
 - **定义**：训练室的训练位/协助位保持现状不被排班系统改动。
 - **解除时机**：每次排班进训练室重新读房重判，条件一变自动解除（开始训练 / 协助位换人 / 训练位空了）。
 - **挡住谁**：既挡排班系统动房间，也挡 mower 自己开始训练——mower 想开始训练但房间受保护时**发邮件提醒用户**（新通知⑤），计划保持 idle。
+- **例外（2026-08-31 方案 A）**：受保护空闲格若**训练位已是计划干员**（`scan_plan` 非 None 且 idle，`room.train_slot` 匹配计划干员 char_name/char_id），开始训练不动训练位（只按路线补协助位），保护不适用 → 放行 mower 开始。训练位空/坐别人，或 `scan_plan` None/非 idle 时仍按上条保护。
 - 已知风险：待收取+非专三+协助位逻各斯/艾丽妮+干员技能都不在计划时，若无新训练开始，房间会长期受保护（现读现判下条件不变则持续），见 §14。
 
 ### 16.6 恢复流程（待收取 + 干员+技能都在计划内 + 非专三）


### PR DESCRIPTION
## 目标

训练室协助位为逻各斯或艾丽妮时，房间受到保护。此前空闲分支在保护下会无条件拒绝开始训练。当训练位已经是计划干员时，开始训练只是按路线补充协助位，不会移动训练位，保护的核心对象不受影响；但此时仍被拒绝，会让计划卡在 idle，每次仓库扫描都重复调度。

## 主要改动

训练位已经是计划干员时放行开始训练；训练位为空或坐着别人、以及 `scan_plan` 缺失或不是 idle 时，保留保护。同步更新 `doc/mastery-constraints.md` 的第 16.4 与 16.5 节，记录这一例外。

## 验证与风险

- 新增 `TestReconcileProtectedRelease` 覆盖放行与保留的各分支，`mastery_reader_tests` 通过（195 项），`ruff` 检查通过。
- 改动只影响「训练位=计划干员」这一条件下的受保护房间开始训练判定，其他保护分支不变。
