### PR TITLE
fix(update): 刷新并缓存 Maa 更新版本

### DIFF
--- a/arknights_mower/tests/config_tests.py
+++ b/arknights_mower/tests/config_tests.py
@@ -15,10 +15,12 @@ class TestMaaConfig(unittest.TestCase):
         conf = Conf(
             maa_mirrorchyan_token="fixture-token",
             maa_update_channel="beta",
+            maa_auto_check_update=True,
         )
         restored = Conf(**conf.model_dump())
         self.assertEqual(restored.maa_mirrorchyan_token, "fixture-token")
         self.assertEqual(restored.maa_update_channel, "beta")
+        self.assertTrue(restored.maa_auto_check_update)
 
 
 class TestUpdateConfig(unittest.TestCase):

--- a/arknights_mower/tests/maa_update_route_tests.py
+++ b/arknights_mower/tests/maa_update_route_tests.py
@@ -55,6 +55,7 @@ class TestMaaUpdateRoutes(unittest.TestCase):
                 "source": "",
                 "current_version": "",
                 "latest_version": "",
+                "latest_release_note": "",
             }
         )
         server.maa_update_job.update({"thread": None, "status": "idle"})
@@ -75,7 +76,7 @@ class TestMaaUpdateRoutes(unittest.TestCase):
             patch(
                 "arknights_mower.utils.maa_update.read_installed_version",
                 return_value="v6.17.0",
-            ),
+            ) as read_version,
             patch(
                 "arknights_mower.utils.maa_update.get_latest_release",
                 return_value=_maa_release("v6.18.0"),
@@ -95,6 +96,7 @@ class TestMaaUpdateRoutes(unittest.TestCase):
         self.assertTrue(data["ok"])
         self.assertTrue(data["available"])
         self.assertTrue(data["check_id"])
+        read_version.assert_called_once_with(self.target, fresh=True)
 
         with (
             patch.object(server, "__system__", "darwin"),
@@ -125,6 +127,45 @@ class TestMaaUpdateRoutes(unittest.TestCase):
         self.assertTrue(data["ok"])
         self.assertFalse(data["available"])
         self.assertEqual(data["check_id"], "")
+
+    def test_maa_info_returns_cached_latest_and_fresh_installed_version(self):
+        target = str(Path(self.target).expanduser())
+        channel = server.config.conf.maa_update_channel
+        server.maa_update_check.update(
+            {
+                "id": "",
+                "target": target,
+                "source": "github",
+                "channel": channel,
+                "installed_version": "v6.17.0",
+                "latest_version": "v6.18.0",
+            }
+        )
+        with (
+            patch.object(server, "__system__", "darwin"),
+            patch(
+                "arknights_mower.utils.maa_update.has_maa_installation",
+                return_value=True,
+            ),
+            patch(
+                "arknights_mower.utils.maa_update.read_installed_version",
+                return_value="v6.18.0",
+            ) as read_version,
+        ):
+            response = self.client.get(
+                "/maa-update/info",
+                query_string={
+                    "maa_path": target,
+                    "source": "github",
+                    "channel": channel,
+                },
+                headers=self.headers,
+            )
+
+        data = response.get_json()
+        self.assertEqual(data["latest"]["tag"], "v6.18.0")
+        self.assertEqual(data["installed_version"], "v6.18.0")
+        read_version.assert_called_once_with(Path(target), fresh=True)
 
     def test_maa_update_start_requires_matching_successful_check(self):
         with (
@@ -283,6 +324,40 @@ class TestMaaUpdateRoutes(unittest.TestCase):
         data = response.get_json()
         self.assertFalse(data["ok"])
         self.assertIn("先检查 Maa 资源更新", data["message"])
+
+    def test_resource_info_returns_cached_latest_version(self):
+        target = str(Path(self.target).expanduser())
+        latest = "2026-09-04 01:07:54.000"
+        server.maa_resource_update_check.update(
+            {
+                "id": "",
+                "target": target,
+                "source": "github",
+                "current_version": "2026-09-03 01:00:00.000",
+                "latest_version": latest,
+                "latest_release_note": "测试活动",
+            }
+        )
+        with (
+            patch.object(server, "__system__", "darwin"),
+            patch(
+                "arknights_mower.utils.maa_update.has_maa_installation",
+                return_value=True,
+            ),
+            patch(
+                "arknights_mower.utils.maa_resource_update.read_maa_resource_info",
+                return_value={"version": latest, "release_note": "测试活动"},
+            ),
+        ):
+            response = self.client.get(
+                "/maa-resource-update/info",
+                query_string={"maa_path": target, "source": "github"},
+                headers=self.headers,
+            )
+
+        data = response.get_json()
+        self.assertEqual(data["latest"]["version"], latest)
+        self.assertEqual(data["latest"]["release_note"], "测试活动")
 
     def test_resource_update_start_rejects_equal_checked_version(self):
         target = str(Path(self.target).expanduser())

--- a/arknights_mower/tests/maa_update_tests.py
+++ b/arknights_mower/tests/maa_update_tests.py
@@ -554,28 +554,60 @@ class TestArchiveExtraction(unittest.TestCase):
 
 
 class TestInstalledVersion(unittest.TestCase):
-    def test_reads_version_from_maa_core(self):
+    @staticmethod
+    def _library(version=b"v6.17.0"):
         class GetVersion:
             argtypes = None
             restype = None
 
             def __call__(self):
-                return b"v6.17.0"
+                return version
 
         class Library:
             _handle = 123
             AsstGetVersion = GetVersion()
 
+        return Library()
+
+    def test_reads_version_from_maa_core(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             (root / "libMaaCore.dylib").write_bytes(b"fixture")
             with (
-                patch.object(mu.ctypes, "CDLL", return_value=Library()),
+                patch.object(mu.ctypes, "CDLL", return_value=self._library()),
                 patch.object(mu, "_close_dynamic_library") as close,
             ):
                 version = mu.read_installed_version(root)
 
         self.assertEqual(version, "v6.17.0")
+        close.assert_called_once_with(123)
+
+    def test_fresh_read_uses_and_removes_unique_library_copy(self):
+        loaded_paths = []
+
+        def load_library(path):
+            loaded_path = Path(path)
+            self.assertTrue(loaded_path.is_file())
+            loaded_paths.append(loaded_path)
+            return self._library(b"v6.18.0")
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            library_path = root / "libMaaCore.dylib"
+            library_path.write_bytes(b"fixture")
+            with (
+                patch.object(mu.ctypes, "CDLL", side_effect=load_library),
+                patch.object(mu, "_close_dynamic_library") as close,
+            ):
+                version = mu.read_installed_version(root, fresh=True)
+
+            self.assertEqual(len(loaded_paths), 1)
+            self.assertNotEqual(loaded_paths[0], library_path)
+            self.assertEqual(loaded_paths[0].parent, root)
+            self.assertIn(".version-probe-", loaded_paths[0].name)
+            self.assertFalse(loaded_paths[0].exists())
+
+        self.assertEqual(version, "v6.18.0")
         close.assert_called_once_with(123)
 
     def test_missing_maa_core_has_no_installed_version(self):

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -215,6 +215,8 @@ class MaaPart(ConfModel):
     "Mirror酱下载 Token"
     maa_update_channel: str = "stable"
     "MAA 版本通道：stable 正式版，beta 公测版"
+    maa_auto_check_update: bool = False
+    "进入 Maa 设置页后自动检查 Maa 本体及资源更新"
     maa_conn_preset: str = "General"
     maa_touch_option: str = "maatouch"
 

--- a/arknights_mower/utils/maa_update.py
+++ b/arknights_mower/utils/maa_update.py
@@ -1306,16 +1306,29 @@ def _close_dynamic_library(handle: int) -> None:
         pass
 
 
-def read_installed_version(target: Path | str) -> str:
-    """直接调用安装目录中 MaaCore 的版本接口，不依赖更新记录文件。"""
+def read_installed_version(target: Path | str, *, fresh: bool = False) -> str:
+    """直接调用安装目录中 MaaCore 的版本接口，不依赖更新记录文件。
+
+    ``fresh`` 会把 MaaCore 临时复制到同目录的唯一文件名后再加载，避开
+    macOS 等平台按动态库路径复用旧映像的缓存。
+    """
     library_path = _find_maa_core_library(target)
     if library_path is None:
         return ""
 
+    load_path = library_path
+    probe_path = None
     library = None
     get_version = None
     try:
-        library = ctypes.CDLL(str(library_path))
+        if fresh:
+            probe_path = library_path.with_name(
+                f".{library_path.stem}.version-probe-{uuid.uuid4().hex}"
+                f"{library_path.suffix}"
+            )
+            shutil.copy2(library_path, probe_path)
+            load_path = probe_path
+        library = ctypes.CDLL(str(load_path))
         get_version = library.AsstGetVersion
         get_version.argtypes = []
         get_version.restype = ctypes.c_char_p
@@ -1334,6 +1347,11 @@ def read_installed_version(target: Path | str) -> str:
             handle = library._handle
             library = None
             _close_dynamic_library(handle)
+        if probe_path is not None:
+            try:
+                probe_path.unlink(missing_ok=True)
+            except OSError:
+                pass
 
 
 def clear_loaded_maa_cache(target: Path | str) -> None:

--- a/server.py
+++ b/server.py
@@ -135,6 +135,7 @@ maa_resource_update_check = {
     "source": "",
     "current_version": "",
     "latest_version": "",
+    "latest_release_note": "",
 }
 maa_resource_update_check_lock = RLock()
 maa_maintenance_lock = RLock()
@@ -215,6 +216,14 @@ def _checked_latest_version(check: dict, lock: RLock, check_id: str) -> str:
         if not check_id or check.get("id") != check_id:
             return ""
         return str(check.get("latest_version") or "")
+
+
+def _cached_update_check(check: dict, lock: RLock, **expected: str) -> dict:
+    """读取最近一次匹配的检查结果；检查凭据消费后仍保留展示缓存。"""
+    with lock:
+        if not all(check.get(key) == value for key, value in expected.items()):
+            return {}
+        return dict(check)
 
 
 def _consume_update_check(
@@ -303,7 +312,9 @@ def _run_maa_update(
             channel=channel,
         )
         clear_loaded_maa_cache(result["target"])
-        result["installed_version"] = read_installed_version(result["target"])
+        result["installed_version"] = read_installed_version(
+            result["target"], fresh=True
+        )
     except Exception as e:
         logger.exception(f"MAA {operation}失败：{e}")
         with maa_update_lock:
@@ -994,7 +1005,7 @@ def get_maa_update_info():
     target = Path(configured_target).expanduser() if configured_target else None
     target_text = str(target) if target is not None else ""
     job = _maa_update_snapshot()
-    installed_version = read_installed_version(target) if target else ""
+    installed_version = read_installed_version(target, fresh=True) if target else ""
     installed = has_maa_installation(target) if target else False
     channel_error = ""
     try:
@@ -1004,6 +1015,15 @@ def get_maa_update_info():
     except MaaUpdateError as e:
         channel = "stable"
         channel_error = str(e)
+    source = str(request.args.get("source") or "github").strip()
+    cached_check = _cached_update_check(
+        maa_update_check,
+        maa_update_check_lock,
+        target=target_text,
+        source=source,
+        channel=channel,
+    )
+    cached_latest = str(cached_check.get("latest_version") or "")
     supported = __system__ in {"darwin", "linux"} or (
         __system__ == "windows" and not installed
     )
@@ -1035,7 +1055,7 @@ def get_maa_update_info():
         "backup": str(backup_path_for(target)) if target is not None else "",
         "installed": installed,
         "installed_version": installed_version,
-        "latest": None,
+        "latest": {"tag": cached_latest} if cached_latest else None,
         "check_required": installed and __system__ in {"darwin", "linux"},
         "job": job,
     }
@@ -1090,7 +1110,7 @@ def check_maa_update():
         channel = normalize_update_channel(
             payload.get("channel") or config.conf.maa_update_channel
         )
-        installed_version = read_installed_version(target)
+        installed_version = read_installed_version(target, fresh=True)
         if not installed_version:
             raise MaaUpdateError("未读取到已安装的 Maa 版本，请检查 Maa 目录")
         release = (
@@ -1194,7 +1214,7 @@ def start_maa_update():
                 return {"ok": False, "message": f"MAA {operation}正在进行中"}
             if installed:
                 check_id = str(payload.get("check_id") or "")
-                installed_version = read_installed_version(target)
+                installed_version = read_installed_version(target, fresh=True)
                 checked_latest = _checked_latest_version(
                     maa_update_check,
                     maa_update_check_lock,
@@ -1304,6 +1324,15 @@ def get_maa_resource_update_info():
         request.args.get("maa_path") or config.conf.maa_path or ""
     ).strip()
     target = Path(configured_target).expanduser() if configured_target else None
+    target_text = str(target) if target else ""
+    source = str(request.args.get("source") or "github").strip()
+    cached_check = _cached_update_check(
+        maa_resource_update_check,
+        maa_resource_update_check_lock,
+        target=target_text,
+        source=source,
+    )
+    cached_latest = str(cached_check.get("latest_version") or "")
     installed = has_maa_installation(target) if target else False
     supported = __system__ in {"darwin", "linux"} and installed
     current = (
@@ -1315,9 +1344,16 @@ def get_maa_resource_update_info():
         "ok": True,
         "supported": supported,
         "platform": __system__,
-        "target": str(target) if target else "",
+        "target": target_text,
         "current": current,
-        "latest": None,
+        "latest": (
+            {
+                "version": cached_latest,
+                "release_note": str(cached_check.get("latest_release_note") or ""),
+            }
+            if cached_latest
+            else None
+        ),
         "available": False,
         "backup": str(resource_backup_path(target)) if target else "",
         "job": _maa_resource_update_snapshot(),
@@ -1383,6 +1419,7 @@ def check_maa_resource_update():
             source=source,
             current_version=current["version"],
             latest_version=release.version,
+            latest_release_note=release.release_note,
         )
     source_label = "Mirror酱" if source == "mirrorchyan" else "GitHub"
     return {

--- a/ui/src/components/MaaBasic.vue
+++ b/ui/src/components/MaaBasic.vue
@@ -8,8 +8,14 @@ import { useConfigStore } from '@/stores/config'
 const store = useConfigStore()
 
 import { storeToRefs } from 'pinia'
-const { maa_path, maa_mirrorchyan_token, maa_update_channel, maa_conn_preset, maa_touch_option } =
-  storeToRefs(store)
+const {
+  maa_path,
+  maa_mirrorchyan_token,
+  maa_update_channel,
+  maa_auto_check_update,
+  maa_conn_preset,
+  maa_touch_option
+} = storeToRefs(store)
 
 import { folder_dialog } from '@/utils/dialog'
 
@@ -126,6 +132,7 @@ const maa_resource_update_job = ref({
 let maa_resource_update_timer = null
 let maa_resource_update_info_request_id = 0
 let maa_path_refresh_timer = null
+let maa_auto_check_timer = null
 const mirrorchyan_cdk_status = ref({
   loading: false,
   checked_token: '',
@@ -151,6 +158,10 @@ function reset_mirrorchyan_cdk_status(message = '') {
 }
 
 async function check_mirrorchyan_cdk(token = maa_mirrorchyan_token.value) {
+  if (mirrorchyan_cdk_timer) {
+    window.clearTimeout(mirrorchyan_cdk_timer)
+    mirrorchyan_cdk_timer = null
+  }
   const normalized_token = String(token || '').trim()
   if (normalized_token.length !== 24) {
     reset_mirrorchyan_cdk_status(normalized_token ? '请输入完整的 24 位 Mirror酱 CDK' : '')
@@ -219,25 +230,27 @@ function schedule_mirrorchyan_cdk_check(token) {
   mirrorchyan_cdk_timer = window.setTimeout(() => check_mirrorchyan_cdk(normalized_token), 500)
 }
 
-function reset_maa_update_check() {
+function reset_maa_update_check(clear_latest = true) {
   maa_update_check.value = {
     status: 'idle',
     message: '',
     available: false,
     id: ''
   }
-  maa_latest_version.value = ''
+  if (clear_latest) maa_latest_version.value = ''
 }
 
-function reset_maa_resource_update_check() {
+function reset_maa_resource_update_check(clear_latest = true) {
   maa_resource_update_check.value = {
     status: 'idle',
     message: '',
     available: false,
     id: ''
   }
-  maa_resource_latest_version.value = ''
-  maa_resource_release_note.value = ''
+  if (clear_latest) {
+    maa_resource_latest_version.value = ''
+    maa_resource_release_note.value = ''
+  }
 }
 
 function normalize_maa_version(value) {
@@ -264,23 +277,36 @@ watch(
     if (maa_update_supported.value) {
       schedule_mirrorchyan_cdk_check(token)
     }
+    schedule_auto_check_updates(900)
   },
   { immediate: true }
 )
 
-watch(maa_update_channel, (channel, previous_channel) => {
+watch(maa_update_channel, async (channel, previous_channel) => {
   if (channel === previous_channel) return
   reset_maa_update_check()
   if (maa_update_supported.value) {
     schedule_mirrorchyan_cdk_check(maa_mirrorchyan_token.value)
+    await get_maa_update_info()
   }
-  if (maa_update_supported.value) get_maa_update_info()
+  schedule_auto_check_updates()
 })
 
-watch(maa_update_source, (source, previous_source) => {
+watch(maa_update_source, async (source, previous_source) => {
   if (source === previous_source) return
   reset_maa_update_check()
   reset_maa_resource_update_check()
+  await Promise.all([get_maa_update_info(), get_maa_resource_update_info()])
+  schedule_auto_check_updates()
+})
+
+watch(maa_auto_check_update, (enabled) => {
+  if (enabled) {
+    schedule_auto_check_updates(0)
+  } else if (maa_auto_check_timer) {
+    window.clearTimeout(maa_auto_check_timer)
+    maa_auto_check_timer = null
+  }
 })
 
 const maa_updating = computed(() => maa_update_job.value.status === 'running')
@@ -374,6 +400,46 @@ const maa_resource_update_progress_status = computed(() => {
   return 'default'
 })
 
+async function auto_check_updates() {
+  if (
+    !maa_auto_check_update.value ||
+    maa_path_missing.value ||
+    maa_updating.value ||
+    maa_resource_updating.value ||
+    maa_update_checking.value ||
+    maa_resource_update_checking.value
+  ) {
+    return
+  }
+  if (
+    maa_update_source.value === 'mirrorchyan' &&
+    String(maa_mirrorchyan_token.value || '').trim().length !== 24
+  ) {
+    return
+  }
+  if (maa_installed.value && maa_update_supported.value) {
+    await check_maa_update()
+  }
+  if (
+    maa_auto_check_update.value &&
+    !maa_updating.value &&
+    !maa_resource_updating.value &&
+    maa_resource_update_supported.value
+  ) {
+    await check_maa_resource_update()
+  }
+}
+
+function schedule_auto_check_updates(delay = 400) {
+  if (maa_auto_check_timer) window.clearTimeout(maa_auto_check_timer)
+  maa_auto_check_timer = null
+  if (!maa_auto_check_update.value) return
+  maa_auto_check_timer = window.setTimeout(() => {
+    maa_auto_check_timer = null
+    auto_check_updates()
+  }, delay)
+}
+
 function format_bytes(value) {
   const size = Number(value || 0)
   if (!size) return '0 B'
@@ -385,27 +451,23 @@ function format_bytes(value) {
 function apply_maa_update_job(job, apply_install_info = true) {
   if (!job) return
   maa_update_job.value = { ...maa_update_job.value, ...job }
-  if (apply_install_info) {
-    if (job.result?.backup) maa_backup_path.value = job.result.backup
-    if (job.status === 'success' && job.result?.installed_version) {
-      maa_installed_version.value = job.result.installed_version
-    }
-  }
+  if (apply_install_info && job.result?.backup) maa_backup_path.value = job.result.backup
 }
 
 async function poll_maa_update() {
   if (maa_update_timer) window.clearTimeout(maa_update_timer)
   try {
     const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/maa-update/status`)
-    apply_maa_update_job(response.data.job)
+    apply_maa_update_job(response.data.job, false)
     if (maa_update_job.value.status === 'running') {
       maa_update_timer = window.setTimeout(poll_maa_update, 800)
     } else if (maa_update_job.value.status === 'success') {
-      reset_maa_update_check()
-      reset_maa_resource_update_check()
+      reset_maa_update_check(false)
+      reset_maa_resource_update_check(false)
       await get_maa_update_info()
       await get_maa_resource_update_info()
       await get_maa_conn_presets()
+      schedule_auto_check_updates()
     }
   } catch (error) {
     maa_update_job.value.status = 'error'
@@ -417,7 +479,11 @@ async function get_maa_update_info() {
   const request_id = ++maa_update_info_request_id
   try {
     const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/maa-update/info`, {
-      params: { channel: maa_update_channel.value, maa_path: maa_path.value }
+      params: {
+        channel: maa_update_channel.value,
+        maa_path: maa_path.value,
+        source: maa_update_source.value
+      }
     })
     if (request_id !== maa_update_info_request_id) return
     const data = response.data
@@ -434,7 +500,7 @@ async function get_maa_update_info() {
       maa_update_source.value = data.default_source === 'mirrorchyan' ? 'mirrorchyan' : 'github'
       maa_update_source_initialized = true
     }
-    maa_latest_version.value = data.latest?.tag || ''
+    if (data.latest?.tag) maa_latest_version.value = data.latest.tag
     maa_installed_version.value = data.installed_version || ''
     maa_backup_path.value = data.backup || ''
     maa_update_info_msg.value = data.ok
@@ -465,9 +531,10 @@ async function poll_maa_resource_update() {
     if (maa_resource_update_job.value.status === 'running') {
       maa_resource_update_timer = window.setTimeout(poll_maa_resource_update, 800)
     } else if (maa_resource_update_job.value.status === 'success') {
-      reset_maa_resource_update_check()
+      reset_maa_resource_update_check(false)
       await get_maa_resource_update_info()
       await get_maa_conn_presets()
+      schedule_auto_check_updates()
     }
   } catch (error) {
     maa_resource_update_job.value.status = 'error'
@@ -479,14 +546,16 @@ async function get_maa_resource_update_info() {
   const request_id = ++maa_resource_update_info_request_id
   try {
     const response = await axios.get(`${import.meta.env.VITE_HTTP_URL}/maa-resource-update/info`, {
-      params: { maa_path: maa_path.value }
+      params: { maa_path: maa_path.value, source: maa_update_source.value }
     })
     if (request_id !== maa_resource_update_info_request_id) return
     const data = response.data
     maa_resource_update_supported.value = Boolean(data.supported)
     maa_resource_current_version.value = data.current?.version || ''
-    maa_resource_latest_version.value = data.latest?.version || ''
-    maa_resource_release_note.value = data.latest?.release_note || ''
+    if (data.latest?.version) {
+      maa_resource_latest_version.value = data.latest.version
+      maa_resource_release_note.value = data.latest.release_note || ''
+    }
     maa_resource_backup_path.value = data.backup || ''
     maa_resource_update_info_msg.value = data.ok ? '' : data.message || '读取 Maa 资源版本失败'
     if (data.job?.target === data.target) {
@@ -513,7 +582,7 @@ async function get_maa_resource_update_info() {
 
 async function check_maa_update() {
   if (maa_update_checking.value || maa_updating.value || !maa_installed.value) return
-  reset_maa_update_check()
+  reset_maa_update_check(false)
   maa_update_info_msg.value = ''
   if (maa_path_missing.value) {
     maa_update_check.value.status = 'error'
@@ -565,7 +634,7 @@ async function check_maa_update() {
 async function check_maa_resource_update() {
   if (maa_resource_update_checking.value || maa_resource_updating.value || maa_updating.value)
     return
-  reset_maa_resource_update_check()
+  reset_maa_resource_update_check(false)
   maa_resource_update_info_msg.value = ''
   if (maa_path_missing.value) {
     maa_resource_update_check.value.status = 'error'
@@ -648,7 +717,7 @@ async function start_maa_update() {
         response.data.message || `MAA ${maa_managed_operation_label.value}启动失败`
       return
     }
-    reset_maa_update_check()
+    reset_maa_update_check(false)
     apply_maa_update_job(response.data.job)
     poll_maa_update()
   } catch (error) {
@@ -691,7 +760,7 @@ async function start_maa_resource_update() {
       maa_resource_update_job.value.message = response.data.message || 'Maa 资源更新启动失败'
       return
     }
-    reset_maa_resource_update_check()
+    reset_maa_resource_update_check(false)
     apply_maa_resource_update_job(response.data.job)
     poll_maa_resource_update()
   } catch (error) {
@@ -706,25 +775,29 @@ watch(maa_path, (value, previous_value) => {
   reset_maa_update_check()
   reset_maa_resource_update_check()
   if (maa_path_refresh_timer) window.clearTimeout(maa_path_refresh_timer)
-  maa_path_refresh_timer = window.setTimeout(() => {
-    get_maa_update_info()
-    get_maa_resource_update_info()
-    get_maa_conn_presets()
+  maa_path_refresh_timer = window.setTimeout(async () => {
+    await Promise.all([
+      get_maa_update_info(),
+      get_maa_resource_update_info(),
+      get_maa_conn_presets()
+    ])
+    schedule_auto_check_updates()
   }, 400)
 })
 
-onMounted(() => {
-  get_maa_conn_presets()
-  get_maa_update_info()
-  get_maa_resource_update_info()
+onMounted(async () => {
+  await Promise.all([get_maa_conn_presets(), get_maa_update_info(), get_maa_resource_update_info()])
+  schedule_auto_check_updates()
 })
 
 onUnmounted(() => {
   if (maa_update_timer) window.clearTimeout(maa_update_timer)
   if (maa_resource_update_timer) window.clearTimeout(maa_resource_update_timer)
   if (maa_path_refresh_timer) window.clearTimeout(maa_path_refresh_timer)
+  if (maa_auto_check_timer) window.clearTimeout(maa_auto_check_timer)
   if (mirrorchyan_cdk_timer) window.clearTimeout(mirrorchyan_cdk_timer)
   mirrorchyan_cdk_request_id++
+  maa_update_info_request_id++
   maa_resource_update_info_request_id++
 })
 </script>
@@ -772,11 +845,16 @@ onUnmounted(() => {
         <div class="update-meta">
           <span>
             可{{ maa_managed_operation_label }}的{{ maa_update_channel_label }}：{{
-              maa_latest_version || '待获取'
+              maa_latest_version || '尚未检查'
             }}
           </span>
           <span v-if="maa_update_platform === 'windows'">已安装：未检测到 Maa</span>
           <span v-else>已安装：{{ maa_installed_version || '未知/手动安装' }}</span>
+        </div>
+        <div class="update-option">
+          <span class="update-option-label">自动检查更新</span>
+          <n-switch v-model:value="maa_auto_check_update" />
+          <span class="update-hint">进入此页面或更新配置后自动检查 Maa 本体与 Maa 资源。</span>
         </div>
         <div class="update-option">
           <span class="update-option-label">{{ maa_managed_operation_label }}通道</span>
@@ -930,7 +1008,7 @@ onUnmounted(() => {
         </div>
         <div class="update-meta">
           <span>当前资源：{{ maa_resource_current_version || '未知' }}</span>
-          <span>最新资源：{{ maa_resource_latest_version || '待获取' }}</span>
+          <span>最新资源：{{ maa_resource_latest_version || '尚未检查' }}</span>
         </div>
         <div v-if="maa_resource_release_note" class="update-hint">
           最新活动资源：{{ maa_resource_release_note }}

--- a/ui/src/stores/config.js
+++ b/ui/src/stores/config.js
@@ -18,6 +18,7 @@ export const useConfigStore = defineStore('config', () => {
   const maa_path = ref('')
   const maa_mirrorchyan_token = ref('')
   const maa_update_channel = ref('stable')
+  const maa_auto_check_update = ref(false)
   const maa_expiring_medicine = ref(true)
   const ap_fallback = ref(0)
   const maa_weekly_plan = ref([])
@@ -270,6 +271,7 @@ export const useConfigStore = defineStore('config', () => {
     maa_path.value = response.data.maa_path
     maa_mirrorchyan_token.value = response.data.maa_mirrorchyan_token || ''
     maa_update_channel.value = response.data.maa_update_channel === 'beta' ? 'beta' : 'stable'
+    maa_auto_check_update.value = response.data.maa_auto_check_update ?? false
     maa_rg_enable.value = response.data.maa_rg_enable == 1
     maa_long_task_type.value = response.data.maa_long_task_type
     maa_expiring_medicine.value = response.data.maa_expiring_medicine
@@ -382,6 +384,7 @@ export const useConfigStore = defineStore('config', () => {
       maa_path: maa_path.value,
       maa_mirrorchyan_token: maa_mirrorchyan_token.value,
       maa_update_channel: maa_update_channel.value,
+      maa_auto_check_update: maa_auto_check_update.value,
       maa_rg_enable: maa_rg_enable.value ? 1 : 0,
       maa_long_task_type: maa_long_task_type.value,
       maa_expiring_medicine: maa_expiring_medicine.value,
@@ -526,6 +529,7 @@ export const useConfigStore = defineStore('config', () => {
     maa_path,
     maa_mirrorchyan_token,
     maa_update_channel,
+    maa_auto_check_update,
     maa_rg_enable,
     maa_long_task_type,
     maa_expiring_medicine,


### PR DESCRIPTION
## 目标

修复 Maa 更新完成后设置页仍显示旧安装版本、已检查的最新版本被重置为“待获取”的问题，并增加可持久化的自动检查更新开关。

## 主要改动

- Maa 更新完成后先清理 Mower 已加载的 MaaCore 与 Python 缓存，再通过唯一临时副本重新加载安装目录中的 MaaCore，读取实际安装版本并立即刷新页面。
- 页面不再使用下载任务中的版本号直接覆盖“已安装版本”，安装版本统一以重新读取 MaaCore 的结果为准。
- 缓存最近一次与目录、更新源、版本通道匹配的 Maa/MaaResource 最新版本；更新开始、完成及重新读取本地信息时不再清空展示缓存。
- 路径、更新源、版本通道或 Mirror酱 CDK 改变时仍会清除不再匹配的前端检查状态；未检查时文案调整为“尚未检查”。
- 新增持久化“自动检查更新”开关，进入 Maa 设置页或相关配置变化后自动检查 Maa 本体与 MaaResource。
- 检查结果仍使用一次性凭据控制更新按钮；已安装版本与最新版本一致时保持按钮关闭。

## 验证

- `ruff check .`
- `ruff format --check .`
- `npx --yes prettier@latest --check \"ui/**/*.js\" \"ui/**/*.vue\"`
- Maa 下载/更新、MaaResource、配置与路由测试：83 项通过
- Vite production build 通过
- `git diff --check`