### PR TITLE
fix(update): Windows Maa 改为提示手动更新

### DIFF
--- a/arknights_mower/tests/maa_update_tests.py
+++ b/arknights_mower/tests/maa_update_tests.py
@@ -825,7 +825,7 @@ class TestInstallAndBackup(unittest.TestCase):
                 "get_latest_release",
                 side_effect=AssertionError("已安装 Maa 时不应请求下载信息"),
             ),
-            self.assertRaisesRegex(mu.MaaUpdateError, "Maa 自带更新程序"),
+            self.assertRaisesRegex(mu.MaaUpdateError, "手动打开 Maa 进行更新"),
         ):
             mu.install_latest_maa(
                 self.target,
@@ -862,30 +862,7 @@ class TestInstallAndBackup(unittest.TestCase):
         self.assertEqual((self.backup / "older.txt").read_text(), "older")
 
 
-class TestBuiltinUpdater(unittest.TestCase):
-    def test_windows_updater_is_started_without_install_replacement(self):
-        with tempfile.TemporaryDirectory() as temp:
-            root = Path(temp)
-            launcher = root / "MAA.Updater.exe"
-            launcher.write_bytes(b"fixture")
-            (root / "MAA.exe").write_bytes(b"main")
-            with patch.object(mu.subprocess, "Popen") as popen:
-                found = mu.launch_builtin_maa_update(root, "windows")
-            self.assertEqual(found, launcher)
-            popen.assert_called_once_with(
-                [str(launcher)],
-                cwd=str(root),
-                close_fds=True,
-                creationflags=0x00000200 | 0x00000008,
-            )
-
-    def test_linux_has_no_builtin_update_launcher(self):
-        with tempfile.TemporaryDirectory() as temp:
-            root = Path(temp)
-            (root / "maa").write_text("#!/bin/sh\n", encoding="utf-8")
-            with self.assertRaises(mu.MaaUpdateError):
-                mu.find_builtin_maa_launcher(root, "linux")
-
+class TestLoadedMaaCache(unittest.TestCase):
     def test_loaded_maa_cache_is_released(self):
         target = Path("/tmp/test-maa-cache")
         python_path = str(target / "Python")

--- a/arknights_mower/utils/maa_update.py
+++ b/arknights_mower/utils/maa_update.py
@@ -3,7 +3,7 @@
 运行库使用官方 macOS runtime 包；Python API 则通过 HTTP Range 读取 Windows
 arm64 ZIP 的中央目录，只提取其中的 ``Python`` 目录，避免下载完整 Windows 包。
 Linux 按当前架构下载单个官方 ``tar.gz`` 完整包。
-Windows 未安装 Maa 时按当前架构下载完整包，已有安装则交由 Maa 自带更新程序处理。
+Windows 未安装 Maa 时按当前架构下载完整包，已有安装则提示用户打开 Maa 手动更新。
 """
 
 from __future__ import annotations
@@ -1360,45 +1360,6 @@ def clear_loaded_maa_cache(target: Path | str) -> None:
     gc.collect()
 
 
-def find_builtin_maa_launcher(target: Path | str, system: str) -> Path:
-    """查找 Windows 的 MAA 自带更新程序。"""
-    system = system.lower()
-    target_path = Path(target).expanduser()
-    if target_path.is_file():
-        if system == "windows" and target_path.name.lower() == "maa.updater.exe":
-            return target_path
-        raise MaaUpdateError("请选择包含 MAA.Updater.exe 的 Maa 目录")
-    if not target_path.is_dir():
-        raise MaaUpdateError("Maa 目录不存在")
-
-    if system == "windows":
-        candidates = [target_path / "MAA.Updater.exe"]
-    else:
-        raise MaaUpdateError("MAA 自带更新入口仅用于 Windows")
-
-    for candidate in candidates:
-        if candidate.is_file():
-            return candidate
-    raise MaaUpdateError("Maa 目录中没有找到 MAA.Updater.exe")
-
-
-def launch_builtin_maa_update(target: Path | str, system: str) -> Path:
-    """启动 Windows ``MAA.Updater.exe``，不改写安装目录。"""
-    launcher = find_builtin_maa_launcher(target, system)
-    kwargs: dict[str, Any] = {
-        "cwd": str(launcher.parent),
-        "close_fds": True,
-    }
-    kwargs["creationflags"] = getattr(
-        subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200
-    ) | getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
-    try:
-        subprocess.Popen([str(launcher)], **kwargs)
-    except OSError as e:
-        raise MaaUpdateError(f"启动 MAA.Updater.exe 失败：{e}") from e
-    return launcher
-
-
 def install_latest_maa(
     target: Path | str,
     callback: ProgressCallback | None = None,
@@ -1429,7 +1390,7 @@ def install_latest_maa(
     elif system == "windows":
         arch = normalize_windows_arch(machine)
         if installed_before:
-            raise MaaUpdateError("已检测到 Windows Maa，请使用 Maa 自带更新程序")
+            raise MaaUpdateError("已检测到 Windows Maa，请手动打开 Maa 进行更新")
     else:
         arch = ""
     if source not in {"github", "mirrorchyan"}:

--- a/server.py
+++ b/server.py
@@ -916,7 +916,7 @@ def start_maa_update():
     if __system__ == "windows" and installed:
         return {
             "ok": False,
-            "message": "已检测到 Windows Maa，请使用 Maa 自带更新程序",
+            "message": "已检测到 Windows Maa，请手动打开 Maa 进行更新",
         }
     if source not in {"github", "mirrorchyan"}:
         return {"ok": False, "message": f"未知的 MAA {operation}源"}
@@ -1008,55 +1008,6 @@ def get_maa_mirrorchyan_status():
 @require_token
 def get_maa_update_status():
     return {"ok": True, "job": _maa_update_snapshot()}
-
-
-@app.route("/maa-update/builtin", methods=["POST"])
-@require_token
-def start_builtin_maa_update():
-    from arknights_mower.utils.maa_update import (
-        MaaUpdateError,
-        clear_loaded_maa_cache,
-        launch_builtin_maa_update,
-        normalize_update_channel,
-    )
-
-    if __system__ != "windows":
-        return {"ok": False, "message": "MAA 自带更新程序仅用于 Windows"}
-    if busy := _mower_busy_response():
-        return busy
-    payload = request.get_json(silent=True) or {}
-    target = str(payload.get("maa_path") or config.conf.maa_path).strip()
-    if not target:
-        return {"ok": False, "message": "请先设置 Maa 目录"}
-    try:
-        channel = normalize_update_channel(
-            payload.get("channel") or config.conf.maa_update_channel
-        )
-    except MaaUpdateError as e:
-        return {"ok": False, "message": str(e)}
-    mirror_token = str(payload.get("mirror_token") or "").strip()
-    config_changed = False
-    if mirror_token and mirror_token != config.conf.maa_mirrorchyan_token:
-        config.conf.maa_mirrorchyan_token = mirror_token
-        config_changed = True
-    if channel != config.conf.maa_update_channel:
-        config.conf.maa_update_channel = channel
-        config_changed = True
-    if config_changed:
-        config.save_conf()
-    try:
-        launcher = launch_builtin_maa_update(target, __system__)
-    except MaaUpdateError as e:
-        return {"ok": False, "message": str(e)}
-    clear_loaded_maa_cache(target)
-    return {
-        "ok": True,
-        "message": (
-            "已启动 MAA.Updater.exe，后续更新由 Maa 自带更新程序处理，"
-            "更新源和版本通道以 Maa 内的配置为准"
-        ),
-        "launcher": str(launcher),
-    }
 
 
 @app.route("/maa-conn-preset")

--- a/ui/src/components/MaaBasic.vue
+++ b/ui/src/components/MaaBasic.vue
@@ -94,8 +94,6 @@ const maa_update_job = ref({
 })
 let maa_update_timer = null
 let maa_update_info_request_id = 0
-const builtin_update_loading = ref(false)
-const builtin_update_msg = ref('')
 const mirrorchyan_cdk_status = ref({
   loading: false,
   checked_token: '',
@@ -193,7 +191,7 @@ watch(
   maa_mirrorchyan_token,
   (token, previousToken = '') => {
     if (token.trim() && !previousToken.trim()) maa_update_source.value = 'mirrorchyan'
-    if (maa_update_supported.value || maa_update_platform.value === 'windows') {
+    if (maa_update_supported.value) {
       schedule_mirrorchyan_cdk_check(token)
     }
   },
@@ -202,7 +200,7 @@ watch(
 
 watch(maa_update_channel, (channel, previous_channel) => {
   if (channel === previous_channel) return
-  if (maa_update_supported.value || maa_update_platform.value === 'windows') {
+  if (maa_update_supported.value) {
     schedule_mirrorchyan_cdk_check(maa_mirrorchyan_token.value)
   }
   if (maa_update_supported.value) get_maa_update_info()
@@ -308,7 +306,7 @@ async function get_maa_update_info() {
     maa_update_platform.value = data.platform || ''
     maa_update_arch.value = data.arch || ''
     maa_installed.value = Boolean(data.installed)
-    if (maa_update_supported.value || maa_update_platform.value === 'windows') {
+    if (maa_update_supported.value) {
       schedule_mirrorchyan_cdk_check(maa_mirrorchyan_token.value)
     } else {
       reset_mirrorchyan_cdk_status()
@@ -367,30 +365,6 @@ async function start_maa_update() {
     maa_update_job.value.message =
       error.response?.data?.message ||
       `MAA ${maa_managed_operation_label.value}启动失败：${error.message}`
-  }
-}
-
-async function start_builtin_maa_update() {
-  if (builtin_update_loading.value) return
-  if (maa_path_missing.value) {
-    builtin_update_msg.value = '请先设置 Maa 目录'
-    return
-  }
-  builtin_update_loading.value = true
-  builtin_update_msg.value = ''
-  try {
-    const response = await axios.post(`${import.meta.env.VITE_HTTP_URL}/maa-update/builtin`, {
-      maa_path: maa_path.value,
-      mirror_token: maa_update_source.value === 'mirrorchyan' ? maa_mirrorchyan_token.value : '',
-      channel: maa_update_channel.value
-    })
-    builtin_update_msg.value = response.data.message || ''
-    if (!response.data.ok) return
-  } catch (error) {
-    builtin_update_msg.value =
-      error.response?.data?.message || `启动 MAA 自带更新失败：${error.message}`
-  } finally {
-    builtin_update_loading.value = false
   }
 }
 
@@ -569,64 +543,14 @@ onUnmounted(() => {
     <template v-else-if="maa_update_platform === 'windows'">
       <n-divider />
       <div class="maa-updater">
-        <div class="update-title">Maa 自带更新</div>
+        <div class="update-title">Windows 更新 Maa</div>
         <div class="update-meta">
           <span>已安装：{{ maa_installed_version || '已检测到 Maa' }}</span>
         </div>
-        <div class="update-option">
-          <span class="update-option-label">Mower 下载通道</span>
-          <n-radio-group v-model:value="maa_update_channel">
-            <n-space>
-              <n-radio value="stable">正式版</n-radio>
-              <n-radio value="beta">公测版</n-radio>
-            </n-space>
-          </n-radio-group>
-        </div>
-        <div class="update-option">
-          <span class="update-option-label">Mower 下载源</span>
-          <n-radio-group v-model:value="maa_update_source">
-            <n-space>
-              <n-radio value="github">GitHub</n-radio>
-              <n-radio value="mirrorchyan">Mirror酱</n-radio>
-            </n-space>
-          </n-radio-group>
-        </div>
-        <template v-if="maa_update_source === 'mirrorchyan'">
-          <n-input
-            v-model:value="maa_mirrorchyan_token"
-            type="password"
-            show-password-on="mousedown"
-            placeholder="Mirror酱 CDK"
-            :disabled="builtin_update_loading"
-          />
-          <div
-            v-if="mirrorchyan_cdk_message"
-            :class="mirrorchyan_cdk_message_class"
-            aria-live="polite"
-          >
-            {{ mirrorchyan_cdk_message }}
-          </div>
-          <div class="update-hint">
-            CDK 保存在 Mower 配置文件中。
-            <n-a href="https://mirrorchyan.com/" target="_blank" rel="noopener noreferrer">
-              获取 CDK
-            </n-a>
-          </div>
-        </template>
         <div class="update-hint">
-          已检测到 Windows Maa，本次操作只启动 MAA.Updater.exe，Mower 不会替换 Maa
-          目录。上方更新源、版本通道和 CDK 只用于 Mower 首次下载，本次更新不会传递给
-          MAA.Updater.exe；请在 Maa 内配置正式版/公测版通道、更新源和 Mirror酱 CDK。
+          已检测到 Windows Maa，请手动打开 Maa，并在 Maa 设置中检查和完成更新。更新源、版本通道和
+          Mirror酱 CDK 以 Maa 内的配置为准，Mower 不会覆盖 Maa 目录。
         </div>
-        <div v-if="builtin_update_msg" class="update-message">{{ builtin_update_msg }}</div>
-        <n-button
-          type="primary"
-          :loading="builtin_update_loading"
-          :disabled="builtin_update_loading"
-          @click="start_builtin_maa_update"
-        >
-          启动 MAA.Updater.exe
-        </n-button>
       </div>
     </template>
   </n-card>


### PR DESCRIPTION
## 目标

Windows 已安装 Maa 时不再尝试直接启动仅供 Maa 内部调用的 `MAA.Updater.exe`，改为提示用户手动打开 Maa 并在 Maa 设置中完成更新。

## 主要改动

- 删除后端 `/maa-update/builtin` 接口及直接启动 `MAA.Updater.exe` 的实现。
- Windows 检测到已有 Maa 后，仅展示手动更新提示，不再显示无效的启动按钮。
- 已安装页面不再展示只对首次下载有效的 Mower 下载源、版本通道与 Mirror酱 CDK 选项。
- Windows 已安装状态下停止发起无实际用途的 Mirror酱 CDK 检查。
- 保留 Windows 未安装 Maa 时通过 GitHub 或 Mirror酱按架构下载安装完整包的行为。
- 更新后端保护性错误文案及对应单元测试。

## 验证

- `python -m unittest arknights_mower.tests.maa_update_tests -v`：37 项通过。
- `ruff check arknights_mower/utils/maa_update.py arknights_mower/tests/maa_update_tests.py server.py`
- `npx prettier --check src/components/MaaBasic.vue`
- `npm run build`
- `git diff --check`
