### PR TITLE
feat(update): 资源包更新支持免重启与自动更新

### DIFF
--- a/arknights_mower/data/__init__.py
+++ b/arknights_mower/data/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from .. import __rootdir__
 from ..utils.path import get_path
-from ..utils.resource_pkg import resource_pkg_path
+from ..utils.resource_pkg import register_resource_reload, resource_pkg_path
 
 
 def _data_path(name: str) -> Path:
@@ -12,7 +12,7 @@ def _data_path(name: str) -> Path:
 
 
 def stage_data_path() -> Path:
-    """打包内置的全量关卡基线（常驻 + 当时活动），启动读一次，之后不变。"""
+    """资源包里的全量关卡基线（常驻 + 当时活动）。"""
     return _data_path("stage_data_full.json")
 
 
@@ -21,7 +21,7 @@ def stage_data_overlay_path() -> Path:
     return get_path("@app/tmp/hot_update/stage_data.json")
 
 
-# 全量基线：启动读一次进内存，之后不变（常驻关卡只在基线，不随热更改）。
+# 全量基线：启动时读入，资源包更新后原位刷新（常驻关卡只在基线）。
 _stage_data_base = json.loads(stage_data_path().read_text("utf-8"))
 
 
@@ -34,7 +34,7 @@ def _stage_key(item: dict) -> str | None:
 
 
 class StageData:
-    """关卡信息合并视图：内置全量基线（启动固定）+ 热更活动层（运行时读）。
+    """关卡信息合并视图：资源包全量基线 + 热更活动层（运行时读）。
 
     常驻关卡（MAIN/DAILY/剿灭）只在基线；热更层按约定只含 ACTIVITY 活动关，
     按 id（缺省 name）覆盖基线同名、补全新关。stageType 不做代码过滤——"只放活动关"
@@ -124,30 +124,75 @@ recruit_result = json.loads(_data_path("recruit_result.json").read_text("utf-8")
 
 key_mapping = json.loads(_data_path("key_mapping.json").read_text("utf-8"))
 
-recruit_tag = ["资深干员", "高级资深干员"]
-for x in recruit_agent.values():
-    recruit_tag += x["tags"]
-recruit_tag = list(set(recruit_tag))
 
-"""
-按tag分类组合干员
-"""
+def _build_recruit_views(recruit_data: dict, result_data: dict):
+    tags = {"资深干员", "高级资深干员"}
+    for recruit in recruit_data.values():
+        tags.update(recruit["tags"])
 
-agent_with_tags = {}
-for item in recruit_tag:
-    agent_with_tags[item] = []
-    for agent in recruit_agent:
-        if {item} < set(recruit_agent[agent]["tags"]):
-            agent_with_tags[item].append(
-                {
-                    "id": agent,
-                    "name": recruit_agent[agent]["name"],
-                    "star": recruit_agent[agent]["stars"],
-                }
-            )
+    by_tag = {}
+    for tag in tags:
+        by_tag[tag] = []
+        for agent, recruit in recruit_data.items():
+            if {tag} < set(recruit["tags"]):
+                by_tag[tag].append(
+                    {
+                        "id": agent,
+                        "name": recruit["name"],
+                        "star": recruit["stars"],
+                    }
+                )
 
-result_template_list = []
+    templates = []
+    for result in result_data.values():
+        templates.extend(result)
+    return sorted(tags), by_tag, templates
 
-for item in recruit_result:
-    for name in recruit_result[item]:
-        result_template_list.append(name)
+
+recruit_tag, agent_with_tags, result_template_list = _build_recruit_views(
+    recruit_agent, recruit_result
+)
+
+
+def _replace_list(target: list, source: list) -> None:
+    target[:] = source
+
+
+def _replace_dict(target: dict, source: dict) -> None:
+    target.clear()
+    target.update(source)
+
+
+def _read_resource_json(name: str, expected_type: type):
+    value = json.loads(_data_path(name).read_text("utf-8"))
+    if not isinstance(value, expected_type):
+        raise ValueError(f"资源数据 {name} 类型错误")
+    return value
+
+
+@register_resource_reload
+def reload_resource_data() -> None:
+    """资源包切换后原位刷新数据，保留各调用模块已经导入的对象引用。"""
+    new_stage_data_base = _read_resource_json("stage_data_full.json", list)
+    new_agent_list = _read_resource_json("agent.json", list)
+    new_agent_profession = _read_resource_json("agent_profession.json", dict)
+    new_workshop_formula = _read_resource_json("workshop_formula.json", dict)
+    new_stage_order = _read_resource_json("stage_order.json", list)
+    new_recruit_agent = _read_resource_json("recruit.json", dict)
+    new_recruit_result = _read_resource_json("recruit_result.json", dict)
+    new_key_mapping = _read_resource_json("key_mapping.json", dict)
+    new_recruit_tag, new_agent_with_tags, new_result_template_list = (
+        _build_recruit_views(new_recruit_agent, new_recruit_result)
+    )
+
+    _replace_list(_stage_data_base, new_stage_data_base)
+    _replace_list(agent_list, new_agent_list)
+    _replace_dict(agent_profession, new_agent_profession)
+    _replace_dict(workshop_formula, new_workshop_formula)
+    _replace_list(stage_order, new_stage_order)
+    _replace_dict(recruit_agent, new_recruit_agent)
+    _replace_dict(recruit_result, new_recruit_result)
+    _replace_dict(key_mapping, new_key_mapping)
+    _replace_list(recruit_tag, new_recruit_tag)
+    _replace_dict(agent_with_tags, new_agent_with_tags)
+    _replace_list(result_template_list, new_result_template_list)

--- a/arknights_mower/data/version.json
+++ b/arknights_mower/data/version.json
@@ -1,0 +1,14 @@
+{
+  "res_version": "v2026.09.03-3e4ac10",
+  "last_updated": "",
+  "activity": {
+    "name": "直到大地变成一颗酸橙",
+    "time": 1785538800,
+    "endTime": 1787342399
+  },
+  "gacha": {
+    "name": "车辙与风的归所",
+    "time": 1785538800,
+    "endTime": 1786737599
+  }
+}

--- a/arknights_mower/solvers/base_mixin.py
+++ b/arknights_mower/solvers/base_mixin.py
@@ -12,12 +12,23 @@ from arknights_mower.utils.character_recognize import operator_list, operator_li
 from arknights_mower.utils.csleep import MowerExit
 from arknights_mower.utils.image import cropimg, loadres, thres2
 from arknights_mower.utils.log import logger
-from arknights_mower.utils.resource_pkg import resource_pkg_path
+from arknights_mower.utils.resource_pkg import (
+    register_resource_reload,
+    resource_pkg_path,
+)
 
-with lzma.open(
-    str(resource_pkg_path("arknights_mower/models/operator_room.model")), "rb"
-) as f:
-    OP_ROOM = pickle.loads(f.read())
+
+def _load_operator_room_model():
+    with lzma.open(
+        str(resource_pkg_path("arknights_mower/models/operator_room.model")), "rb"
+    ) as f:
+        model = pickle.loads(f.read())
+    if not isinstance(model, dict):
+        raise ValueError("基建干员识别模型格式错误")
+    return model
+
+
+OP_ROOM = _load_operator_room_model()
 
 kernel = np.ones((12, 12), np.uint8)
 PREFIX_NAME_SCORE_RATIO = 0.9
@@ -51,6 +62,18 @@ def _foreground_width(img):
 OP_ROOM_WIDTH = {
     operator: _foreground_width(template) for operator, template in OP_ROOM.items()
 }
+
+
+@register_resource_reload
+def reload_resource_models() -> None:
+    model = _load_operator_room_model()
+    widths = {
+        operator: _foreground_width(template) for operator, template in model.items()
+    }
+    OP_ROOM.clear()
+    OP_ROOM.update(model)
+    OP_ROOM_WIDTH.clear()
+    OP_ROOM_WIDTH.update(widths)
 
 
 def _resolve_operator_room_prefix(

--- a/arknights_mower/solvers/recruit.py
+++ b/arknights_mower/solvers/recruit.py
@@ -17,16 +17,41 @@ from arknights_mower.utils.graph import SceneGraphSolver
 from arknights_mower.utils.image import cmatch, cropimg, loadres, thres2
 from arknights_mower.utils.log import logger
 from arknights_mower.utils.recognize import Recognizer, Scene
-from arknights_mower.utils.resource_pkg import resource_pkg_path
+from arknights_mower.utils.resource_pkg import (
+    register_resource_reload,
+    resource_pkg_path,
+)
 from arknights_mower.utils.vector import va
 
 number = riic_base_digits
-with lzma.open(
-    str(resource_pkg_path("arknights_mower/models/recruit_result.pkl")), "rb"
-) as f:
-    recruit_res_template = pickle.load(f)
-with lzma.open(str(resource_pkg_path("arknights_mower/models/recruit.pkl")), "rb") as f:
-    tag_template = pickle.load(f)
+
+
+def _load_recruit_models():
+    with lzma.open(
+        str(resource_pkg_path("arknights_mower/models/recruit_result.pkl")), "rb"
+    ) as f:
+        result = pickle.load(f)
+    with lzma.open(
+        str(resource_pkg_path("arknights_mower/models/recruit.pkl")), "rb"
+    ) as f:
+        tags = pickle.load(f)
+    if not isinstance(result, dict) or not isinstance(tags, dict):
+        raise ValueError("公开招募识别模型格式错误")
+    return result, tags
+
+
+recruit_res_template, tag_template = _load_recruit_models()
+
+
+@register_resource_reload
+def reload_resource_models() -> None:
+    result, tags = _load_recruit_models()
+    recruit_res_template.clear()
+    recruit_res_template.update(result)
+    tag_template.clear()
+    tag_template.update(tags)
+
+
 job_list = [
     "recruit/riic_res/CASTER",
     "recruit/riic_res/MEDIC",

--- a/arknights_mower/tests/config_tests.py
+++ b/arknights_mower/tests/config_tests.py
@@ -21,6 +21,16 @@ class TestMaaConfig(unittest.TestCase):
         self.assertEqual(restored.maa_update_channel, "beta")
 
 
+class TestUpdateConfig(unittest.TestCase):
+    def test_auto_update_enables_check_and_round_trips(self):
+        conf = Conf(hot_update={"enable": False, "auto_update": True})
+        self.assertTrue(conf.hot_update.enable)
+        self.assertTrue(conf.hot_update.auto_update)
+        restored = Conf(**conf.model_dump())
+        self.assertTrue(restored.hot_update.enable)
+        self.assertTrue(restored.hot_update.auto_update)
+
+
 class TestAtomicWrite(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()

--- a/arknights_mower/tests/hot_update_tests.py
+++ b/arknights_mower/tests/hot_update_tests.py
@@ -30,6 +30,9 @@ class TestHotUpdateBase(unittest.TestCase):
         self.version = self.dir / "hot_update_version.json"
 
         self.enable = patch.object(config.conf.hot_update, "enable", True)
+        self.auto_update = patch.object(config.conf.hot_update, "auto_update", True)
+        self.auto_update.start()
+        self.addCleanup(self.auto_update.stop)
         self.extract_p = patch.object(hu, "extract_path", self.extract)
         self.version_p = patch.object(hu, "version_state", self.version)
         # 模块全局 last_update 跨用例残留会触发 30 分钟节流，逐用例重置
@@ -109,6 +112,23 @@ class TestUpdateOrchestration(TestHotUpdateBase):
         ):
             hu.update()
             dl.assert_not_called()
+
+    def test_new_version_check_only_does_not_download(self):
+        self.version.write_text("v2026.08.21-aaaaaa", encoding="utf-8")
+        with (
+            self.enable,
+            patch.object(config.conf.hot_update, "auto_update", False),
+            self.extract_p,
+            self.version_p,
+            patch.object(hu, "_latest_release_tag", return_value="v2026.08.22-bbbbbb"),
+            patch.object(hu, "_download_and_extract") as dl,
+        ):
+            hu.update()
+            dl.assert_not_called()
+            self.assertEqual(
+                self.version.read_text(encoding="utf-8"), "v2026.08.21-aaaaaa"
+            )
+            self.assertIsNotNone(hu.last_update)
 
     def test_new_version_downloads_and_records(self):
         self.version.write_text("v2026.08.21-aaaaaa", encoding="utf-8")

--- a/arknights_mower/tests/manual_update_tests.py
+++ b/arknights_mower/tests/manual_update_tests.py
@@ -19,8 +19,15 @@ class TestApplyManualUpdate(unittest.TestCase):
         data = _zip_bytes({"arknights_mower/data/version.json": '{"res_version":"v1"}'})
         with patch.object(manual_update, "install_resource_pkg", return_value=True):
             got = manual_update.apply_manual_update(data)
-        self.assertEqual(got["kind"], "resource")
-        self.assertTrue(got["ok"])
+        self.assertEqual(
+            got,
+            {
+                "ok": True,
+                "kind": "resource",
+                "restart_required": False,
+                "message": "资源包安装成功，已生效，无需重启 Mower",
+            },
+        )
 
     def test_resource_package_honors_busy_response(self):
         data = _zip_bytes({"arknights_mower/data/version.json": '{"res_version":"v1"}'})

--- a/arknights_mower/tests/resource_cache_reload_tests.py
+++ b/arknights_mower/tests/resource_cache_reload_tests.py
@@ -1,0 +1,149 @@
+import unittest
+from copy import deepcopy
+from unittest.mock import patch
+
+import numpy as np
+
+from arknights_mower import data
+from arknights_mower.solvers import base_mixin, recruit
+from arknights_mower.utils import character_recognize, mastery_recommendation
+
+
+class TestResourceCacheReload(unittest.TestCase):
+    def test_data_reload_preserves_imported_container_references(self):
+        targets = {
+            "stage_data_full.json": [{"id": "HOT-1"}],
+            "agent.json": ["测试干员"],
+            "agent_profession.json": {"测试干员": "WARRIOR"},
+            "workshop_formula.json": {"测试材料": {"apCost": 2}},
+            "stage_order.json": ["HOT-1"],
+            "recruit.json": {
+                "char_test": {
+                    "name": "测试干员",
+                    "stars": 6,
+                    "tags": ["测试标签", "近战位"],
+                }
+            },
+            "recruit_result.json": {"6": ["测试干员"]},
+            "key_mapping.json": {"item_test": ["item_test", "MATERIAL", "测试材料"]},
+        }
+        containers = {
+            "_stage_data_base": data._stage_data_base,
+            "agent_list": data.agent_list,
+            "agent_profession": data.agent_profession,
+            "workshop_formula": data.workshop_formula,
+            "stage_order": data.stage_order,
+            "recruit_agent": data.recruit_agent,
+            "recruit_result": data.recruit_result,
+            "key_mapping": data.key_mapping,
+            "recruit_tag": data.recruit_tag,
+            "agent_with_tags": data.agent_with_tags,
+            "result_template_list": data.result_template_list,
+        }
+        originals = {name: deepcopy(value) for name, value in containers.items()}
+
+        try:
+            with patch.object(
+                data,
+                "_read_resource_json",
+                side_effect=lambda name, expected_type: deepcopy(targets[name]),
+            ):
+                data.reload_resource_data()
+
+            for name, original_ref in containers.items():
+                self.assertIs(getattr(data, name), original_ref)
+            self.assertEqual(data.agent_list, ["测试干员"])
+            self.assertEqual(data._stage_data_base, [{"id": "HOT-1"}])
+            self.assertEqual(
+                data.agent_with_tags["测试标签"],
+                [{"id": "char_test", "name": "测试干员", "star": 6}],
+            )
+            self.assertEqual(data.result_template_list, ["测试干员"])
+        finally:
+            for name, original in originals.items():
+                current = getattr(data, name)
+                if isinstance(current, list):
+                    data._replace_list(current, original)
+                else:
+                    data._replace_dict(current, original)
+
+    def test_recognition_model_reload_preserves_references(self):
+        select_ref = character_recognize.OP_SELECT
+        train_ref = character_recognize.OP_TRAIN
+        select_original = select_ref.copy()
+        train_original = train_ref.copy()
+        try:
+            with patch.object(
+                character_recognize,
+                "_load_models",
+                return_value=({"select": "new"}, {"train": "new"}),
+            ):
+                character_recognize.reload_resource_models()
+            self.assertIs(character_recognize.OP_SELECT, select_ref)
+            self.assertIs(character_recognize.OP_TRAIN, train_ref)
+            self.assertEqual(select_ref, {"select": "new"})
+            self.assertEqual(train_ref, {"train": "new"})
+        finally:
+            select_ref.clear()
+            select_ref.update(select_original)
+            train_ref.clear()
+            train_ref.update(train_original)
+
+    def test_room_model_reload_refreshes_widths_in_place(self):
+        room_ref = base_mixin.OP_ROOM
+        widths_ref = base_mixin.OP_ROOM_WIDTH
+        room_original = room_ref.copy()
+        widths_original = widths_ref.copy()
+        model = {"测试干员": np.ones((4, 7), dtype=np.uint8)}
+        try:
+            with patch.object(
+                base_mixin, "_load_operator_room_model", return_value=model
+            ):
+                base_mixin.reload_resource_models()
+            self.assertIs(base_mixin.OP_ROOM, room_ref)
+            self.assertIs(base_mixin.OP_ROOM_WIDTH, widths_ref)
+            self.assertEqual(widths_ref, {"测试干员": 7})
+        finally:
+            room_ref.clear()
+            room_ref.update(room_original)
+            widths_ref.clear()
+            widths_ref.update(widths_original)
+
+    def test_recruit_and_skill_reload_preserve_references(self):
+        result_ref = recruit.recruit_res_template
+        tag_ref = recruit.tag_template
+        skill_ref = mastery_recommendation.get_skill_data()
+        result_original = result_ref.copy()
+        tag_original = tag_ref.copy()
+        skill_original = deepcopy(skill_ref)
+        try:
+            with patch.object(
+                recruit,
+                "_load_recruit_models",
+                return_value=({"result": "new"}, {"tag": "new"}),
+            ):
+                recruit.reload_resource_models()
+            with patch.object(
+                mastery_recommendation,
+                "_load_skill_data",
+                return_value={"characters": {"char_test": {}}},
+            ):
+                mastery_recommendation.reload_resource_data()
+
+            self.assertIs(recruit.recruit_res_template, result_ref)
+            self.assertIs(recruit.tag_template, tag_ref)
+            self.assertIs(mastery_recommendation.get_skill_data(), skill_ref)
+            self.assertEqual(result_ref, {"result": "new"})
+            self.assertEqual(tag_ref, {"tag": "new"})
+            self.assertEqual(skill_ref, {"characters": {"char_test": {}}})
+        finally:
+            result_ref.clear()
+            result_ref.update(result_original)
+            tag_ref.clear()
+            tag_ref.update(tag_original)
+            skill_ref.clear()
+            skill_ref.update(skill_original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/resource_pkg_tests.py
+++ b/arknights_mower/tests/resource_pkg_tests.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from arknights_mower import __rootdir__
 from arknights_mower.utils import resource_pkg as rp
+from build_assets import _collect_arknights_mower_datas
 
 
 def _zip_bytes(entries=None, marker=True):
@@ -42,6 +43,9 @@ class ResourcePkgTestBase(unittest.TestCase):
         self._patch.enter_context(patch.object(rp, "RESOURCE_OVERLAY", self.overlay))
         self._patch.enter_context(patch.object(rp, "_STAGING", self.staging))
         self._patch.enter_context(patch.object(rp, "_OLD", self.old))
+        self.reload_caches = self._patch.enter_context(
+            patch.object(rp, "reload_resource_caches")
+        )
         self.addCleanup(self._patch.close)
 
 
@@ -60,6 +64,13 @@ class TestResourcePkgPath(ResourcePkgTestBase):
         got = rp.resource_pkg_path("arknights_mower/data/key_mapping.json")
         self.assertEqual(got, Path(__rootdir__) / "data/key_mapping.json")
 
+    def test_pyinstaller_collects_builtin_version(self):
+        collected = {
+            Path(source).relative_to(Path(__rootdir__).parent).as_posix()
+            for source, _destination in _collect_arknights_mower_datas()
+        }
+        self.assertIn("arknights_mower/data/version.json", collected)
+
 
 class TestInstallResourcePkg(ResourcePkgTestBase):
     def test_missing_marker_rejected(self):
@@ -77,6 +88,7 @@ class TestInstallResourcePkg(ResourcePkgTestBase):
         self.assertTrue((self.overlay / "ui/public/depot/x.webp").is_file())
         self.assertFalse(self.staging.exists())
         self.assertFalse(self.old.exists())
+        self.reload_caches.assert_called_once_with()
 
     def test_replaces_previous_overlay(self):
         self.assertTrue(rp.install_resource_pkg(_zip_bytes()))
@@ -120,6 +132,32 @@ class TestInstallResourcePkg(ResourcePkgTestBase):
             ),
             old_marker,
         )
+        self.assertFalse(self.old.exists())
+
+    def test_reload_failure_rolls_back_previous_overlay_and_caches(self):
+        self.assertTrue(rp.install_resource_pkg(_zip_bytes()))
+        old_marker = (self.overlay / "arknights_mower/data/version.json").read_text(
+            encoding="utf-8"
+        )
+        self.reload_caches.reset_mock()
+        self.reload_caches.side_effect = [RuntimeError("bad resource"), None]
+
+        new = _zip_bytes(
+            entries={
+                "arknights_mower/data/version.json": json.dumps(
+                    {"res_version": "v2026.08.24-bbbbbbb"}
+                )
+            }
+        )
+        self.assertFalse(rp.install_resource_pkg(new))
+        self.assertEqual(
+            (self.overlay / "arknights_mower/data/version.json").read_text(
+                encoding="utf-8"
+            ),
+            old_marker,
+        )
+        self.assertEqual(self.reload_caches.call_count, 2)
+        self.assertFalse(self.staging.exists())
         self.assertFalse(self.old.exists())
 
 

--- a/arknights_mower/tests/resource_version_tests.py
+++ b/arknights_mower/tests/resource_version_tests.py
@@ -5,8 +5,15 @@ from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import patch
 
+from arknights_mower import __rootdir__
 from arknights_mower.utils import resource_version as rv
-from arknights_mower.utils.res_version import parse_version, version_newer
+from arknights_mower.utils.res_version import (
+    content_hash,
+    display_version,
+    package_file_paths,
+    parse_version,
+    version_newer,
+)
 
 
 def _version(res_version="2026.08.23-31a240b", name="墟·复刻", time=1724068800):
@@ -160,6 +167,46 @@ class TestCheckResourceUpdate(unittest.TestCase):
 
 
 class TestReadLocalVersion(unittest.TestCase):
+    def test_builtin_version_is_available_without_overlay(self):
+        marker = json.loads(
+            (Path(__rootdir__) / "data/version.json").read_text(encoding="utf-8")
+        )
+        with tempfile.TemporaryDirectory() as d:
+            missing_overlay = Path(d) / "resource"
+            with patch(
+                "arknights_mower.utils.resource_pkg.RESOURCE_OVERLAY",
+                missing_overlay,
+            ):
+                got = rv.check_resource_update(local_only=True)
+
+        self.assertTrue(got["current_version"])
+        self.assertTrue(got["current_display"])
+        self.assertEqual(got["current_version"], marker["res_version"])
+        self.assertEqual(got["current_display"], display_version(marker))
+
+    def test_overlay_version_replaces_builtin_version(self):
+        with tempfile.TemporaryDirectory() as d:
+            overlay = Path(d) / "resource"
+            marker = overlay / "arknights_mower/data/version.json"
+            marker.parent.mkdir(parents=True)
+            marker.write_text(
+                json.dumps(_version("2026.09.04-bbbbbbb", "墟·复刻", 1787342400)),
+                encoding="utf-8",
+            )
+            with patch("arknights_mower.utils.resource_pkg.RESOURCE_OVERLAY", overlay):
+                got = rv.check_resource_update(local_only=True)
+
+        self.assertEqual(got["current_version"], "2026.09.04-bbbbbbb")
+        self.assertEqual(got["current_display"], "墟·复刻#0822")
+
+    def test_builtin_version_hash_matches_bundled_resources(self):
+        project_root = Path(__rootdir__).parent
+        marker = json.loads(
+            (Path(__rootdir__) / "data/version.json").read_text(encoding="utf-8")
+        )
+        digest = content_hash(project_root, package_file_paths(project_root))
+        self.assertTrue(marker["res_version"].endswith(f"-{digest[:7]}"))
+
     def test_resolves_overlay_path_on_every_read(self):
         with tempfile.TemporaryDirectory() as d:
             first = Path(d) / "builtin.json"

--- a/arknights_mower/utils/character_recognize.py
+++ b/arknights_mower/utils/character_recognize.py
@@ -7,19 +7,38 @@ import numpy as np
 
 from arknights_mower.utils.image import cropimg, thres2
 from arknights_mower.utils.log import logger
-from arknights_mower.utils.resource_pkg import resource_pkg_path
+from arknights_mower.utils.resource_pkg import (
+    register_resource_reload,
+    resource_pkg_path,
+)
 
 kernel = np.ones((10, 10), np.uint8)
 
-with lzma.open(
-    str(resource_pkg_path("arknights_mower/models/operator_select.model")), "rb"
-) as f:
-    OP_SELECT = pickle.loads(f.read())
 
-with lzma.open(
-    str(resource_pkg_path("arknights_mower/models/operator_train.model")), "rb"
-) as f:
-    OP_TRAIN = pickle.loads(f.read())
+def _load_models():
+    with lzma.open(
+        str(resource_pkg_path("arknights_mower/models/operator_select.model")), "rb"
+    ) as f:
+        select = pickle.loads(f.read())
+    with lzma.open(
+        str(resource_pkg_path("arknights_mower/models/operator_train.model")), "rb"
+    ) as f:
+        train = pickle.loads(f.read())
+    if not isinstance(select, dict) or not isinstance(train, dict):
+        raise ValueError("干员选择识别模型格式错误")
+    return select, train
+
+
+OP_SELECT, OP_TRAIN = _load_models()
+
+
+@register_resource_reload
+def reload_resource_models() -> None:
+    select, train = _load_models()
+    OP_SELECT.clear()
+    OP_SELECT.update(select)
+    OP_TRAIN.clear()
+    OP_TRAIN.update(train)
 
 
 def operator_list(img, draw=False, full_scan=True):

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -196,6 +196,14 @@ class LongTaskPart(ConfModel):
     class HotUpdateConf(ConfModel):
         enable: bool = False
         "热更新检查开关（默认关）"
+        auto_update: bool = False
+        "发现热更新或资源包更新时自动安装"
+
+        @model_validator(mode="after")
+        def auto_update_requires_check(self):
+            if self.auto_update:
+                self.enable = True
+            return self
 
     hot_update: HotUpdateConf
     "热更新"

--- a/arknights_mower/utils/hot_update.py
+++ b/arknights_mower/utils/hot_update.py
@@ -136,10 +136,10 @@ def _download_and_extract() -> bool:
 
 
 def update():
-    """检查并应用热更：GitHub Releases latest 的 tag 与本地已应用版本比对。
+    """检查热更，并在开启自动更新时应用。
 
-    由 config.conf.hot_update.enable 控制（默认关）；保留 30 分钟节流。
-    仅在发现新版本或检测失败时记录日志，其余情况静默返回。
+    由 ``hot_update.enable`` 控制检查，``hot_update.auto_update`` 控制安装；
+    保留 30 分钟节流。仅在发现新版本或检测失败时记录日志，其余情况静默返回。
     """
     global last_update
 
@@ -156,6 +156,13 @@ def update():
 
     local_tag = _read_applied_tag()
     if not version_newer(remote_tag, local_tag, require_v=True):
+        last_update = datetime.now()
+        return
+
+    if not config.conf.hot_update.auto_update:
+        logger.info(
+            f"发现新热更版本 {remote_tag}（本地 {local_tag or '无'}），等待手动更新"
+        )
         last_update = datetime.now()
         return
 

--- a/arknights_mower/utils/manual_update.py
+++ b/arknights_mower/utils/manual_update.py
@@ -37,7 +37,8 @@ def apply_manual_update(data: bytes, busy_check: BusyCheck | None = None) -> dic
             return {
                 "ok": True,
                 "kind": "resource",
-                "message": "资源包安装成功，重启后完全生效",
+                "restart_required": False,
+                "message": "资源包安装成功，已生效，无需重启 Mower",
             }
         return {
             "ok": False,

--- a/arknights_mower/utils/mastery_recommendation.py
+++ b/arknights_mower/utils/mastery_recommendation.py
@@ -3,7 +3,10 @@ import os
 from typing import Optional
 
 from arknights_mower.utils.path import _install_dir, _internal_dir, get_path
-from arknights_mower.utils.resource_pkg import resource_pkg_path
+from arknights_mower.utils.resource_pkg import (
+    register_resource_reload,
+    resource_pkg_path,
+)
 from arknights_mower.utils.skill_label import format_skill_label
 
 
@@ -23,16 +26,33 @@ def _find_skill_data():
 _skill_data_cache = None
 
 
+def _load_skill_data():
+    path = _find_skill_data()
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            raise ValueError("专精推荐资源格式错误")
+        return data
+    return {}
+
+
 def get_skill_data():
     global _skill_data_cache
     if _skill_data_cache is None:
-        path = _find_skill_data()
-        if os.path.exists(path):
-            with open(path, "r", encoding="utf-8") as f:
-                _skill_data_cache = json.load(f)
-        else:
-            _skill_data_cache = {}
+        _skill_data_cache = _load_skill_data()
     return _skill_data_cache
+
+
+@register_resource_reload
+def reload_resource_data() -> None:
+    global _skill_data_cache
+    new_data = _load_skill_data()
+    if _skill_data_cache is None:
+        _skill_data_cache = new_data
+    else:
+        _skill_data_cache.clear()
+        _skill_data_cache.update(new_data)
 
 
 def get_skill_real_name(char_id: str, skill_index: int):

--- a/arknights_mower/utils/resource_pkg.py
+++ b/arknights_mower/utils/resource_pkg.py
@@ -5,12 +5,15 @@
 - zip 内路径相对仓库根（``arknights_mower/data/X.json``、``ui/public/depot/X.webp``）。
 - 安装走「原子换目录」：staging → resource，旧目录先挪走，失败回滚；version.json 随 zip
   在整目录内原子落位（资源全成功才版本生效，失败整体回滚）。
+- 切换后刷新已登记的进程内 JSON/模型缓存；刷新失败时连同目录一起回滚，无需重启进程。
 """
 
 import os
+from collections.abc import Callable
 from io import BytesIO
 from pathlib import Path
 from shutil import rmtree
+from threading import RLock
 from zipfile import ZipFile
 
 import requests
@@ -30,6 +33,21 @@ RESOURCE_ZIP_URL = (
 # 有效资源包的标记：zip 根相对路径里的 version.json
 _RESOURCE_MARKER = "arknights_mower/data/version.json"
 _PKG_PREFIX = "arknights_mower/"
+_install_lock = RLock()
+_reload_callbacks: dict[str, Callable[[], None]] = {}
+
+
+def register_resource_reload(callback: Callable[[], None]) -> Callable[[], None]:
+    """登记一个资源包切换后的进程内缓存刷新函数。"""
+    key = f"{callback.__module__}.{callback.__qualname__}"
+    _reload_callbacks[key] = callback
+    return callback
+
+
+def reload_resource_caches() -> None:
+    """刷新当前进程里已经加载过的资源数据；任一失败都向上抛出。"""
+    for callback in tuple(_reload_callbacks.values()):
+        callback()
 
 
 def resource_pkg_path(rel: str) -> Path:
@@ -54,41 +72,58 @@ def download_resource_pkg() -> bytes | None:
 
 
 def install_resource_pkg(data: bytes) -> bool:
-    """校验资源包 zip -> 解压到 staging -> 原子换目录（失败回滚）。成功返回 True。"""
-    try:
-        with ZipFile(BytesIO(data)) as z:
-            names = z.namelist()
-            if _RESOURCE_MARKER not in names:
-                logger.warning(
-                    f"不是有效的资源包（缺 {_RESOURCE_MARKER}）：{names[:5]}"
-                )
-                return False
-            if any(is_unsafe_zip_member(n) for n in names):
-                logger.warning(f"资源包含非法路径，拒绝应用：{names[:5]}")
-                return False
-            if _STAGING.exists():
-                rmtree(_STAGING)
-            if _OLD.exists():
-                rmtree(_OLD)
-            z.extractall(_STAGING)
-    except Exception as e:
-        logger.exception(f"资源包解压失败：{e}")
-        return False
+    """原子安装资源包并刷新进程内缓存；切换或加载失败均回滚。"""
+    with _install_lock:
+        try:
+            with ZipFile(BytesIO(data)) as z:
+                names = z.namelist()
+                if _RESOURCE_MARKER not in names:
+                    logger.warning(
+                        f"不是有效的资源包（缺 {_RESOURCE_MARKER}）：{names[:5]}"
+                    )
+                    return False
+                if any(is_unsafe_zip_member(n) for n in names):
+                    logger.warning(f"资源包含非法路径，拒绝应用：{names[:5]}")
+                    return False
+                if _STAGING.exists():
+                    rmtree(_STAGING)
+                if _OLD.exists():
+                    rmtree(_OLD)
+                z.extractall(_STAGING)
+        except Exception as e:
+            logger.exception(f"资源包解压失败：{e}")
+            return False
 
-    try:
-        if RESOURCE_OVERLAY.exists():
-            os.replace(RESOURCE_OVERLAY, _OLD)
-        os.replace(_STAGING, RESOURCE_OVERLAY)
-    except Exception as e:
-        logger.exception(f"资源包安装失败：{e}")
-        if _OLD.exists() and not RESOURCE_OVERLAY.exists():
+        try:
+            if RESOURCE_OVERLAY.exists():
+                os.replace(RESOURCE_OVERLAY, _OLD)
+            os.replace(_STAGING, RESOURCE_OVERLAY)
+        except Exception as e:
+            logger.exception(f"资源包安装失败：{e}")
+            if _OLD.exists() and not RESOURCE_OVERLAY.exists():
+                try:
+                    os.replace(_OLD, RESOURCE_OVERLAY)
+                except Exception as e2:
+                    logger.error(f"资源包回滚失败：{e2}")
+            rmtree(_STAGING, ignore_errors=True)
+            return False
+
+        try:
+            reload_resource_caches()
+        except Exception as e:
+            logger.exception(f"资源包进程内加载失败，正在回滚：{e}")
             try:
-                os.replace(_OLD, RESOURCE_OVERLAY)
-            except Exception as e2:
-                logger.error(f"资源包回滚失败：{e2}")
-        rmtree(_STAGING, ignore_errors=True)
-        return False
-    if _OLD.exists():
-        rmtree(_OLD, ignore_errors=True)
-    logger.info(f"资源包安装成功：{RESOURCE_OVERLAY}")
-    return True
+                if RESOURCE_OVERLAY.exists():
+                    os.replace(RESOURCE_OVERLAY, _STAGING)
+                if _OLD.exists():
+                    os.replace(_OLD, RESOURCE_OVERLAY)
+                reload_resource_caches()
+            except Exception as rollback_error:
+                logger.exception(f"资源包回滚后重新加载失败：{rollback_error}")
+            rmtree(_STAGING, ignore_errors=True)
+            return False
+
+        if _OLD.exists():
+            rmtree(_OLD, ignore_errors=True)
+        logger.info(f"资源包安装成功并已在当前进程生效：{RESOURCE_OVERLAY}")
+        return True

--- a/server.py
+++ b/server.py
@@ -309,7 +309,9 @@ def serve_resource_overlay():
         base = Path(get_path("@app/tmp/resource/ui/public"))
         p = (base / path).resolve()
         if base.resolve() in p.parents and p.is_file():
-            return send_file(p)
+            response = send_file(p)
+            response.headers["Cache-Control"] = "no-cache"
+            return response
 
 
 @app.after_request
@@ -1124,7 +1126,11 @@ def install_resource():
         return {"ok": False, "message": "资源包下载失败，请检查网络"}
     if not install_resource_pkg(data):
         return {"ok": False, "message": "资源包安装失败（已回滚）"}
-    return {"ok": True, "message": "安装成功，重启后完全生效"}
+    return {
+        "ok": True,
+        "restart_required": False,
+        "message": "资源包安装成功，已生效，无需重启 Mower",
+    }
 
 
 def str2date(target: str):

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -378,8 +378,14 @@ const watermarkData = ref('mower')
 
 const config_store = useConfigStore()
 const { load_config, load_shop, load_item } = config_store
-const { hot_update_enable, simulator, start_automatically, theme, webview } =
-  storeToRefs(config_store)
+const {
+  hot_update_enable,
+  hot_update_auto_update,
+  simulator,
+  start_automatically,
+  theme,
+  webview
+} = storeToRefs(config_store)
 
 const plan_store = usePlanStore()
 const { operators } = storeToRefs(plan_store)
@@ -395,7 +401,7 @@ const { ackUpdateNotice, loadUpdateNotice } = update_notice_store
 const showUpdateNoticeModal = ref(false)
 
 const resource_version_store = useResourceVersionStore()
-const { loadResourceVersion } = resource_version_store
+const { installResource, loadResourceVersion } = resource_version_store
 
 const axios = inject('axios')
 
@@ -497,7 +503,12 @@ onMounted(async () => {
   }
   if (hot_update_enable.value) {
     try {
-      await loadResourceVersion()
+      const resourceInfo = await loadResourceVersion()
+      if (hot_update_auto_update.value && resourceInfo.update_available === true) {
+        if (await installResource()) {
+          await Promise.all([load_shop(), load_item(), load_operators()])
+        }
+      }
     } catch (error) {
       console.error('failed to load resource version', error)
     }

--- a/ui/src/components/ResourceUpdate.vue
+++ b/ui/src/components/ResourceUpdate.vue
@@ -3,20 +3,33 @@ import axios from 'axios'
 import { onMounted, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useConfigStore } from '@/stores/config'
+import { usePlanStore } from '@/stores/plan'
 import { useResourceVersionStore } from '@/stores/resourceVersion'
 import { getDroppedFile, postManualUpdate } from '@/utils/manualUpdate'
 
 const manual_url = `${import.meta.env.VITE_HTTP_URL}/hot-update/manual`
 
 const config_store = useConfigStore()
-const { hot_update_enable } = storeToRefs(config_store)
+const { hot_update_enable, hot_update_auto_update } = storeToRefs(config_store)
+const { load_item, load_shop } = config_store
+
+const plan_store = usePlanStore()
+const { load_operators } = plan_store
 
 const resource_store = useResourceVersionStore()
-const { info, loading, installing, install_message } = storeToRefs(resource_store)
+const { canInstall, info, loading, installing, install_message } = storeToRefs(resource_store)
 const { loadResourceVersion, loadResourceVersionLocal, installResource } = resource_store
 
 const manual_result = ref('')
 const manual_installing = ref(false)
+
+async function refresh_resource_options() {
+  try {
+    await Promise.all([load_item(), load_shop(), load_operators()])
+  } catch (error) {
+    console.error('failed to refresh resource-backed options', error)
+  }
+}
 
 onMounted(() => {
   // 当前版本常驻显示；开启「启动时检查更新」时才顺带拉远端最新版本。
@@ -30,11 +43,18 @@ onMounted(() => {
 async function show_manual_result(data) {
   manual_result.value = data && typeof data.message === 'string' ? data.message : '更新包应用失败'
   if (data?.ok && data.kind === 'resource') {
+    await refresh_resource_options()
     if (hot_update_enable.value) {
       await loadResourceVersion(true)
     } else {
       await loadResourceVersionLocal()
     }
+  }
+}
+
+async function install_resource() {
+  if (await installResource()) {
+    await refresh_resource_options()
   }
 }
 
@@ -70,14 +90,36 @@ function drop_manual_update(event) {
     void upload_manual_file(file)
   }
 }
+
+function set_auto_check(checked) {
+  hot_update_enable.value = checked
+  if (!checked) {
+    hot_update_auto_update.value = false
+  }
+}
+
+function set_auto_update(checked) {
+  hot_update_auto_update.value = checked
+  if (checked) {
+    hot_update_enable.value = true
+  }
+}
 </script>
 
 <template>
   <n-card title="资源更新">
     <n-form :show-feedback="false" label-placement="left" label-width="72">
       <n-form-item :show-label="false">
-        <n-checkbox v-model:checked="hot_update_enable">启动时检查更新</n-checkbox>
+        <n-checkbox :checked="hot_update_enable" @update:checked="set_auto_check">
+          自动检查更新
+        </n-checkbox>
         <span class="hint">打开 mower 时自动检查热更新和资源包</span>
+      </n-form-item>
+      <n-form-item :show-label="false">
+        <n-checkbox :checked="hot_update_auto_update" @update:checked="set_auto_update">
+          自动更新
+        </n-checkbox>
+        <span class="hint">发现更新后自动应用热更新和资源包</span>
       </n-form-item>
       <n-form-item label="当前版本">
         <span>{{ info.current_display || '未安装' }}</span>
@@ -96,11 +138,11 @@ function drop_manual_update(event) {
             检查更新
           </n-button>
           <n-button
-            v-if="info.update_available === true"
             size="small"
             type="primary"
             :loading="installing"
-            @click="installResource"
+            :disabled="!canInstall"
+            @click="install_resource"
           >
             下载并安装
           </n-button>
@@ -108,6 +150,9 @@ function drop_manual_update(event) {
       </n-form-item>
       <n-form-item v-if="install_message" :show-label="false">
         <span>{{ install_message }}</span>
+      </n-form-item>
+      <n-form-item :show-label="false">
+        <span class="hint">资源包安装后会在当前进程内生效；仅软件版本更新需要重启 Mower</span>
       </n-form-item>
       <n-form-item label="手动应用">
         <n-upload

--- a/ui/src/stores/config.js
+++ b/ui/src/stores/config.js
@@ -109,6 +109,7 @@ export const useConfigStore = defineStore('config', () => {
   const credit_fight = ref({})
   const custom_screenshot = ref({})
   const hot_update_enable = ref(false)
+  const hot_update_auto_update = ref(false)
   const notification_level = ref('INFO')
   const waiting_scene = ref({})
   const exipring_medicine_on_weekend = ref(false)
@@ -354,6 +355,7 @@ export const useConfigStore = defineStore('config', () => {
     t5_operators.value = response.data.t5_operators || ['年']
     book_operators.value = response.data.book_operators || ['司霆惊蛰']
     hot_update_enable.value = response.data.hot_update?.enable ?? false
+    hot_update_auto_update.value = response.data.hot_update?.auto_update ?? false
     notification_level.value = response.data.notification_level
     waiting_scene.value = response.data.waiting_scene
     exipring_medicine_on_weekend.value = response.data.exipring_medicine_on_weekend
@@ -468,7 +470,10 @@ export const useConfigStore = defineStore('config', () => {
       fodder_operators: fodder_operators.value,
       t5_operators: t5_operators.value,
       book_operators: book_operators.value,
-      hot_update: { enable: hot_update_enable.value },
+      hot_update: {
+        enable: hot_update_enable.value,
+        auto_update: hot_update_auto_update.value
+      },
       notification_level: notification_level.value,
       waiting_scene: waiting_scene.value,
       exipring_medicine_on_weekend: exipring_medicine_on_weekend.value,
@@ -610,6 +615,7 @@ export const useConfigStore = defineStore('config', () => {
     credit_fight,
     custom_screenshot,
     hot_update_enable,
+    hot_update_auto_update,
     notification_level,
     waiting_scene,
     exipring_medicine_on_weekend,

--- a/ui/src/stores/resourceVersion.js
+++ b/ui/src/stores/resourceVersion.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import axios from 'axios'
 
@@ -16,11 +16,22 @@ export const useResourceVersionStore = defineStore('resourceVersion', () => {
   const loaded = ref(false)
   const installing = ref(false)
   const install_message = ref('')
+  const canInstall = computed(
+    () => loaded.value && !loading.value && info.value.update_available === true
+  )
 
   async function loadResourceVersion(force = false) {
     if (loading.value) return info.value
     if (loaded.value && !force) return info.value
     loading.value = true
+    loaded.value = false
+    info.value = {
+      ...info.value,
+      remote_version: '',
+      remote_display: '',
+      update_available: null,
+      error: null
+    }
     try {
       const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/resource-version`)
       info.value = {
@@ -33,7 +44,13 @@ export const useResourceVersionStore = defineStore('resourceVersion', () => {
       }
       loaded.value = true
     } catch (error) {
-      info.value = { ...info.value, error: '网络错误：无法获取资源版本' }
+      info.value = {
+        ...info.value,
+        remote_version: '',
+        remote_display: '',
+        update_available: null,
+        error: '网络错误：无法获取资源版本'
+      }
     } finally {
       loading.value = false
     }
@@ -42,12 +59,23 @@ export const useResourceVersionStore = defineStore('resourceVersion', () => {
 
   async function loadResourceVersionLocal() {
     // 只读本地已装版本，常驻显示「当前版本」，不触碰网络。
+    loaded.value = false
+    info.value = {
+      ...info.value,
+      remote_version: '',
+      remote_display: '',
+      update_available: null,
+      error: null
+    }
     try {
       const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/resource-version?local=1`)
       info.value = {
         ...info.value,
         current_version: response.data.current_version || '',
         current_display: response.data.current_display || '',
+        remote_version: '',
+        remote_display: '',
+        update_available: null,
         error: null
       }
     } catch (error) {
@@ -56,7 +84,12 @@ export const useResourceVersionStore = defineStore('resourceVersion', () => {
   }
 
   async function installResource() {
-    if (installing.value) return
+    if (installing.value || !canInstall.value) {
+      if (!loading.value && !canInstall.value) {
+        install_message.value = '请先检查更新，发现新版本后再安装'
+      }
+      return false
+    }
     installing.value = true
     install_message.value = ''
     try {
@@ -66,8 +99,10 @@ export const useResourceVersionStore = defineStore('resourceVersion', () => {
         loaded.value = false
         await loadResourceVersion(true)
       }
+      return response.data.ok === true
     } catch (error) {
       install_message.value = error.response?.data?.message || '安装失败：网络错误'
+      return false
     } finally {
       installing.value = false
     }
@@ -79,6 +114,7 @@ export const useResourceVersionStore = defineStore('resourceVersion', () => {
     loaded,
     installing,
     install_message,
+    canInstall,
     loadResourceVersion,
     loadResourceVersionLocal,
     installResource

--- a/ui/src/stores/resourceVersion.test.js
+++ b/ui/src/stores/resourceVersion.test.js
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+import axios from 'axios'
+import { useResourceVersionStore } from './resourceVersion.js'
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn()
+  }
+}))
+
+describe('resource version store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('returns true and refreshes the version after a successful install', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        current_version: 'v2026.09.03-aaaaaaa',
+        remote_version: 'v2026.09.04-deadbee',
+        update_available: true
+      }
+    })
+    axios.post.mockResolvedValue({
+      data: { ok: true, message: '资源包安装成功，已生效，无需重启 Mower' }
+    })
+    axios.get.mockResolvedValueOnce({
+      data: {
+        current_version: 'v2026.09.04-deadbee',
+        update_available: false
+      }
+    })
+    const store = useResourceVersionStore()
+
+    await store.loadResourceVersion()
+    expect(store.canInstall).toBe(true)
+    await expect(store.installResource()).resolves.toBe(true)
+    expect(store.install_message).toBe('资源包安装成功，已生效，无需重启 Mower')
+    expect(store.info.current_version).toBe('v2026.09.04-deadbee')
+    expect(axios.get).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not install before a check finds a new version', async () => {
+    const store = useResourceVersionStore()
+
+    await expect(store.installResource()).resolves.toBe(false)
+    expect(axios.post).not.toHaveBeenCalled()
+    expect(store.install_message).toBe('请先检查更新，发现新版本后再安装')
+  })
+
+  it('clears a stale update result when a forced check fails', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        current_version: 'v2026.09.03-aaaaaaa',
+        remote_version: 'v2026.09.04-deadbee',
+        update_available: true
+      }
+    })
+    const store = useResourceVersionStore()
+    await store.loadResourceVersion()
+    expect(store.canInstall).toBe(true)
+
+    axios.get.mockRejectedValueOnce(new Error('network'))
+    await store.loadResourceVersion(true)
+
+    expect(store.canInstall).toBe(false)
+    expect(store.info.update_available).toBeNull()
+    expect(store.info.remote_version).toBe('')
+  })
+
+  it('returns false when the checked install request fails', async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        current_version: 'v2026.09.03-aaaaaaa',
+        remote_version: 'v2026.09.04-deadbee',
+        update_available: true
+      }
+    })
+    axios.post.mockRejectedValue(new Error('network'))
+    const store = useResourceVersionStore()
+
+    await store.loadResourceVersion()
+    await expect(store.installResource()).resolves.toBe(false)
+    expect(store.install_message).toBe('安装失败：网络错误')
+  })
+})


### PR DESCRIPTION
## 目标

资源包更新后直接在当前 mower 进程内生效，不再要求重启；同时补充自动检查、自动更新选项，并让首次安装能够显示随软件内置的初始资源版本。

## 主要改动

- 资源包原子切换后刷新已加载的 JSON 数据、公开招募模型、干员识别模型和专精数据缓存；刷新失败时同时回滚资源目录与进程内缓存。
- 保留已被其他模块导入的列表、字典和模型容器引用，避免热加载后出现新旧引用并存。
- 资源安装接口和手动更新结果统一标记为无需重启，资源图片响应禁用浏览器缓存，使新版图片刷新后立即可见。
- 新增“自动检查更新”和“自动更新”配置；开启自动更新时联动开启检查，严格按“检查发现新版本 → 安装”的顺序执行。
- 下载并安装按钮默认禁用，只有本次检查确认存在新资源版本后才开放；重新检查失败或只读取本地版本时会清除旧检查结果，避免按过期状态安装。
- 热更新在只开启自动检查时仅记录可用版本，不自动下载；开启自动更新后先检查版本，再沿用原有下载安装流程。
- 增加内置资源版本清单，首次安装显示初始资源版本；运行时安装的新资源包仍通过 overlay 版本覆盖显示。
- 本 PR 仅处理内置初始版本，MowerResource 跨仓库同步流程另行处理。

## 验证

- `ruff check .`：通过。
- 后端测试：816 项通过。
- 脚本测试：85 项通过，1 项跳过。
- 前端测试：23 项通过。
- `npm run build`：通过。
- `git diff --check`：通过。
- 已检查提交内容，不包含本机用户目录等绝对路径。
