### PR TITLE
feat(update): 新增 Maa 资源检查与更新

### DIFF
--- a/arknights_mower/tests/maa_resource_update_tests.py
+++ b/arknights_mower/tests/maa_resource_update_tests.py
@@ -1,0 +1,371 @@
+import json
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+from zipfile import ZipFile, ZipInfo
+
+import requests
+
+from arknights_mower.utils import maa_resource_update as mru
+
+
+def _version_payload(version: str, activity: str = "测试活动") -> dict:
+    return {
+        "activity": {"name": activity, "time": 0},
+        "last_updated": version,
+    }
+
+
+def _write_resource_zip(
+    path: Path,
+    version: str,
+    prefix: str = "MaaResource-main/resource",
+    files: dict[str, bytes] | None = None,
+) -> None:
+    with ZipFile(path, "w") as archive:
+        for name, data in (files or {}).items():
+            archive.writestr(f"{prefix}/{name}", data)
+        archive.writestr(
+            f"{prefix}/version.json",
+            json.dumps(_version_payload(version), ensure_ascii=False),
+        )
+
+
+class _JsonResponse:
+    def __init__(self, payload, status_error: Exception | None = None):
+        self.payload = payload
+        self.status_error = status_error
+
+    def raise_for_status(self):
+        if self.status_error:
+            raise self.status_error
+
+    def json(self):
+        return self.payload
+
+
+class TestMaaResourceVersion(unittest.TestCase):
+    def test_reads_local_resource_version(self):
+        with tempfile.TemporaryDirectory() as temp:
+            target = Path(temp)
+            version_file = target / "resource" / "version.json"
+            version_file.parent.mkdir()
+            version_file.write_text(
+                json.dumps(_version_payload("2026-09-04 01:07:54.000", "月行水上")),
+                encoding="utf-8",
+            )
+
+            info = mru.read_maa_resource_info(target)
+
+        self.assertEqual(info["version"], "2026-09-04 01:07:54.000")
+        self.assertEqual(info["release_note"], "月行水上")
+
+    def test_invalid_local_version_is_treated_as_unknown(self):
+        with tempfile.TemporaryDirectory() as temp:
+            target = Path(temp)
+            version_file = target / "resource" / "version.json"
+            version_file.parent.mkdir()
+            version_file.write_text('{"last_updated":"bad"}', encoding="utf-8")
+
+            info = mru.read_maa_resource_info(target)
+
+        self.assertEqual(info, {"version": "", "release_note": ""})
+
+    def test_github_release_uses_resource_version(self):
+        session = Mock()
+        session.get.return_value = _JsonResponse(
+            _version_payload("2026-09-04 01:07:54.000", "月行水上")
+        )
+
+        release = mru.get_github_resource_release(session)
+
+        self.assertEqual(release.version, "2026-09-04 01:07:54.000")
+        self.assertEqual(release.release_note, "月行水上")
+        self.assertEqual(release.source, "github")
+
+    def test_github_check_marks_same_version_as_current(self):
+        release = mru.MaaResourceRelease(
+            version="2026-09-04 01:07:54.000",
+            source="github",
+        )
+        with patch.object(mru, "get_github_resource_release", return_value=release):
+            checked = mru.get_maa_resource_release(
+                "github",
+                current_version="2026-09-04 01:07:54.000",
+            )
+
+        self.assertFalse(checked.available)
+
+    def test_github_check_marks_newer_version_available(self):
+        release = mru.MaaResourceRelease(
+            version="2026-09-04 01:07:54.000",
+            source="github",
+        )
+        with patch.object(mru, "get_github_resource_release", return_value=release):
+            checked = mru.get_maa_resource_release(
+                "github",
+                current_version="2026-09-03 01:00:00.000",
+            )
+
+        self.assertTrue(checked.available)
+
+    def test_mirrorchyan_release_request_does_not_use_app_channel(self):
+        session = Mock()
+        session.get.return_value = _JsonResponse(
+            {
+                "code": 0,
+                "data": {
+                    "version_name": "2026-09-04 01:07:54.000",
+                    "release_note": "月行水上",
+                    "url": "https://example.test/resource.zip",
+                    "filesize": 123,
+                    "sha256": "abc",
+                },
+            }
+        )
+
+        release = mru.get_mirrorchyan_resource_release(
+            "fixture-token",
+            current_version="2026-09-03 01:00:00.000",
+            session=session,
+        )
+
+        params = session.get.call_args.kwargs["params"]
+        self.assertNotIn("channel", params)
+        self.assertNotIn("os", params)
+        self.assertEqual(params["current_version"], "2026-09-03 01:00:00.000")
+        self.assertTrue(release.available)
+        self.assertEqual(release.size, 123)
+
+    def test_mirrorchyan_error_does_not_echo_token(self):
+        token = "fixture-sensitive-token"
+        session = Mock()
+        session.get.side_effect = requests.RequestException(
+            f"https://example.test/?cdk={token}"
+        )
+
+        with self.assertRaises(mru.MaaUpdateError) as context:
+            mru.get_mirrorchyan_resource_release(token, session=session)
+
+        self.assertNotIn(token, str(context.exception))
+
+    def test_mirrorchyan_expired_timestamp_is_rejected(self):
+        session = Mock()
+        session.get.return_value = _JsonResponse(
+            {
+                "code": 0,
+                "data": {
+                    "version_name": "2026-09-04 01:07:54.000",
+                    "url": "https://example.test/resource.zip",
+                    "cdk_expired_time": 1,
+                },
+            }
+        )
+
+        with self.assertRaisesRegex(mru.MaaUpdateError, "已过期"):
+            mru.get_mirrorchyan_resource_release(
+                "fixture-token",
+                current_version="2026-09-03 01:00:00.000",
+                session=session,
+            )
+
+
+class TestMaaResourceArchive(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.current = self.root / "current"
+        self.current.mkdir()
+        (self.current / "version.json").write_text(
+            json.dumps(_version_payload("2026-09-03 01:00:00.000")),
+            encoding="utf-8",
+        )
+        (self.current / "keep.json").write_text("old", encoding="utf-8")
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_github_archive_is_merged_without_deleting_old_files(self):
+        archive = self.root / "github.zip"
+        _write_resource_zip(
+            archive,
+            "2026-09-04 01:07:54.000",
+            files={"tasks.json": b"new"},
+        )
+        staged = self.root / "staged"
+
+        version = mru.merge_resource_archive(archive, self.current, staged)
+
+        self.assertEqual(version, "2026-09-04 01:07:54.000")
+        self.assertEqual((staged / "keep.json").read_text(), "old")
+        self.assertEqual((staged / "tasks.json").read_bytes(), b"new")
+
+    def test_mirrorchyan_root_resource_archive_is_supported(self):
+        archive = self.root / "mirror.zip"
+        _write_resource_zip(
+            archive,
+            "2026-09-04 01:07:54.000",
+            prefix="resource",
+            files={"template/item.png": b"image"},
+        )
+        staged = self.root / "staged"
+
+        mru.merge_resource_archive(archive, self.current, staged)
+
+        self.assertEqual((staged / "template" / "item.png").read_bytes(), b"image")
+
+    def test_path_traversal_is_rejected(self):
+        archive = self.root / "unsafe.zip"
+        with ZipFile(archive, "w") as z:
+            z.writestr("MaaResource-main/resource/../../escaped", b"bad")
+            z.writestr(
+                "MaaResource-main/resource/version.json",
+                json.dumps(_version_payload("2026-09-04 01:07:54.000")),
+            )
+
+        with self.assertRaisesRegex(mru.MaaUpdateError, "非法路径"):
+            mru.merge_resource_archive(archive, self.current, self.root / "staged")
+
+    def test_symlink_is_rejected(self):
+        archive = self.root / "symlink.zip"
+        with ZipFile(archive, "w") as z:
+            link = ZipInfo("MaaResource-main/resource/link")
+            link.create_system = 3
+            link.external_attr = (stat.S_IFLNK | 0o777) << 16
+            z.writestr(link, "target")
+            z.writestr(
+                "MaaResource-main/resource/version.json",
+                json.dumps(_version_payload("2026-09-04 01:07:54.000")),
+            )
+
+        with self.assertRaisesRegex(mru.MaaUpdateError, "符号链接"):
+            mru.merge_resource_archive(archive, self.current, self.root / "staged")
+
+    def test_existing_resource_symlink_is_rejected(self):
+        archive = self.root / "safe.zip"
+        _write_resource_zip(archive, "2026-09-04 01:07:54.000")
+        (self.current / "redirect").symlink_to(self.root)
+
+        with self.assertRaisesRegex(mru.MaaUpdateError, "符号链接"):
+            mru.merge_resource_archive(archive, self.current, self.root / "staged")
+
+
+class TestInstallMaaResource(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.target = Path(self.temp.name) / "MAA"
+        self.resource = self.target / "resource"
+        self.resource.mkdir(parents=True)
+        (self.target / "libMaaCore.dylib").write_bytes(b"core")
+        (self.resource / "version.json").write_text(
+            json.dumps(_version_payload("2026-09-03 01:00:00.000")),
+            encoding="utf-8",
+        )
+        (self.resource / "old.txt").write_text("current", encoding="utf-8")
+        self.package = self.target.parent / "resource.zip"
+        _write_resource_zip(
+            self.package,
+            "2026-09-04 01:07:54.000",
+            files={"new.txt": b"new"},
+        )
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def _install(self):
+        release = mru.MaaResourceRelease(
+            version="2026-09-04 01:07:54.000",
+            source="github",
+            url="https://example.test/resource.zip",
+            release_note="月行水上",
+        )
+
+        def fake_download(release, destination, **kwargs):
+            destination.write_bytes(self.package.read_bytes())
+            return destination.stat().st_size
+
+        with (
+            patch.object(mru, "get_github_resource_release", return_value=release),
+            patch.object(mru, "download_resource_archive", side_effect=fake_download),
+        ):
+            return mru.install_maa_resource_update(self.target, system="darwin")
+
+    def test_update_keeps_incremental_files_and_creates_backup(self):
+        old_backup = self.target / "resource.old"
+        old_backup.mkdir()
+        (old_backup / "older.txt").write_text("older", encoding="utf-8")
+
+        result = self._install()
+
+        self.assertTrue(result["updated"])
+        self.assertEqual(result["version"], "2026-09-04 01:07:54.000")
+        self.assertEqual((self.resource / "old.txt").read_text(), "current")
+        self.assertEqual((self.resource / "new.txt").read_text(), "new")
+        self.assertEqual((old_backup / "old.txt").read_text(), "current")
+        self.assertFalse((old_backup / "older.txt").exists())
+
+    def test_archive_version_mismatch_keeps_current_resource(self):
+        release = mru.MaaResourceRelease(
+            version="2026-09-05 01:07:54.000",
+            source="github",
+            url="https://example.test/resource.zip",
+        )
+
+        def fake_download(release, destination, **kwargs):
+            destination.write_bytes(self.package.read_bytes())
+            return destination.stat().st_size
+
+        with (
+            patch.object(mru, "get_github_resource_release", return_value=release),
+            patch.object(mru, "download_resource_archive", side_effect=fake_download),
+            self.assertRaisesRegex(mru.MaaUpdateError, "版本信息不一致"),
+        ):
+            mru.install_maa_resource_update(self.target, system="darwin")
+
+        self.assertEqual((self.resource / "old.txt").read_text(), "current")
+        self.assertEqual(
+            mru.read_maa_resource_info(self.target)["version"],
+            "2026-09-03 01:00:00.000",
+        )
+
+    def test_post_swap_validation_failure_restores_resource_and_previous_backup(self):
+        old_backup = self.target / "resource.old"
+        old_backup.mkdir()
+        (old_backup / "older.txt").write_text("older", encoding="utf-8")
+        release = mru.MaaResourceRelease(
+            version="2026-09-04 01:07:54.000",
+            source="github",
+            url="https://example.test/resource.zip",
+        )
+
+        def fake_download(release, destination, **kwargs):
+            destination.write_bytes(self.package.read_bytes())
+            return destination.stat().st_size
+
+        with (
+            patch.object(mru, "get_github_resource_release", return_value=release),
+            patch.object(mru, "download_resource_archive", side_effect=fake_download),
+            patch.object(
+                mru,
+                "read_maa_resource_info",
+                side_effect=[
+                    {
+                        "version": "2026-09-03 01:00:00.000",
+                        "release_note": "",
+                    },
+                    {"version": "", "release_note": ""},
+                ],
+            ),
+            self.assertRaisesRegex(mru.MaaUpdateError, "已回滚"),
+        ):
+            mru.install_maa_resource_update(self.target, system="darwin")
+
+        self.assertEqual((self.resource / "old.txt").read_text(), "current")
+        self.assertEqual((old_backup / "older.txt").read_text(), "older")
+        self.assertFalse((self.resource / "new.txt").exists())
+
+    def test_windows_keeps_resource_update_in_maa(self):
+        with self.assertRaisesRegex(mru.MaaUpdateError, "Maa 主程序"):
+            mru.install_maa_resource_update(self.target, system="windows")

--- a/arknights_mower/tests/maa_update_route_tests.py
+++ b/arknights_mower/tests/maa_update_route_tests.py
@@ -1,0 +1,250 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import server
+from arknights_mower.utils.maa_resource_update import MaaResourceRelease
+from arknights_mower.utils.maa_update import MaaRelease, ReleaseAsset
+
+
+def _maa_release(version: str) -> MaaRelease:
+    return MaaRelease(
+        tag=version,
+        runtime=ReleaseAsset(
+            name=f"MAA-{version}-macos-runtime-universal.zip",
+            url="https://example.test/maa.zip",
+            size=1,
+        ),
+    )
+
+
+class _FakeThread:
+    def __init__(self, *args, **kwargs):
+        self.started = False
+
+    def is_alive(self):
+        return False
+
+    def start(self):
+        self.started = True
+
+
+class TestMaaUpdateRoutes(unittest.TestCase):
+    def setUp(self):
+        self.client = server.app.test_client()
+        self.headers = {}
+        if hasattr(server.app, "token"):
+            self.headers["token"] = server.app.token
+        self.temp = tempfile.TemporaryDirectory()
+        self.target = str(Path(self.temp.name) / "MAA")
+        server.maa_update_check.update(
+            {
+                "id": "",
+                "target": "",
+                "source": "",
+                "channel": "",
+                "installed_version": "",
+                "latest_version": "",
+            }
+        )
+        server.maa_resource_update_check.update(
+            {
+                "id": "",
+                "target": "",
+                "source": "",
+                "current_version": "",
+                "latest_version": "",
+            }
+        )
+        server.maa_update_job.update({"thread": None, "status": "idle"})
+        server.maa_resource_update_job.update({"thread": None, "status": "idle"})
+
+    def tearDown(self):
+        server.maa_update_job.update({"thread": None, "status": "idle"})
+        server.maa_resource_update_job.update({"thread": None, "status": "idle"})
+        self.temp.cleanup()
+
+    def test_maa_check_returns_check_id_only_for_new_version(self):
+        with (
+            patch.object(server, "__system__", "darwin"),
+            patch(
+                "arknights_mower.utils.maa_update.has_maa_installation",
+                return_value=True,
+            ),
+            patch(
+                "arknights_mower.utils.maa_update.read_installed_version",
+                return_value="v6.17.0",
+            ),
+            patch(
+                "arknights_mower.utils.maa_update.get_latest_release",
+                return_value=_maa_release("v6.18.0"),
+            ),
+        ):
+            response = self.client.post(
+                "/maa-update/check",
+                json={
+                    "maa_path": self.target,
+                    "source": "github",
+                    "channel": "stable",
+                },
+                headers=self.headers,
+            )
+
+        data = response.get_json()
+        self.assertTrue(data["ok"])
+        self.assertTrue(data["available"])
+        self.assertTrue(data["check_id"])
+
+        with (
+            patch.object(server, "__system__", "darwin"),
+            patch(
+                "arknights_mower.utils.maa_update.has_maa_installation",
+                return_value=True,
+            ),
+            patch(
+                "arknights_mower.utils.maa_update.read_installed_version",
+                return_value="v6.18.0",
+            ),
+            patch(
+                "arknights_mower.utils.maa_update.get_latest_release",
+                return_value=_maa_release("v6.18.0"),
+            ),
+        ):
+            response = self.client.post(
+                "/maa-update/check",
+                json={
+                    "maa_path": self.target,
+                    "source": "github",
+                    "channel": "stable",
+                },
+                headers=self.headers,
+            )
+
+        data = response.get_json()
+        self.assertTrue(data["ok"])
+        self.assertFalse(data["available"])
+        self.assertEqual(data["check_id"], "")
+
+    def test_maa_update_start_requires_matching_successful_check(self):
+        with (
+            patch.object(server, "__system__", "darwin"),
+            patch.object(server, "_mower_busy_response", return_value=None),
+            patch(
+                "arknights_mower.utils.maa_update.has_maa_installation",
+                return_value=True,
+            ),
+            patch(
+                "arknights_mower.utils.maa_update.read_installed_version",
+                return_value="v6.17.0",
+            ),
+        ):
+            response = self.client.post(
+                "/maa-update/start",
+                json={
+                    "maa_path": self.target,
+                    "source": "github",
+                    "channel": server.config.conf.maa_update_channel,
+                },
+                headers=self.headers,
+            )
+
+        data = response.get_json()
+        self.assertFalse(data["ok"])
+        self.assertIn("先检查 Maa 更新", data["message"])
+
+    def test_maa_update_start_accepts_matching_successful_check(self):
+        target = str(Path(self.target).expanduser())
+        channel = server.config.conf.maa_update_channel
+        check_id = server._record_update_check(
+            server.maa_update_check,
+            server.maa_update_check_lock,
+            target=target,
+            source="github",
+            channel=channel,
+            installed_version="v6.17.0",
+            latest_version="v6.18.0",
+        )
+        with (
+            patch.object(server, "__system__", "darwin"),
+            patch.object(server, "Thread", _FakeThread),
+            patch.object(server, "_mower_busy_response", return_value=None),
+            patch(
+                "arknights_mower.utils.maa_update.has_maa_installation",
+                return_value=True,
+            ),
+            patch(
+                "arknights_mower.utils.maa_update.read_installed_version",
+                return_value="v6.17.0",
+            ),
+        ):
+            response = self.client.post(
+                "/maa-update/start",
+                json={
+                    "maa_path": target,
+                    "source": "github",
+                    "channel": channel,
+                    "check_id": check_id,
+                },
+                headers=self.headers,
+            )
+
+        data = response.get_json()
+        self.assertTrue(data["ok"])
+        self.assertEqual(server.maa_update_check["id"], "")
+
+    def test_resource_check_and_start_use_separate_check_result(self):
+        current = {"version": "2026-09-03 01:00:00.000", "release_note": ""}
+        release = MaaResourceRelease(
+            version="2026-09-04 01:07:54.000",
+            source="github",
+            available=True,
+        )
+        with (
+            patch.object(server, "__system__", "darwin"),
+            patch(
+                "arknights_mower.utils.maa_update.has_maa_installation",
+                return_value=True,
+            ),
+            patch(
+                "arknights_mower.utils.maa_resource_update.read_maa_resource_info",
+                return_value=current,
+            ),
+            patch(
+                "arknights_mower.utils.maa_resource_update.get_maa_resource_release",
+                return_value=release,
+            ),
+        ):
+            checked = self.client.post(
+                "/maa-resource-update/check",
+                json={"maa_path": self.target, "source": "github"},
+                headers=self.headers,
+            ).get_json()
+
+        self.assertTrue(checked["available"])
+        self.assertTrue(checked["check_id"])
+
+        with (
+            patch.object(server, "__system__", "darwin"),
+            patch(
+                "arknights_mower.utils.maa_update.has_maa_installation",
+                return_value=True,
+            ),
+            patch(
+                "arknights_mower.utils.maa_resource_update.read_maa_resource_info",
+                return_value=current,
+            ),
+        ):
+            response = self.client.post(
+                "/maa-resource-update/start",
+                json={"maa_path": self.target, "source": "github"},
+                headers=self.headers,
+            )
+
+        data = response.get_json()
+        self.assertFalse(data["ok"])
+        self.assertIn("先检查 Maa 资源更新", data["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/maa_update_route_tests.py
+++ b/arknights_mower/tests/maa_update_route_tests.py
@@ -193,6 +193,45 @@ class TestMaaUpdateRoutes(unittest.TestCase):
         self.assertTrue(data["ok"])
         self.assertEqual(server.maa_update_check["id"], "")
 
+    def test_maa_update_start_rejects_equal_checked_version(self):
+        target = str(Path(self.target).expanduser())
+        channel = server.config.conf.maa_update_channel
+        check_id = server._record_update_check(
+            server.maa_update_check,
+            server.maa_update_check_lock,
+            target=target,
+            source="github",
+            channel=channel,
+            installed_version="v6.18.0",
+            latest_version="v6.18.0",
+        )
+        with (
+            patch.object(server, "__system__", "darwin"),
+            patch.object(server, "_mower_busy_response", return_value=None),
+            patch(
+                "arknights_mower.utils.maa_update.has_maa_installation",
+                return_value=True,
+            ),
+            patch(
+                "arknights_mower.utils.maa_update.read_installed_version",
+                return_value="v6.18.0",
+            ),
+        ):
+            response = self.client.post(
+                "/maa-update/start",
+                json={
+                    "maa_path": target,
+                    "source": "github",
+                    "channel": channel,
+                    "check_id": check_id,
+                },
+                headers=self.headers,
+            )
+
+        data = response.get_json()
+        self.assertFalse(data["ok"])
+        self.assertIn("发现新版本后再更新", data["message"])
+
     def test_resource_check_and_start_use_separate_check_result(self):
         current = {"version": "2026-09-03 01:00:00.000", "release_note": ""}
         release = MaaResourceRelease(
@@ -244,6 +283,42 @@ class TestMaaUpdateRoutes(unittest.TestCase):
         data = response.get_json()
         self.assertFalse(data["ok"])
         self.assertIn("先检查 Maa 资源更新", data["message"])
+
+    def test_resource_update_start_rejects_equal_checked_version(self):
+        target = str(Path(self.target).expanduser())
+        version = "2026-09-04 01:07:54.000"
+        check_id = server._record_update_check(
+            server.maa_resource_update_check,
+            server.maa_resource_update_check_lock,
+            target=target,
+            source="github",
+            current_version=version,
+            latest_version=version,
+        )
+        with (
+            patch.object(server, "__system__", "darwin"),
+            patch(
+                "arknights_mower.utils.maa_update.has_maa_installation",
+                return_value=True,
+            ),
+            patch(
+                "arknights_mower.utils.maa_resource_update.read_maa_resource_info",
+                return_value={"version": version, "release_note": ""},
+            ),
+        ):
+            response = self.client.post(
+                "/maa-resource-update/start",
+                json={
+                    "maa_path": target,
+                    "source": "github",
+                    "check_id": check_id,
+                },
+                headers=self.headers,
+            )
+
+        data = response.get_json()
+        self.assertFalse(data["ok"])
+        self.assertIn("发现新版本后再更新", data["message"])
 
 
 if __name__ == "__main__":

--- a/arknights_mower/tests/maa_update_tests.py
+++ b/arknights_mower/tests/maa_update_tests.py
@@ -22,6 +22,15 @@ def _asset(name: str, size: int = 100) -> dict:
 
 
 class TestReleaseParsing(unittest.TestCase):
+    def test_compares_stable_and_beta_versions(self):
+        self.assertTrue(mu.is_maa_version_newer("v6.18.0", "v6.17.0"))
+        self.assertTrue(mu.is_maa_version_newer("v6.18.0-beta.2", "v6.18.0-beta.1"))
+        self.assertFalse(mu.is_maa_version_newer("v6.17.0", "v6.17.0"))
+
+    def test_invalid_version_comparison_is_rejected(self):
+        with self.assertRaisesRegex(mu.MaaUpdateError, "版本号格式无效"):
+            mu.is_maa_version_newer("latest", "v6.17.0")
+
     def test_selects_runtime_and_arm64_python_source(self):
         release = mu.parse_release(
             {

--- a/arknights_mower/utils/maa_resource_update.py
+++ b/arknights_mower/utils/maa_resource_update.py
@@ -1,0 +1,507 @@
+"""macOS 与 Linux 的 MaaResource 独立更新支持。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import stat
+import tempfile
+import time
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable
+from urllib.parse import urlsplit
+from zipfile import BadZipFile, ZipFile, ZipInfo
+
+import requests
+
+from arknights_mower.utils.maa_update import (
+    MaaUpdateError,
+    backup_path_for,
+    has_maa_installation,
+    mirrorchyan_sp_id,
+    replace_with_backup,
+)
+from arknights_mower.utils.zip_safe import is_unsafe_zip_member
+
+GITHUB_RESOURCE_VERSION_URL = (
+    "https://raw.githubusercontent.com/"
+    "MaaAssistantArknights/MaaResource/main/resource/version.json"
+)
+GITHUB_RESOURCE_ARCHIVE_URL = (
+    "https://github.com/MaaAssistantArknights/MaaResource/archive/refs/heads/main.zip"
+)
+MIRRORCHYAN_RESOURCE_API = "https://mirrorchyan.com/api/resources/MaaResource/latest"
+REQUEST_TIMEOUT = (10, 60)
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+MAX_RESOURCE_FILES = 100_000
+MAX_RESOURCE_SIZE = 2 * 1024 * 1024 * 1024
+RESOURCE_VERSION_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
+
+ProgressCallback = Callable[[str, int, int, str], None]
+
+_MIRRORCHYAN_ERRORS = {
+    1001: "Mirror酱请求参数错误",
+    7001: "Mirror酱 CDK 已过期，请使用新的 CDK。",
+    7002: "Mirror酱 CDK 无效，请检查输入是否正确。",
+    7003: "Mirror酱 CDK 今日下载次数已达上限。",
+    7004: "Mirror酱 CDK 与 MaaResource 不匹配。",
+    7005: "Mirror酱 CDK 已失效（已被封禁）。",
+    8001: "Mirror酱中没有 MaaResource 资源",
+}
+
+
+@dataclass(frozen=True)
+class MaaResourceRelease:
+    version: str
+    source: str
+    url: str = ""
+    size: int = 0
+    sha256: str = ""
+    release_note: str = ""
+    available: bool = True
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "source": self.source,
+            "release_note": self.release_note,
+            "available": self.available,
+        }
+
+
+def _emit(
+    callback: ProgressCallback | None,
+    phase: str,
+    current: int,
+    total: int,
+    message: str,
+) -> None:
+    if callback is not None:
+        callback(phase, current, total, message)
+
+
+def parse_resource_version(value: str) -> datetime:
+    """把 MaaResource ``last_updated`` 解析为 UTC 时间。"""
+    try:
+        return datetime.strptime(value, RESOURCE_VERSION_FORMAT).replace(
+            tzinfo=timezone.utc
+        )
+    except (TypeError, ValueError):
+        raise MaaUpdateError("Maa 资源版本格式无效") from None
+
+
+def _resource_info_from_payload(payload: Any) -> dict[str, str]:
+    if not isinstance(payload, dict):
+        raise MaaUpdateError("Maa 资源版本文件格式无效")
+    version = payload.get("last_updated")
+    if not isinstance(version, str) or not version.strip():
+        raise MaaUpdateError("Maa 资源版本文件缺少 last_updated")
+    version = version.strip()
+    parse_resource_version(version)
+    activity = payload.get("activity")
+    activity_name = activity.get("name") if isinstance(activity, dict) else ""
+    return {
+        "version": version,
+        "release_note": activity_name if isinstance(activity_name, str) else "",
+    }
+
+
+def read_maa_resource_info(target: Path | str) -> dict[str, str]:
+    """读取安装目录中 ``resource/version.json`` 的资源版本。"""
+    version_file = Path(target).expanduser() / "resource" / "version.json"
+    try:
+        payload = json.loads(version_file.read_text(encoding="utf-8"))
+        return _resource_info_from_payload(payload)
+    except (OSError, json.JSONDecodeError, MaaUpdateError):
+        return {"version": "", "release_note": ""}
+
+
+def resource_backup_path(target: Path | str) -> Path:
+    return backup_path_for(Path(target).expanduser() / "resource")
+
+
+def get_github_resource_release(
+    session: requests.Session | None = None,
+) -> MaaResourceRelease:
+    """读取 MaaResource main 分支的最新资源版本。"""
+    client = session or requests.Session()
+    try:
+        response = client.get(GITHUB_RESOURCE_VERSION_URL, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        info = _resource_info_from_payload(response.json())
+    except MaaUpdateError:
+        raise
+    except (requests.RequestException, ValueError):
+        raise MaaUpdateError("获取最新 Maa 资源版本失败") from None
+    return MaaResourceRelease(
+        version=info["version"],
+        source="github",
+        url=GITHUB_RESOURCE_ARCHIVE_URL,
+        release_note=info["release_note"],
+    )
+
+
+def _mirrorchyan_error(code: int) -> str:
+    return _MIRRORCHYAN_ERRORS.get(code, "Mirror酱服务返回业务错误")
+
+
+def get_mirrorchyan_resource_release(
+    token: str,
+    current_version: str = "",
+    session: requests.Session | None = None,
+) -> MaaResourceRelease:
+    """通过 Mirror酱检查 MaaResource 增量更新。"""
+    token = token.strip()
+    if not token:
+        raise MaaUpdateError("请填写 Mirror酱 CDK")
+    if current_version:
+        parse_resource_version(current_version)
+    client = session or requests.Session()
+    params = {
+        "current_version": current_version or "1970-01-01 00:00:00.000",
+        "cdk": token,
+        "user_agent": "arknights_mower",
+        "sp_id": mirrorchyan_sp_id(),
+    }
+    try:
+        response = client.get(
+            MIRRORCHYAN_RESOURCE_API,
+            params=params,
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError):
+        # requests 的异常可能包含带 CDK 的完整 URL，不向上回显原异常。
+        raise MaaUpdateError("连接 Mirror酱服务失败") from None
+    if not isinstance(payload, dict):
+        raise MaaUpdateError("Mirror酱返回了无效数据")
+    try:
+        code = int(payload.get("code"))
+    except (TypeError, ValueError):
+        raise MaaUpdateError("Mirror酱返回了无效状态码") from None
+    if code != 0:
+        raise MaaUpdateError(_mirrorchyan_error(code))
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise MaaUpdateError("Mirror酱返回的 MaaResource 信息不完整")
+    expires_at = data.get("cdk_expired_time")
+    try:
+        normalized_expires_at = int(expires_at or 0)
+    except (TypeError, ValueError):
+        normalized_expires_at = 0
+    if normalized_expires_at and normalized_expires_at <= int(time.time()):
+        raise MaaUpdateError(_MIRRORCHYAN_ERRORS[7001])
+    version = data.get("version_name")
+    if not isinstance(version, str):
+        raise MaaUpdateError("Mirror酱返回的 Maa 资源版本无效")
+    version = version.strip()
+    remote_time = parse_resource_version(version)
+    available = not current_version or remote_time > parse_resource_version(
+        current_version
+    )
+    url = data.get("url")
+    if available:
+        if not isinstance(url, str) or urlsplit(url).scheme != "https":
+            raise MaaUpdateError("Mirror酱没有返回有效的 MaaResource 下载地址")
+    else:
+        url = ""
+    size = data.get("filesize")
+    try:
+        normalized_size = max(int(size or 0), 0)
+    except (TypeError, ValueError):
+        normalized_size = 0
+    checksum = data.get("sha256")
+    release_note = data.get("release_note")
+    return MaaResourceRelease(
+        version=version,
+        source="mirrorchyan",
+        url=url,
+        size=normalized_size,
+        sha256=checksum if isinstance(checksum, str) else "",
+        release_note=release_note if isinstance(release_note, str) else "",
+        available=available,
+    )
+
+
+def get_maa_resource_release(
+    source: str,
+    current_version: str = "",
+    mirror_token: str = "",
+    session: requests.Session | None = None,
+) -> MaaResourceRelease:
+    """按所选更新源检查 MaaResource，并统一计算是否有新版本。"""
+    client = session or requests.Session()
+    if source == "mirrorchyan":
+        return get_mirrorchyan_resource_release(
+            mirror_token,
+            current_version=current_version,
+            session=client,
+        )
+    if source != "github":
+        raise MaaUpdateError("未知的 Maa 资源更新源")
+    release = get_github_resource_release(client)
+    return replace(
+        release,
+        available=not current_version
+        or parse_resource_version(release.version)
+        > parse_resource_version(current_version),
+    )
+
+
+def download_resource_archive(
+    release: MaaResourceRelease,
+    destination: Path,
+    session: requests.Session | None = None,
+    callback: ProgressCallback | None = None,
+) -> int:
+    """流式下载 MaaResource ZIP，并校验可用的大小与 SHA-256。"""
+    if not release.url:
+        raise MaaUpdateError("没有可下载的 MaaResource 更新包")
+    client = session or requests.Session()
+    part_path = destination.with_suffix(destination.suffix + ".part")
+    downloaded = 0
+    digest = hashlib.sha256()
+    try:
+        with client.get(
+            release.url,
+            stream=True,
+            timeout=REQUEST_TIMEOUT,
+        ) as response:
+            response.raise_for_status()
+            total = int(response.headers.get("Content-Length") or release.size or 0)
+            with part_path.open("wb") as target:
+                for chunk in response.iter_content(DOWNLOAD_CHUNK_SIZE):
+                    if not chunk:
+                        continue
+                    target.write(chunk)
+                    digest.update(chunk)
+                    downloaded += len(chunk)
+                    _emit(
+                        callback,
+                        "downloading",
+                        downloaded,
+                        total,
+                        f"正在通过 {'Mirror酱' if release.source == 'mirrorchyan' else 'GitHub'}下载 Maa 资源包",
+                    )
+    except requests.RequestException:
+        raise MaaUpdateError("下载 Maa 资源包失败") from None
+    finally:
+        if part_path.exists() and downloaded == 0:
+            part_path.unlink()
+    if release.size and downloaded != release.size:
+        part_path.unlink(missing_ok=True)
+        raise MaaUpdateError(f"Maa 资源包下载不完整：{downloaded}/{release.size} 字节")
+    if release.sha256 and digest.hexdigest().lower() != release.sha256.lower():
+        part_path.unlink(missing_ok=True)
+        raise MaaUpdateError("Maa 资源包 SHA-256 校验失败")
+    os.replace(part_path, destination)
+    return downloaded
+
+
+def _zip_info_is_symlink(info: ZipInfo) -> bool:
+    return stat.S_IFMT(info.external_attr >> 16) == stat.S_IFLNK
+
+
+def _resource_relative_path(info: ZipInfo) -> PurePosixPath | None:
+    path = PurePosixPath(info.filename)
+    parts = path.parts
+    if len(parts) >= 2 and parts[:2] == ("MaaResource-main", "resource"):
+        return PurePosixPath(*parts[2:])
+    if parts and parts[0] == "resource":
+        return PurePosixPath(*parts[1:])
+    return None
+
+
+def _inspect_resource_archive(archive: ZipFile) -> tuple[str, list[ZipInfo]]:
+    infos = archive.infolist()
+    if len(infos) > MAX_RESOURCE_FILES:
+        raise MaaUpdateError("Maa 资源包文件数量异常")
+    if sum(info.file_size for info in infos) > MAX_RESOURCE_SIZE:
+        raise MaaUpdateError("Maa 资源包解压后体积异常")
+    resource_infos: list[ZipInfo] = []
+    version_infos: list[ZipInfo] = []
+    for info in infos:
+        if is_unsafe_zip_member(info.filename):
+            raise MaaUpdateError("Maa 资源包包含非法路径")
+        if _zip_info_is_symlink(info):
+            raise MaaUpdateError("Maa 资源包包含不支持的符号链接")
+        relative = _resource_relative_path(info)
+        if relative is None or not relative.parts:
+            continue
+        resource_infos.append(info)
+        if relative == PurePosixPath("version.json"):
+            version_infos.append(info)
+    if len(version_infos) != 1:
+        raise MaaUpdateError("Maa 资源包缺少唯一的 resource/version.json")
+    try:
+        payload = json.loads(archive.read(version_infos[0]).decode("utf-8"))
+        version = _resource_info_from_payload(payload)["version"]
+    except (KeyError, UnicodeDecodeError, json.JSONDecodeError):
+        raise MaaUpdateError("Maa 资源包中的 version.json 无效") from None
+    return version, resource_infos
+
+
+def _ensure_current_resource_tree_safe(current_resource: Path) -> None:
+    if current_resource.is_symlink():
+        raise MaaUpdateError("Maa resource 目录不能是符号链接")
+    for path in current_resource.rglob("*"):
+        if path.is_symlink():
+            raise MaaUpdateError("Maa resource 目录包含不支持的符号链接")
+
+
+def merge_resource_archive(
+    archive_path: Path,
+    current_resource: Path,
+    staged_resource: Path,
+    callback: ProgressCallback | None = None,
+) -> str:
+    """把增量资源覆盖到旧资源副本，返回包内资源版本。"""
+    if not current_resource.is_dir():
+        raise MaaUpdateError("Maa 安装目录中没有 resource 文件夹")
+    _ensure_current_resource_tree_safe(current_resource)
+    try:
+        shutil.copytree(current_resource, staged_resource)
+    except OSError as e:
+        raise MaaUpdateError(f"复制现有 Maa 资源失败：{e}") from e
+    try:
+        with ZipFile(archive_path) as archive:
+            version, infos = _inspect_resource_archive(archive)
+            version_info = next(
+                info
+                for info in infos
+                if _resource_relative_path(info) == PurePosixPath("version.json")
+            )
+            ordered = [info for info in infos if info is not version_info]
+            ordered.append(version_info)
+            files = [info for info in ordered if not info.is_dir()]
+            file_index = 0
+            for info in ordered:
+                relative = _resource_relative_path(info)
+                if relative is None:
+                    continue
+                destination = staged_resource.joinpath(*relative.parts)
+                if info.is_dir():
+                    destination.mkdir(parents=True, exist_ok=True)
+                    continue
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                with archive.open(info) as source, destination.open("wb") as target:
+                    shutil.copyfileobj(source, target)
+                file_index += 1
+                _emit(
+                    callback,
+                    "merging",
+                    file_index,
+                    len(files),
+                    "正在合并 Maa 增量资源",
+                )
+    except BadZipFile:
+        raise MaaUpdateError("Maa 资源包不是有效的 ZIP") from None
+    except (OSError, RuntimeError) as e:
+        raise MaaUpdateError(f"合并 Maa 资源包失败：{e}") from e
+    try:
+        payload = json.loads(
+            (staged_resource / "version.json").read_text(encoding="utf-8")
+        )
+        staged_info = _resource_info_from_payload(payload)
+    except (OSError, json.JSONDecodeError, MaaUpdateError):
+        staged_info = {"version": "", "release_note": ""}
+    if staged_info["version"] != version:
+        raise MaaUpdateError("合并后的 Maa 资源版本校验失败")
+    return version
+
+
+def install_maa_resource_update(
+    target: Path | str,
+    source: str = "github",
+    mirror_token: str = "",
+    system: str = "darwin",
+    session: requests.Session | None = None,
+    callback: ProgressCallback | None = None,
+) -> dict[str, Any]:
+    """检查并原子合并 MaaResource；Windows 由 Maa 主程序负责。"""
+    system = system.lower()
+    if system not in {"darwin", "linux"}:
+        raise MaaUpdateError("当前平台请在 Maa 主程序中更新 Maa 资源")
+    target_path = Path(target).expanduser()
+    if not has_maa_installation(target_path):
+        raise MaaUpdateError("请先下载并设置有效的 Maa 目录")
+    resource_path = target_path / "resource"
+    if not resource_path.is_dir():
+        raise MaaUpdateError("Maa 安装目录中没有 resource 文件夹")
+    if source not in {"github", "mirrorchyan"}:
+        raise MaaUpdateError("未知的 Maa 资源更新源")
+
+    current = read_maa_resource_info(target_path)
+    _emit(callback, "checking", 0, 0, "正在检查 Maa 资源更新")
+    client = session or requests.Session()
+    release = get_maa_resource_release(
+        source,
+        current_version=current["version"],
+        mirror_token=mirror_token,
+        session=client,
+    )
+    if not release.available:
+        return {
+            "updated": False,
+            "source": release.source,
+            "version": current["version"] or release.version,
+            "previous_version": current["version"],
+            "release_note": release.release_note,
+            "target": str(target_path),
+            "backup": str(resource_backup_path(target_path)),
+            "downloaded": 0,
+        }
+
+    with tempfile.TemporaryDirectory(
+        prefix=".maa-resource-update-", dir=target_path
+    ) as temp:
+        work_dir = Path(temp)
+        archive_path = work_dir / "MaaResource.zip"
+        staged_resource = work_dir / "resource"
+        downloaded = download_resource_archive(
+            release,
+            archive_path,
+            session=client,
+            callback=callback,
+        )
+        merged_version = merge_resource_archive(
+            archive_path,
+            resource_path,
+            staged_resource,
+            callback=callback,
+        )
+        if merged_version != release.version:
+            raise MaaUpdateError("下载包与 Maa 资源版本信息不一致")
+        _emit(callback, "installing", 0, 0, "正在切换 Maa 资源并保留回滚副本")
+        try:
+            backup = replace_with_backup(staged_resource, resource_path, work_dir)
+        except OSError as e:
+            raise MaaUpdateError(f"替换 Maa 资源目录失败：{e}") from e
+        installed = read_maa_resource_info(target_path)
+        if installed["version"] != release.version:
+            failed_resource = work_dir / "failed-resource"
+            previous_backup = work_dir / "previous.old"
+            try:
+                os.replace(resource_path, failed_resource)
+                os.replace(backup, resource_path)
+                if previous_backup.exists():
+                    os.replace(previous_backup, backup)
+            except OSError as e:
+                raise MaaUpdateError(f"Maa 资源版本校验失败且回滚失败：{e}") from e
+            raise MaaUpdateError("更新后重新读取 Maa 资源版本失败，已回滚")
+
+    return {
+        "updated": True,
+        "source": release.source,
+        "version": installed["version"],
+        "previous_version": current["version"],
+        "release_note": release.release_note,
+        "target": str(target_path),
+        "backup": str(backup),
+        "downloaded": downloaded,
+    }

--- a/arknights_mower/utils/maa_update.py
+++ b/arknights_mower/utils/maa_update.py
@@ -30,6 +30,7 @@ from urllib.parse import urlsplit
 from zipfile import BadZipFile, ZipFile, ZipInfo
 
 import requests
+from packaging.version import InvalidVersion, Version
 
 from arknights_mower.utils.zip_safe import is_unsafe_zip_member
 
@@ -171,6 +172,14 @@ def normalize_update_channel(channel: str | None = None) -> str:
     if normalized not in {"stable", "beta"}:
         raise MaaUpdateError(f"未知的 MAA 版本通道：{normalized or '未知'}")
     return normalized
+
+
+def is_maa_version_newer(latest: str, installed: str) -> bool:
+    """按 MAA 使用的 SemVer 版本号判断是否存在更新。"""
+    try:
+        return Version(latest.strip()) > Version(installed.strip())
+    except (AttributeError, InvalidVersion):
+        raise MaaUpdateError("Maa 版本号格式无效，请检查安装目录") from None
 
 
 def parse_release(

--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ from functools import wraps
 from io import BytesIO
 from pathlib import Path
 from threading import RLock, Thread
+from uuid import uuid4
 
 from flask import Flask, abort, request, send_file, send_from_directory
 from flask_cors import CORS
@@ -104,6 +105,39 @@ maa_update_job = {
     "result": None,
 }
 maa_update_lock = RLock()
+maa_update_check = {
+    "id": "",
+    "target": "",
+    "source": "",
+    "channel": "",
+    "installed_version": "",
+    "latest_version": "",
+}
+maa_update_check_lock = RLock()
+
+maa_resource_update_job = {
+    "thread": None,
+    "status": "idle",
+    "phase": "idle",
+    "message": "",
+    "current": 0,
+    "total": 0,
+    "progress": None,
+    "version": "",
+    "source": "github",
+    "target": "",
+    "result": None,
+}
+maa_resource_update_lock = RLock()
+maa_resource_update_check = {
+    "id": "",
+    "target": "",
+    "source": "",
+    "current_version": "",
+    "latest_version": "",
+}
+maa_resource_update_check_lock = RLock()
+maa_maintenance_lock = RLock()
 
 
 def _collect_maa_check_result():
@@ -149,6 +183,50 @@ def _maa_update_snapshot() -> dict:
         return {key: value for key, value in maa_update_job.items() if key != "thread"}
 
 
+def _maa_resource_update_snapshot() -> dict:
+    with maa_resource_update_lock:
+        return {
+            key: value
+            for key, value in maa_resource_update_job.items()
+            if key != "thread"
+        }
+
+
+def _job_running(job: dict) -> bool:
+    thread = job.get("thread")
+    return job.get("status") == "running" or (thread is not None and thread.is_alive())
+
+
+def _record_update_check(check: dict, lock: RLock, **values: str) -> str:
+    check_id = uuid4().hex
+    with lock:
+        check.clear()
+        check.update({"id": check_id, **values})
+    return check_id
+
+
+def _clear_update_check(check: dict, lock: RLock) -> None:
+    with lock:
+        check["id"] = ""
+
+
+def _consume_update_check(
+    check: dict,
+    lock: RLock,
+    check_id: str,
+    **expected: str,
+) -> bool:
+    with lock:
+        matched = (
+            bool(check_id)
+            and check.get("id") == check_id
+            and all(check.get(key) == value for key, value in expected.items())
+        )
+        if matched:
+            check["id"] = ""
+        return matched
+
+
 def _set_maa_update_progress(
     phase: str,
     current: int,
@@ -160,6 +238,28 @@ def _set_maa_update_progress(
         progress = min(100, round(current * 100 / total, 1))
     with maa_update_lock:
         maa_update_job.update(
+            {
+                "status": "running",
+                "phase": phase,
+                "message": message,
+                "current": current,
+                "total": total,
+                "progress": progress,
+            }
+        )
+
+
+def _set_maa_resource_update_progress(
+    phase: str,
+    current: int,
+    total: int,
+    message: str,
+) -> None:
+    progress = None
+    if total > 0:
+        progress = min(100, round(current * 100 / total, 1))
+    with maa_resource_update_lock:
+        maa_resource_update_job.update(
             {
                 "status": "running",
                 "phase": phase,
@@ -251,6 +351,66 @@ def _run_maa_update(
                 "source": result["source"],
                 "channel": result["channel"],
                 "operation": result["operation"],
+                "result": result,
+                "thread": None,
+            }
+        )
+
+
+def _run_maa_resource_update(
+    target: str,
+    source: str,
+    mirror_token: str,
+    system: str,
+) -> None:
+    from arknights_mower.utils.maa_resource_update import (
+        install_maa_resource_update,
+        read_maa_resource_info,
+    )
+    from arknights_mower.utils.maa_update import clear_loaded_maa_cache
+
+    try:
+        result = install_maa_resource_update(
+            target,
+            source=source,
+            mirror_token=mirror_token,
+            system=system,
+            callback=_set_maa_resource_update_progress,
+        )
+        if result["updated"]:
+            clear_loaded_maa_cache(result["target"])
+        result["installed"] = read_maa_resource_info(result["target"])
+    except Exception as e:
+        logger.exception(f"Maa 资源更新失败：{e}")
+        with maa_resource_update_lock:
+            maa_resource_update_job.update(
+                {
+                    "status": "error",
+                    "phase": "error",
+                    "message": f"Maa 资源更新失败：{e}",
+                    "progress": None,
+                    "result": None,
+                    "thread": None,
+                }
+            )
+        return
+
+    source_label = "Mirror酱" if result["source"] == "mirrorchyan" else "GitHub"
+    if result["updated"]:
+        message = f"Maa 资源 {result['version']} 已通过 {source_label}更新完成"
+    else:
+        message = f"Maa 资源 {result['version']} 已是最新版本"
+    with maa_resource_update_lock:
+        maa_resource_update_job.update(
+            {
+                "status": "success",
+                "phase": "success",
+                "message": message,
+                "current": 0,
+                "total": 0,
+                "progress": 100,
+                "version": result["version"],
+                "source": result["source"],
                 "result": result,
                 "thread": None,
             }
@@ -513,33 +673,39 @@ def start(start_type):
     global mower_thread
     global log_lines
 
-    if mower_thread and mower_thread.is_alive():
-        return "false"
-    # 创建 tmp 文件夹
-    tmp_dir = get_path("@app/tmp")
-    tmp_dir.mkdir(exist_ok=True)
+    with maa_maintenance_lock:
+        if (
+            mower_thread
+            and mower_thread.is_alive()
+            or _job_running(maa_update_job)
+            or _job_running(maa_resource_update_job)
+        ):
+            return "false"
+        # 创建 tmp 文件夹
+        tmp_dir = get_path("@app/tmp")
+        tmp_dir.mkdir(exist_ok=True)
 
-    config.stop_mower.clear()
-    saved_state = load_state()
-    if saved_state is None or start_type == "2":
-        saved_state = {}
-    if start_type == "1":
-        saved_state["tasks"] = []
-    restart_after_mood_read = (
-        start_type == "2" and config.conf.refresh_backup_plan_after_mood
-    )
-    from arknights_mower.__main__ import main
+        config.stop_mower.clear()
+        saved_state = load_state()
+        if saved_state is None or start_type == "2":
+            saved_state = {}
+        if start_type == "1":
+            saved_state["tasks"] = []
+        restart_after_mood_read = (
+            start_type == "2" and config.conf.refresh_backup_plan_after_mood
+        )
+        from arknights_mower.__main__ import main
 
-    mower_thread = Thread(
-        target=main, args=(saved_state, restart_after_mood_read), daemon=True
-    )
-    # /task 路由（views/task.py）独立判定「mower 正在运行」，须与本模块同步
-    set_mower_thread(mower_thread)
-    mower_thread.start()
+        mower_thread = Thread(
+            target=main, args=(saved_state, restart_after_mood_read), daemon=True
+        )
+        # /task 路由（views/task.py）独立判定「mower 正在运行」，须与本模块同步
+        set_mower_thread(mower_thread)
+        mower_thread.start()
 
-    log_lines = []
+        log_lines = []
 
-    return "true"
+        return "true"
 
 
 @app.route("/stop")
@@ -806,7 +972,6 @@ def get_maa_update_info():
     from arknights_mower.utils.maa_update import (
         MaaUpdateError,
         backup_path_for,
-        get_latest_release,
         has_maa_installation,
         normalize_linux_arch,
         normalize_update_channel,
@@ -814,7 +979,9 @@ def get_maa_update_info():
         read_installed_version,
     )
 
-    configured_target = str(config.conf.maa_path or "").strip()
+    configured_target = str(
+        request.args.get("maa_path") or config.conf.maa_path or ""
+    ).strip()
     target = Path(configured_target).expanduser() if configured_target else None
     target_text = str(target) if target is not None else ""
     job = _maa_update_snapshot()
@@ -860,6 +1027,7 @@ def get_maa_update_info():
         "installed": installed,
         "installed_version": installed_version,
         "latest": None,
+        "check_required": installed and __system__ in {"darwin", "linux"},
         "job": job,
     }
     if __system__ in {"linux", "windows"} and not supported and not installed:
@@ -872,15 +1040,88 @@ def get_maa_update_info():
         return result
     if not supported:
         return result
-    try:
-        result["latest"] = get_latest_release(
-            system=__system__,
-            channel=channel,
-        ).as_dict()
-    except MaaUpdateError as e:
-        result["ok"] = False
-        result["message"] = str(e)
     return result
+
+
+@app.route("/maa-update/check", methods=["POST"])
+@require_token
+def check_maa_update():
+    from arknights_mower.utils.maa_update import (
+        MaaUpdateError,
+        get_latest_release,
+        get_mirrorchyan_release,
+        has_maa_installation,
+        is_maa_version_newer,
+        normalize_update_channel,
+        read_installed_version,
+    )
+
+    _clear_update_check(maa_update_check, maa_update_check_lock)
+    payload = request.get_json(silent=True) or {}
+    target_text = str(payload.get("maa_path") or config.conf.maa_path or "").strip()
+    if not target_text:
+        return {"ok": False, "message": "请先设置 Maa 目录"}
+    target = str(Path(target_text).expanduser())
+    if not has_maa_installation(target):
+        return {"ok": False, "message": "当前目录未检测到 Maa，请使用下载功能"}
+    if __system__ == "windows":
+        return {"ok": False, "message": "请手动打开 Maa 检查并完成更新"}
+    if __system__ not in {"darwin", "linux"}:
+        return {"ok": False, "message": "当前平台不使用 Mower 的 MAA 更新功能"}
+
+    source = str(payload.get("source") or "github").strip()
+    mirror_token = str(
+        payload.get("mirror_token") or config.conf.maa_mirrorchyan_token or ""
+    ).strip()
+    if source not in {"github", "mirrorchyan"}:
+        return {"ok": False, "message": "未知的 MAA 更新源"}
+    if source == "mirrorchyan" and not mirror_token:
+        return {"ok": False, "message": "请填写 Mirror酱 CDK"}
+    try:
+        channel = normalize_update_channel(
+            payload.get("channel") or config.conf.maa_update_channel
+        )
+        installed_version = read_installed_version(target)
+        if not installed_version:
+            raise MaaUpdateError("未读取到已安装的 Maa 版本，请检查 Maa 目录")
+        release = (
+            get_mirrorchyan_release(
+                mirror_token,
+                system=__system__,
+                channel=channel,
+            )
+            if source == "mirrorchyan"
+            else get_latest_release(system=__system__, channel=channel)
+        )
+        available = is_maa_version_newer(release.tag, installed_version)
+    except MaaUpdateError as e:
+        return {"ok": False, "message": str(e)}
+
+    check_id = ""
+    if available:
+        check_id = _record_update_check(
+            maa_update_check,
+            maa_update_check_lock,
+            target=target,
+            source=source,
+            channel=channel,
+            installed_version=installed_version,
+            latest_version=release.tag,
+        )
+    source_label = "Mirror酱" if source == "mirrorchyan" else "GitHub"
+    channel_label = "公测版" if channel == "beta" else "正式版"
+    return {
+        "ok": True,
+        "available": available,
+        "check_id": check_id,
+        "installed_version": installed_version,
+        "latest": release.as_dict(),
+        "message": (
+            f"发现 Maa {channel_label}新版本 {release.tag}（{source_label}）"
+            if available
+            else f"当前 Maa 已是最新{channel_label}"
+        ),
+    }
 
 
 @app.route("/maa-update/start", methods=["POST"])
@@ -890,6 +1131,7 @@ def start_maa_update():
         MaaUpdateError,
         has_maa_installation,
         normalize_update_channel,
+        read_installed_version,
     )
 
     if __system__ not in {"darwin", "linux", "windows"}:
@@ -911,6 +1153,7 @@ def start_maa_update():
         return {"ok": False, "message": str(e)}
     if not target:
         return {"ok": False, "message": "请先设置 Maa 目录"}
+    target = str(Path(target).expanduser())
     installed = has_maa_installation(target)
     operation = "更新" if installed else "下载"
     if __system__ == "windows" and installed:
@@ -932,35 +1175,51 @@ def start_maa_update():
     if config_changed:
         config.save_conf()
 
-    with maa_update_lock:
-        thread = maa_update_job.get("thread")
-        if thread is not None and thread.is_alive():
-            return {"ok": False, "message": f"MAA {operation}正在进行中"}
-        thread = Thread(
-            target=_run_maa_update,
-            args=(target, source, mirror_token, __system__, channel),
-            daemon=True,
-        )
-        maa_update_job.update(
-            {
-                "thread": thread,
-                "status": "running",
-                "phase": "checking",
-                "message": (
-                    f"正在获取 MAA "
-                    f"{'公测版' if channel == 'beta' else '正式版'}{operation}信息"
-                ),
-                "current": 0,
-                "total": 0,
-                "progress": None,
-                "version": "",
-                "source": source,
-                "channel": channel,
-                "operation": "update" if installed else "download",
-                "result": None,
-            }
-        )
-        thread.start()
+    with maa_maintenance_lock:
+        if _job_running(maa_resource_update_job):
+            return {"ok": False, "message": "Maa 资源更新正在进行中"}
+        with maa_update_lock:
+            thread = maa_update_job.get("thread")
+            if thread is not None and thread.is_alive():
+                return {"ok": False, "message": f"MAA {operation}正在进行中"}
+            if installed and not _consume_update_check(
+                maa_update_check,
+                maa_update_check_lock,
+                str(payload.get("check_id") or ""),
+                target=target,
+                source=source,
+                channel=channel,
+                installed_version=read_installed_version(target),
+            ):
+                return {
+                    "ok": False,
+                    "message": "请先检查 Maa 更新，发现新版本后再更新",
+                }
+            thread = Thread(
+                target=_run_maa_update,
+                args=(target, source, mirror_token, __system__, channel),
+                daemon=True,
+            )
+            maa_update_job.update(
+                {
+                    "thread": thread,
+                    "status": "running",
+                    "phase": "checking",
+                    "message": (
+                        f"正在获取 MAA "
+                        f"{'公测版' if channel == 'beta' else '正式版'}{operation}信息"
+                    ),
+                    "current": 0,
+                    "total": 0,
+                    "progress": None,
+                    "version": "",
+                    "source": source,
+                    "channel": channel,
+                    "operation": "update" if installed else "download",
+                    "result": None,
+                }
+            )
+            thread.start()
     return {"ok": True, "job": _maa_update_snapshot()}
 
 
@@ -1008,6 +1267,194 @@ def get_maa_mirrorchyan_status():
 @require_token
 def get_maa_update_status():
     return {"ok": True, "job": _maa_update_snapshot()}
+
+
+@app.route("/maa-resource-update/info")
+@require_token
+def get_maa_resource_update_info():
+    from arknights_mower.utils.maa_resource_update import (
+        read_maa_resource_info,
+        resource_backup_path,
+    )
+    from arknights_mower.utils.maa_update import has_maa_installation
+
+    configured_target = str(
+        request.args.get("maa_path") or config.conf.maa_path or ""
+    ).strip()
+    target = Path(configured_target).expanduser() if configured_target else None
+    installed = has_maa_installation(target) if target else False
+    supported = __system__ in {"darwin", "linux"} and installed
+    current = (
+        read_maa_resource_info(target)
+        if target
+        else {"version": "", "release_note": ""}
+    )
+    result = {
+        "ok": True,
+        "supported": supported,
+        "platform": __system__,
+        "target": str(target) if target else "",
+        "current": current,
+        "latest": None,
+        "available": False,
+        "backup": str(resource_backup_path(target)) if target else "",
+        "job": _maa_resource_update_snapshot(),
+    }
+    if __system__ == "windows" and installed:
+        result["message"] = "请在 Maa 主程序中更新 Maa 资源"
+        return result
+    if not configured_target:
+        result["message"] = "请先设置 Maa 目录"
+        return result
+    if not installed:
+        result["message"] = "请先下载并设置有效的 Maa 目录"
+        return result
+    if not supported:
+        result["message"] = "当前平台不使用 Mower 的 Maa 资源更新功能"
+        return result
+    return result
+
+
+@app.route("/maa-resource-update/check", methods=["POST"])
+@require_token
+def check_maa_resource_update():
+    from arknights_mower.utils.maa_resource_update import (
+        get_maa_resource_release,
+        read_maa_resource_info,
+    )
+    from arknights_mower.utils.maa_update import MaaUpdateError, has_maa_installation
+
+    _clear_update_check(maa_resource_update_check, maa_resource_update_check_lock)
+    if __system__ not in {"darwin", "linux"}:
+        return {"ok": False, "message": "请在 Maa 主程序中检查并更新 Maa 资源"}
+    payload = request.get_json(silent=True) or {}
+    target_text = str(payload.get("maa_path") or config.conf.maa_path or "").strip()
+    if not target_text:
+        return {"ok": False, "message": "请先设置 Maa 目录"}
+    target = str(Path(target_text).expanduser())
+    if not has_maa_installation(target):
+        return {"ok": False, "message": "请先下载并设置有效的 Maa 目录"}
+    source = str(payload.get("source") or "github").strip()
+    mirror_token = str(
+        payload.get("mirror_token") or config.conf.maa_mirrorchyan_token or ""
+    ).strip()
+    if source not in {"github", "mirrorchyan"}:
+        return {"ok": False, "message": "未知的 Maa 资源更新源"}
+    if source == "mirrorchyan" and not mirror_token:
+        return {"ok": False, "message": "请填写 Mirror酱 CDK"}
+
+    current = read_maa_resource_info(target)
+    try:
+        release = get_maa_resource_release(
+            source,
+            current_version=current["version"],
+            mirror_token=mirror_token,
+        )
+    except MaaUpdateError as e:
+        return {"ok": False, "message": str(e)}
+    check_id = ""
+    if release.available:
+        check_id = _record_update_check(
+            maa_resource_update_check,
+            maa_resource_update_check_lock,
+            target=target,
+            source=source,
+            current_version=current["version"],
+            latest_version=release.version,
+        )
+    source_label = "Mirror酱" if source == "mirrorchyan" else "GitHub"
+    return {
+        "ok": True,
+        "available": release.available,
+        "check_id": check_id,
+        "current": current,
+        "latest": release.as_dict(),
+        "message": (
+            f"发现 Maa 资源新版本 {release.version}（{source_label}）"
+            if release.available
+            else "当前 Maa 资源已是最新版本"
+        ),
+    }
+
+
+@app.route("/maa-resource-update/start", methods=["POST"])
+@require_token
+def start_maa_resource_update():
+    from arknights_mower.utils.maa_update import has_maa_installation
+
+    if __system__ not in {"darwin", "linux"}:
+        return {"ok": False, "message": "请在 Maa 主程序中更新 Maa 资源"}
+    payload = request.get_json(silent=True) or {}
+    target = str(payload.get("maa_path") or config.conf.maa_path or "").strip()
+    source = str(payload.get("source") or "github").strip()
+    mirror_token = str(
+        payload.get("mirror_token") or config.conf.maa_mirrorchyan_token or ""
+    ).strip()
+    if not target:
+        return {"ok": False, "message": "请先设置 Maa 目录"}
+    target = str(Path(target).expanduser())
+    if not has_maa_installation(target):
+        return {"ok": False, "message": "请先下载并设置有效的 Maa 目录"}
+    if source not in {"github", "mirrorchyan"}:
+        return {"ok": False, "message": "未知的 Maa 资源更新源"}
+    if source == "mirrorchyan" and not mirror_token:
+        return {"ok": False, "message": "请填写 Mirror酱 CDK"}
+    if source == "mirrorchyan" and mirror_token != config.conf.maa_mirrorchyan_token:
+        config.conf.maa_mirrorchyan_token = mirror_token
+        config.save_conf()
+
+    with maa_maintenance_lock:
+        if mower_thread and mower_thread.is_alive():
+            return {"ok": False, "message": "请先停止 Mower，再更新 Maa 资源"}
+        if _job_running(maa_update_job):
+            return {"ok": False, "message": "MAA 下载或更新正在进行中"}
+        with maa_resource_update_lock:
+            if _job_running(maa_resource_update_job):
+                return {"ok": False, "message": "Maa 资源更新正在进行中"}
+            from arknights_mower.utils.maa_resource_update import (
+                read_maa_resource_info,
+            )
+
+            if not _consume_update_check(
+                maa_resource_update_check,
+                maa_resource_update_check_lock,
+                str(payload.get("check_id") or ""),
+                target=target,
+                source=source,
+                current_version=read_maa_resource_info(target)["version"],
+            ):
+                return {
+                    "ok": False,
+                    "message": "请先检查 Maa 资源更新，发现新版本后再更新",
+                }
+            thread = Thread(
+                target=_run_maa_resource_update,
+                args=(target, source, mirror_token, __system__),
+                daemon=True,
+            )
+            maa_resource_update_job.update(
+                {
+                    "thread": thread,
+                    "status": "running",
+                    "phase": "checking",
+                    "message": "正在检查 Maa 资源更新",
+                    "current": 0,
+                    "total": 0,
+                    "progress": None,
+                    "version": "",
+                    "source": source,
+                    "target": target,
+                    "result": None,
+                }
+            )
+            thread.start()
+    return {"ok": True, "job": _maa_resource_update_snapshot()}
+
+
+@app.route("/maa-resource-update/status")
+@require_token
+def get_maa_resource_update_status():
+    return {"ok": True, "job": _maa_resource_update_snapshot()}
 
 
 @app.route("/maa-conn-preset")

--- a/server.py
+++ b/server.py
@@ -210,6 +210,13 @@ def _clear_update_check(check: dict, lock: RLock) -> None:
         check["id"] = ""
 
 
+def _checked_latest_version(check: dict, lock: RLock, check_id: str) -> str:
+    with lock:
+        if not check_id or check.get("id") != check_id:
+            return ""
+        return str(check.get("latest_version") or "")
+
+
 def _consume_update_check(
     check: dict,
     lock: RLock,
@@ -1130,6 +1137,7 @@ def start_maa_update():
     from arknights_mower.utils.maa_update import (
         MaaUpdateError,
         has_maa_installation,
+        is_maa_version_newer,
         normalize_update_channel,
         read_installed_version,
     )
@@ -1182,19 +1190,31 @@ def start_maa_update():
             thread = maa_update_job.get("thread")
             if thread is not None and thread.is_alive():
                 return {"ok": False, "message": f"MAA {operation}正在进行中"}
-            if installed and not _consume_update_check(
-                maa_update_check,
-                maa_update_check_lock,
-                str(payload.get("check_id") or ""),
-                target=target,
-                source=source,
-                channel=channel,
-                installed_version=read_installed_version(target),
-            ):
-                return {
-                    "ok": False,
-                    "message": "请先检查 Maa 更新，发现新版本后再更新",
-                }
+            if installed:
+                check_id = str(payload.get("check_id") or "")
+                installed_version = read_installed_version(target)
+                checked_latest = _checked_latest_version(
+                    maa_update_check,
+                    maa_update_check_lock,
+                    check_id,
+                )
+                try:
+                    newer = is_maa_version_newer(checked_latest, installed_version)
+                except MaaUpdateError:
+                    newer = False
+                if not newer or not _consume_update_check(
+                    maa_update_check,
+                    maa_update_check_lock,
+                    check_id,
+                    target=target,
+                    source=source,
+                    channel=channel,
+                    installed_version=installed_version,
+                ):
+                    return {
+                        "ok": False,
+                        "message": "请先检查 Maa 更新，发现新版本后再更新",
+                    }
             thread = Thread(
                 target=_run_maa_update,
                 args=(target, source, mirror_token, __system__, channel),
@@ -1380,7 +1400,11 @@ def check_maa_resource_update():
 @app.route("/maa-resource-update/start", methods=["POST"])
 @require_token
 def start_maa_resource_update():
-    from arknights_mower.utils.maa_update import has_maa_installation
+    from arknights_mower.utils.maa_resource_update import (
+        parse_resource_version,
+        read_maa_resource_info,
+    )
+    from arknights_mower.utils.maa_update import MaaUpdateError, has_maa_installation
 
     if __system__ not in {"darwin", "linux"}:
         return {"ok": False, "message": "请在 Maa 主程序中更新 Maa 资源"}
@@ -1411,17 +1435,26 @@ def start_maa_resource_update():
         with maa_resource_update_lock:
             if _job_running(maa_resource_update_job):
                 return {"ok": False, "message": "Maa 资源更新正在进行中"}
-            from arknights_mower.utils.maa_resource_update import (
-                read_maa_resource_info,
-            )
-
-            if not _consume_update_check(
+            check_id = str(payload.get("check_id") or "")
+            current_version = read_maa_resource_info(target)["version"]
+            checked_latest = _checked_latest_version(
                 maa_resource_update_check,
                 maa_resource_update_check_lock,
-                str(payload.get("check_id") or ""),
+                check_id,
+            )
+            try:
+                newer = parse_resource_version(checked_latest) > parse_resource_version(
+                    current_version
+                )
+            except MaaUpdateError:
+                newer = False
+            if not newer or not _consume_update_check(
+                maa_resource_update_check,
+                maa_resource_update_check_lock,
+                check_id,
                 target=target,
                 source=source,
-                current_version=read_maa_resource_info(target)["version"],
+                current_version=current_version,
             ):
                 return {
                     "ok": False,

--- a/ui/src/components/MaaBasic.vue
+++ b/ui/src/components/MaaBasic.vue
@@ -240,6 +240,19 @@ function reset_maa_resource_update_check() {
   maa_resource_release_note.value = ''
 }
 
+function normalize_maa_version(value) {
+  return String(value || '')
+    .trim()
+    .replace(/^v/i, '')
+    .toLowerCase()
+}
+
+function versions_are_equal(left, right, normalizer = (value) => String(value || '').trim()) {
+  const normalized_left = normalizer(left)
+  const normalized_right = normalizer(right)
+  return Boolean(normalized_left && normalized_right && normalized_left === normalized_right)
+}
+
 watch(
   maa_mirrorchyan_token,
   (token, previousToken = '') => {
@@ -277,6 +290,12 @@ const maa_resource_update_checking = computed(
   () => maa_resource_update_check.value.status === 'checking'
 )
 const maa_path_missing = computed(() => !String(maa_path.value || '').trim())
+const maa_update_versions_equal = computed(() =>
+  versions_are_equal(maa_latest_version.value, maa_installed_version.value, normalize_maa_version)
+)
+const maa_resource_versions_equal = computed(() =>
+  versions_are_equal(maa_resource_latest_version.value, maa_resource_current_version.value)
+)
 const maa_managed_operation_label = computed(() => (maa_installed.value ? '更新' : '下载'))
 const maa_job_operation_label = computed(() =>
   maa_update_job.value.operation === 'update' ? '更新' : '下载'
@@ -331,6 +350,7 @@ const maa_update_action_disabled = computed(() => {
   if (maa_updating.value || maa_resource_updating.value || maa_update_checking.value) return true
   if (maa_update_source.value === 'mirrorchyan' && !mirrorchyan_cdk_ready.value) return true
   if (!maa_installed.value) return false
+  if (maa_update_versions_equal.value) return true
   return !maa_update_check.value.available || !maa_update_check.value.id
 })
 const maa_resource_update_action_disabled = computed(
@@ -338,6 +358,7 @@ const maa_resource_update_action_disabled = computed(
     maa_resource_updating.value ||
     maa_resource_update_checking.value ||
     maa_updating.value ||
+    maa_resource_versions_equal.value ||
     !maa_resource_update_check.value.available ||
     !maa_resource_update_check.value.id ||
     (maa_update_source.value === 'mirrorchyan' && !mirrorchyan_cdk_ready.value)
@@ -524,11 +545,15 @@ async function check_maa_update() {
     }
     maa_installed_version.value = data.installed_version || maa_installed_version.value
     maa_latest_version.value = data.latest?.tag || ''
+    const available = Boolean(data.available) && !maa_update_versions_equal.value
     maa_update_check.value = {
       status: 'success',
-      message: data.message || (data.available ? '发现 Maa 新版本' : '当前 Maa 已是最新版本'),
-      available: Boolean(data.available),
-      id: data.check_id || ''
+      message:
+        !available && maa_update_versions_equal.value
+          ? '当前 Maa 已是最新版本'
+          : data.message || (available ? '发现 Maa 新版本' : '当前 Maa 已是最新版本'),
+      available,
+      id: available ? data.check_id || '' : ''
     }
   } catch (error) {
     maa_update_check.value.status = 'error'
@@ -576,12 +601,15 @@ async function check_maa_resource_update() {
     maa_resource_current_version.value = data.current?.version || maa_resource_current_version.value
     maa_resource_latest_version.value = data.latest?.version || ''
     maa_resource_release_note.value = data.latest?.release_note || ''
+    const available = Boolean(data.available) && !maa_resource_versions_equal.value
     maa_resource_update_check.value = {
       status: 'success',
       message:
-        data.message || (data.available ? '发现 Maa 资源新版本' : '当前 Maa 资源已是最新版本'),
-      available: Boolean(data.available),
-      id: data.check_id || ''
+        !available && maa_resource_versions_equal.value
+          ? '当前 Maa 资源已是最新版本'
+          : data.message || (available ? '发现 Maa 资源新版本' : '当前 Maa 资源已是最新版本'),
+      available,
+      id: available ? data.check_id || '' : ''
     }
   } catch (error) {
     maa_resource_update_check.value.status = 'error'

--- a/ui/src/components/MaaBasic.vue
+++ b/ui/src/components/MaaBasic.vue
@@ -81,6 +81,12 @@ const maa_installed = ref(false)
 const maa_installed_version = ref('')
 const maa_backup_path = ref('')
 const maa_update_info_msg = ref('')
+const maa_update_check = ref({
+  status: 'idle',
+  message: '',
+  available: false,
+  id: ''
+})
 const maa_update_job = ref({
   status: 'idle',
   phase: 'idle',
@@ -94,6 +100,32 @@ const maa_update_job = ref({
 })
 let maa_update_timer = null
 let maa_update_info_request_id = 0
+const maa_resource_update_supported = ref(false)
+const maa_resource_current_version = ref('')
+const maa_resource_latest_version = ref('')
+const maa_resource_release_note = ref('')
+const maa_resource_backup_path = ref('')
+const maa_resource_update_info_msg = ref('')
+const maa_resource_update_check = ref({
+  status: 'idle',
+  message: '',
+  available: false,
+  id: ''
+})
+const maa_resource_update_job = ref({
+  status: 'idle',
+  phase: 'idle',
+  message: '',
+  progress: null,
+  current: 0,
+  total: 0,
+  version: '',
+  target: '',
+  result: null
+})
+let maa_resource_update_timer = null
+let maa_resource_update_info_request_id = 0
+let maa_path_refresh_timer = null
 const mirrorchyan_cdk_status = ref({
   loading: false,
   checked_token: '',
@@ -187,10 +219,35 @@ function schedule_mirrorchyan_cdk_check(token) {
   mirrorchyan_cdk_timer = window.setTimeout(() => check_mirrorchyan_cdk(normalized_token), 500)
 }
 
+function reset_maa_update_check() {
+  maa_update_check.value = {
+    status: 'idle',
+    message: '',
+    available: false,
+    id: ''
+  }
+  maa_latest_version.value = ''
+}
+
+function reset_maa_resource_update_check() {
+  maa_resource_update_check.value = {
+    status: 'idle',
+    message: '',
+    available: false,
+    id: ''
+  }
+  maa_resource_latest_version.value = ''
+  maa_resource_release_note.value = ''
+}
+
 watch(
   maa_mirrorchyan_token,
   (token, previousToken = '') => {
     if (token.trim() && !previousToken.trim()) maa_update_source.value = 'mirrorchyan'
+    if (token !== previousToken && maa_update_source.value === 'mirrorchyan') {
+      reset_maa_update_check()
+      reset_maa_resource_update_check()
+    }
     if (maa_update_supported.value) {
       schedule_mirrorchyan_cdk_check(token)
     }
@@ -200,13 +257,25 @@ watch(
 
 watch(maa_update_channel, (channel, previous_channel) => {
   if (channel === previous_channel) return
+  reset_maa_update_check()
   if (maa_update_supported.value) {
     schedule_mirrorchyan_cdk_check(maa_mirrorchyan_token.value)
   }
   if (maa_update_supported.value) get_maa_update_info()
 })
 
+watch(maa_update_source, (source, previous_source) => {
+  if (source === previous_source) return
+  reset_maa_update_check()
+  reset_maa_resource_update_check()
+})
+
 const maa_updating = computed(() => maa_update_job.value.status === 'running')
+const maa_resource_updating = computed(() => maa_resource_update_job.value.status === 'running')
+const maa_update_checking = computed(() => maa_update_check.value.status === 'checking')
+const maa_resource_update_checking = computed(
+  () => maa_resource_update_check.value.status === 'checking'
+)
 const maa_path_missing = computed(() => !String(maa_path.value || '').trim())
 const maa_managed_operation_label = computed(() => (maa_installed.value ? '更新' : '下载'))
 const maa_job_operation_label = computed(() =>
@@ -252,9 +321,35 @@ const mirrorchyan_cdk_ready = computed(() => {
     !status.expired
   )
 })
+const maa_update_check_message_class = computed(() =>
+  maa_update_check.value.status === 'error' ? 'update-error' : 'update-success'
+)
+const maa_resource_update_check_message_class = computed(() =>
+  maa_resource_update_check.value.status === 'error' ? 'update-error' : 'update-success'
+)
+const maa_update_action_disabled = computed(() => {
+  if (maa_updating.value || maa_resource_updating.value || maa_update_checking.value) return true
+  if (maa_update_source.value === 'mirrorchyan' && !mirrorchyan_cdk_ready.value) return true
+  if (!maa_installed.value) return false
+  return !maa_update_check.value.available || !maa_update_check.value.id
+})
+const maa_resource_update_action_disabled = computed(
+  () =>
+    maa_resource_updating.value ||
+    maa_resource_update_checking.value ||
+    maa_updating.value ||
+    !maa_resource_update_check.value.available ||
+    !maa_resource_update_check.value.id ||
+    (maa_update_source.value === 'mirrorchyan' && !mirrorchyan_cdk_ready.value)
+)
 const maa_update_progress_status = computed(() => {
   if (maa_update_job.value.status === 'error') return 'error'
   if (maa_update_job.value.status === 'success') return 'success'
+  return 'default'
+})
+const maa_resource_update_progress_status = computed(() => {
+  if (maa_resource_update_job.value.status === 'error') return 'error'
+  if (maa_resource_update_job.value.status === 'success') return 'success'
   return 'default'
 })
 
@@ -285,7 +380,10 @@ async function poll_maa_update() {
     if (maa_update_job.value.status === 'running') {
       maa_update_timer = window.setTimeout(poll_maa_update, 800)
     } else if (maa_update_job.value.status === 'success') {
+      reset_maa_update_check()
+      reset_maa_resource_update_check()
       await get_maa_update_info()
+      await get_maa_resource_update_info()
       await get_maa_conn_presets()
     }
   } catch (error) {
@@ -298,7 +396,7 @@ async function get_maa_update_info() {
   const request_id = ++maa_update_info_request_id
   try {
     const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/maa-update/info`, {
-      params: { channel: maa_update_channel.value }
+      params: { channel: maa_update_channel.value, maa_path: maa_path.value }
     })
     if (request_id !== maa_update_info_request_id) return
     const data = response.data
@@ -329,6 +427,169 @@ async function get_maa_update_info() {
   }
 }
 
+function apply_maa_resource_update_job(job, apply_install_info = true) {
+  if (!job) return
+  maa_resource_update_job.value = { ...maa_resource_update_job.value, ...job }
+  if (apply_install_info && job.status === 'success' && job.result?.installed) {
+    maa_resource_current_version.value = job.result.installed.version || ''
+    if (job.result.backup) maa_resource_backup_path.value = job.result.backup
+  }
+}
+
+async function poll_maa_resource_update() {
+  if (maa_resource_update_timer) window.clearTimeout(maa_resource_update_timer)
+  try {
+    const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/maa-resource-update/status`)
+    apply_maa_resource_update_job(response.data.job)
+    if (maa_resource_update_job.value.status === 'running') {
+      maa_resource_update_timer = window.setTimeout(poll_maa_resource_update, 800)
+    } else if (maa_resource_update_job.value.status === 'success') {
+      reset_maa_resource_update_check()
+      await get_maa_resource_update_info()
+      await get_maa_conn_presets()
+    }
+  } catch (error) {
+    maa_resource_update_job.value.status = 'error'
+    maa_resource_update_job.value.message = `读取 Maa 资源更新进度失败：${error.message}`
+  }
+}
+
+async function get_maa_resource_update_info() {
+  const request_id = ++maa_resource_update_info_request_id
+  try {
+    const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/maa-resource-update/info`, {
+      params: { maa_path: maa_path.value }
+    })
+    if (request_id !== maa_resource_update_info_request_id) return
+    const data = response.data
+    maa_resource_update_supported.value = Boolean(data.supported)
+    maa_resource_current_version.value = data.current?.version || ''
+    maa_resource_latest_version.value = data.latest?.version || ''
+    maa_resource_release_note.value = data.latest?.release_note || ''
+    maa_resource_backup_path.value = data.backup || ''
+    maa_resource_update_info_msg.value = data.ok ? '' : data.message || '读取 Maa 资源版本失败'
+    if (data.job?.target === data.target) {
+      apply_maa_resource_update_job(data.job)
+      if (maa_resource_update_job.value.status === 'running') poll_maa_resource_update()
+    } else {
+      maa_resource_update_job.value = {
+        status: 'idle',
+        phase: 'idle',
+        message: '',
+        progress: null,
+        current: 0,
+        total: 0,
+        version: '',
+        target: data.target || '',
+        result: null
+      }
+    }
+  } catch (error) {
+    if (request_id !== maa_resource_update_info_request_id) return
+    maa_resource_update_info_msg.value = `读取 Maa 资源版本失败：${error.message}`
+  }
+}
+
+async function check_maa_update() {
+  if (maa_update_checking.value || maa_updating.value || !maa_installed.value) return
+  reset_maa_update_check()
+  maa_update_info_msg.value = ''
+  if (maa_path_missing.value) {
+    maa_update_check.value.status = 'error'
+    maa_update_check.value.message = '请先设置 Maa 目录'
+    return
+  }
+  if (maa_update_source.value === 'mirrorchyan') {
+    const valid = await check_mirrorchyan_cdk()
+    if (!valid) {
+      maa_update_check.value.status = 'error'
+      maa_update_check.value.message = mirrorchyan_cdk_status.value.message || '请检查 Mirror酱 CDK'
+      return
+    }
+  }
+  maa_update_check.value.status = 'checking'
+  maa_update_check.value.message = '正在检查 Maa 更新……'
+  try {
+    const response = await axios.post(`${import.meta.env.VITE_HTTP_URL}/maa-update/check`, {
+      maa_path: maa_path.value,
+      source: maa_update_source.value,
+      mirror_token: maa_update_source.value === 'mirrorchyan' ? maa_mirrorchyan_token.value : '',
+      channel: maa_update_channel.value
+    })
+    const data = response.data
+    if (!data.ok) {
+      maa_update_check.value.status = 'error'
+      maa_update_check.value.message = data.message || '检查 Maa 更新失败'
+      return
+    }
+    maa_installed_version.value = data.installed_version || maa_installed_version.value
+    maa_latest_version.value = data.latest?.tag || ''
+    maa_update_check.value = {
+      status: 'success',
+      message: data.message || (data.available ? '发现 Maa 新版本' : '当前 Maa 已是最新版本'),
+      available: Boolean(data.available),
+      id: data.check_id || ''
+    }
+  } catch (error) {
+    maa_update_check.value.status = 'error'
+    maa_update_check.value.message =
+      error.response?.data?.message || `检查 Maa 更新失败：${error.message}`
+  }
+}
+
+async function check_maa_resource_update() {
+  if (maa_resource_update_checking.value || maa_resource_updating.value || maa_updating.value)
+    return
+  reset_maa_resource_update_check()
+  maa_resource_update_info_msg.value = ''
+  if (maa_path_missing.value) {
+    maa_resource_update_check.value.status = 'error'
+    maa_resource_update_check.value.message = '请先设置 Maa 目录'
+    return
+  }
+  if (maa_update_source.value === 'mirrorchyan') {
+    const valid = await check_mirrorchyan_cdk()
+    if (!valid) {
+      maa_resource_update_check.value.status = 'error'
+      maa_resource_update_check.value.message =
+        mirrorchyan_cdk_status.value.message || '请检查 Mirror酱 CDK'
+      return
+    }
+  }
+  maa_resource_update_check.value.status = 'checking'
+  maa_resource_update_check.value.message = '正在检查 Maa 资源更新……'
+  try {
+    const response = await axios.post(
+      `${import.meta.env.VITE_HTTP_URL}/maa-resource-update/check`,
+      {
+        maa_path: maa_path.value,
+        source: maa_update_source.value,
+        mirror_token: maa_update_source.value === 'mirrorchyan' ? maa_mirrorchyan_token.value : ''
+      }
+    )
+    const data = response.data
+    if (!data.ok) {
+      maa_resource_update_check.value.status = 'error'
+      maa_resource_update_check.value.message = data.message || '检查 Maa 资源更新失败'
+      return
+    }
+    maa_resource_current_version.value = data.current?.version || maa_resource_current_version.value
+    maa_resource_latest_version.value = data.latest?.version || ''
+    maa_resource_release_note.value = data.latest?.release_note || ''
+    maa_resource_update_check.value = {
+      status: 'success',
+      message:
+        data.message || (data.available ? '发现 Maa 资源新版本' : '当前 Maa 资源已是最新版本'),
+      available: Boolean(data.available),
+      id: data.check_id || ''
+    }
+  } catch (error) {
+    maa_resource_update_check.value.status = 'error'
+    maa_resource_update_check.value.message =
+      error.response?.data?.message || `检查 Maa 资源更新失败：${error.message}`
+  }
+}
+
 async function start_maa_update() {
   if (maa_updating.value) return
   maa_update_info_msg.value = ''
@@ -350,7 +611,8 @@ async function start_maa_update() {
       maa_path: maa_path.value,
       source: maa_update_source.value,
       mirror_token: maa_update_source.value === 'mirrorchyan' ? maa_mirrorchyan_token.value : '',
-      channel: maa_update_channel.value
+      channel: maa_update_channel.value,
+      check_id: maa_update_check.value.id
     })
     if (!response.data.ok) {
       maa_update_job.value.status = 'error'
@@ -358,6 +620,7 @@ async function start_maa_update() {
         response.data.message || `MAA ${maa_managed_operation_label.value}启动失败`
       return
     }
+    reset_maa_update_check()
     apply_maa_update_job(response.data.job)
     poll_maa_update()
   } catch (error) {
@@ -368,15 +631,73 @@ async function start_maa_update() {
   }
 }
 
+async function start_maa_resource_update() {
+  if (maa_resource_updating.value || maa_updating.value) return
+  maa_resource_update_info_msg.value = ''
+  if (maa_path_missing.value) {
+    maa_resource_update_job.value.status = 'error'
+    maa_resource_update_job.value.message = '请先设置 Maa 目录'
+    return
+  }
+  if (maa_update_source.value === 'mirrorchyan') {
+    const valid = await check_mirrorchyan_cdk()
+    if (!valid) {
+      maa_resource_update_job.value.status = 'error'
+      maa_resource_update_job.value.message =
+        mirrorchyan_cdk_status.value.message || '请检查 Mirror酱 CDK'
+      return
+    }
+  }
+  try {
+    const response = await axios.post(
+      `${import.meta.env.VITE_HTTP_URL}/maa-resource-update/start`,
+      {
+        maa_path: maa_path.value,
+        source: maa_update_source.value,
+        mirror_token: maa_update_source.value === 'mirrorchyan' ? maa_mirrorchyan_token.value : '',
+        check_id: maa_resource_update_check.value.id
+      }
+    )
+    if (!response.data.ok) {
+      maa_resource_update_job.value.status = 'error'
+      maa_resource_update_job.value.message = response.data.message || 'Maa 资源更新启动失败'
+      return
+    }
+    reset_maa_resource_update_check()
+    apply_maa_resource_update_job(response.data.job)
+    poll_maa_resource_update()
+  } catch (error) {
+    maa_resource_update_job.value.status = 'error'
+    maa_resource_update_job.value.message =
+      error.response?.data?.message || `Maa 资源更新启动失败：${error.message}`
+  }
+}
+
+watch(maa_path, (value, previous_value) => {
+  if (value === previous_value) return
+  reset_maa_update_check()
+  reset_maa_resource_update_check()
+  if (maa_path_refresh_timer) window.clearTimeout(maa_path_refresh_timer)
+  maa_path_refresh_timer = window.setTimeout(() => {
+    get_maa_update_info()
+    get_maa_resource_update_info()
+    get_maa_conn_presets()
+  }, 400)
+})
+
 onMounted(() => {
   get_maa_conn_presets()
   get_maa_update_info()
+  get_maa_resource_update_info()
 })
 
 onUnmounted(() => {
   if (maa_update_timer) window.clearTimeout(maa_update_timer)
+  if (maa_resource_update_timer) window.clearTimeout(maa_resource_update_timer)
+  if (maa_path_refresh_timer) window.clearTimeout(maa_path_refresh_timer)
   if (mirrorchyan_cdk_timer) window.clearTimeout(mirrorchyan_cdk_timer)
   mirrorchyan_cdk_request_id++
+  maa_resource_update_info_request_id++
 })
 </script>
 
@@ -519,18 +840,37 @@ onUnmounted(() => {
           </template>
         </div>
         <div v-if="maa_update_info_msg" class="update-error">{{ maa_update_info_msg }}</div>
-        <n-button
-          type="primary"
-          :loading="maa_updating"
-          :disabled="
-            maa_updating || (maa_update_source === 'mirrorchyan' && !mirrorchyan_cdk_ready)
-          "
-          @click="start_maa_update"
+        <div
+          v-if="maa_update_check.message"
+          :class="maa_update_check_message_class"
+          aria-live="polite"
         >
-          {{
-            maa_update_platform === 'windows' ? '下载 Maa' : maa_installed ? '更新 Maa' : '下载 Maa'
-          }}
-        </n-button>
+          {{ maa_update_check.message }}
+        </div>
+        <n-space>
+          <n-button
+            v-if="maa_installed"
+            :loading="maa_update_checking"
+            :disabled="maa_updating || maa_resource_updating || maa_update_checking"
+            @click="check_maa_update"
+          >
+            检查 Maa 更新
+          </n-button>
+          <n-button
+            type="primary"
+            :loading="maa_updating"
+            :disabled="maa_update_action_disabled"
+            @click="start_maa_update"
+          >
+            {{
+              maa_update_platform === 'windows'
+                ? '下载 Maa'
+                : maa_installed
+                  ? '更新 Maa'
+                  : '下载 Maa'
+            }}
+          </n-button>
+        </n-space>
       </div>
     </template>
     <template v-else-if="maa_update_platform === 'linux' && maa_update_info_msg">
@@ -548,9 +888,76 @@ onUnmounted(() => {
           <span>已安装：{{ maa_installed_version || '已检测到 Maa' }}</span>
         </div>
         <div class="update-hint">
-          已检测到 Windows Maa，请手动打开 Maa，并在 Maa 设置中检查和完成更新。更新源、版本通道和
-          Mirror酱 CDK 以 Maa 内的配置为准，Mower 不会覆盖 Maa 目录。
+          已检测到 Windows Maa，请手动打开 Maa，并在 Maa
+          设置中完成程序及资源更新。更新源、版本通道和 Mirror酱 CDK 以 Maa 内的配置为准，Mower
+          不会覆盖 Maa 目录。
         </div>
+      </div>
+    </template>
+    <template v-if="maa_resource_update_supported">
+      <n-divider />
+      <div class="maa-updater">
+        <div class="update-title">
+          {{ maa_update_platform === 'linux' ? 'Linux' : 'macOS' }} 更新 Maa 资源
+        </div>
+        <div class="update-meta">
+          <span>当前资源：{{ maa_resource_current_version || '未知' }}</span>
+          <span>最新资源：{{ maa_resource_latest_version || '待获取' }}</span>
+        </div>
+        <div v-if="maa_resource_release_note" class="update-hint">
+          最新活动资源：{{ maa_resource_release_note }}
+        </div>
+        <div class="update-hint">
+          Maa 资源更新不区分正式版与公测版，将使用上方选择的
+          {{ maa_update_source === 'mirrorchyan' ? 'Mirror酱' : 'GitHub' }}
+          更新源。资源包会增量合并到 resource 目录，不会替换 MaaCore 与 Python。
+        </div>
+        <div v-if="maa_resource_backup_path" class="update-hint">
+          更新前的资源保存在
+          {{ maa_resource_backup_path }}；下一次成功更新时替换该备份，失败时回滚。
+        </div>
+        <n-progress
+          v-if="maa_resource_update_job.progress !== null"
+          type="line"
+          :percentage="maa_resource_update_job.progress"
+          :status="maa_resource_update_progress_status"
+          :indicator-placement="'inside'"
+          processing
+        />
+        <div v-if="maa_resource_update_job.message" class="update-message">
+          {{ maa_resource_update_job.message }}
+          <template v-if="maa_resource_update_job.total">
+            （{{ format_bytes(maa_resource_update_job.current) }} /
+            {{ format_bytes(maa_resource_update_job.total) }}）
+          </template>
+        </div>
+        <div v-if="maa_resource_update_info_msg" class="update-error">
+          {{ maa_resource_update_info_msg }}
+        </div>
+        <div
+          v-if="maa_resource_update_check.message"
+          :class="maa_resource_update_check_message_class"
+          aria-live="polite"
+        >
+          {{ maa_resource_update_check.message }}
+        </div>
+        <n-space>
+          <n-button
+            :loading="maa_resource_update_checking"
+            :disabled="maa_resource_updating || maa_updating || maa_resource_update_checking"
+            @click="check_maa_resource_update"
+          >
+            检查 Maa 资源更新
+          </n-button>
+          <n-button
+            type="primary"
+            :loading="maa_resource_updating"
+            :disabled="maa_resource_update_action_disabled"
+            @click="start_maa_resource_update"
+          >
+            更新 Maa 资源
+          </n-button>
+        </n-space>
       </div>
     </template>
   </n-card>


### PR DESCRIPTION
## 目标

为 macOS 与 Linux 增加独立的 MaaResource 检查/更新入口，并将 Maa 本体和 Maa 资源都调整为“先检查、发现新版本后再更新”的两阶段流程。Windows 已安装 Maa 时继续提示用户在 Maa 主程序中完成程序及资源更新。

## 主要改动

### Maa 资源更新

- 新增 MaaResource GitHub 与 Mirror酱更新支持；GitHub 使用 `MaaResource/main.zip`，Mirror酱调用 `MaaResource/latest` 增量资源接口。
- 读取安装目录中的 `resource/version.json` 判断当前资源版本，支持 Mirror酱 CDK 到期、过期、无效、失效、配额等状态提示，错误信息不回显 CDK。
- 更新包先合并到 staging：复制现有 `resource` 后增量覆盖，并最后写入 `version.json`，保留原有资源中未包含的文件。
- 原子切换资源目录，更新前内容保存在 `resource.old`；下一次成功更新替换旧备份，失败时恢复当前资源及原备份。
- 校验 ZIP 路径、符号链接、文件数量、解压体积、包内版本及更新后实际版本。
- 更新成功后立即清理已加载的 MaaCore、Python 模块及导入缓存，再从安装目录重新读取资源版本并刷新页面。

### 检查后更新

- Maa 本体与 Maa 资源各增加独立的“检查更新”按钮。
- 页面初次打开时只读取本地安装状态，不自动开放更新按钮；检查成功且服务端确认存在新版本后，才开放对应更新按钮。
- Maa 本体使用 SemVer 比较正式版/公测版版本，MaaResource 使用 `last_updated` 时间比较。
- 检查结果与 Maa 目录、更新源、版本通道绑定；任一选项变化都会立即清除旧检查结果并关闭更新按钮。
- 后端签发一次性检查凭据，更新接口会再次核对目录、源、通道及当前版本，阻止跳过检查或使用已经失效的结果。
- 检查无更新或检测版本与已安装版本一致时，前后端都会保持更新按钮关闭并明确显示当前已是最新版本；首次下载安装 Maa 仍保持直接下载流程。

### 平台行为

- macOS/Linux：可由 Mower 检查并更新 Maa 本体及 MaaResource；资源更新要求 Mower 完全停止。
- Windows 未安装 Maa：仍可按架构通过 GitHub 或 Mirror酱下载完整包。
- Windows 已安装 Maa：不覆盖目录，提示手动打开 Maa 并在 Maa 设置中更新程序及资源。
- Maa 本体更新、MaaResource 更新和 Mower 启动之间增加互斥，避免同时操作 Maa 目录。

## 验证

- `ruff check .`
- `ruff format --check .`
- `npx --yes prettier@latest --check "ui/**/*.js" "ui/**/*.vue"`
- Maa 下载/更新、MaaResource 与路由测试：62 项通过
- Python 相关文件编译通过
- Vite production build 通过
- `git diff --check`
