### PR TITLE
fix(schedule): 修复无人机加速面板首次点击未生效时误消费跑单任务

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -8,7 +8,7 @@ import urllib
 from collections import defaultdict, deque
 from ctypes import CFUNCTYPE, c_char_p, c_int, c_void_p
 from datetime import datetime, timedelta
-from typing import Literal
+from typing import Literal, Optional
 
 import cv2
 
@@ -66,7 +66,7 @@ from arknights_mower.utils.operators import (
 )
 from arknights_mower.utils.path import get_path
 from arknights_mower.utils.plan import PlanTriggerTiming
-from arknights_mower.utils.recognize import Recognizer, Scene
+from arknights_mower.utils.recognize import RecognizeError, Recognizer, Scene
 from arknights_mower.utils.scheduler_task import (
     SchedulerTask,
     TaskTypes,
@@ -2395,6 +2395,39 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 break
         return None
 
+    def _tap_drone_accelerate(
+        self,
+        accelerate_res: str,
+        all_in_res: str,
+        max_retry: int = 3,
+        interval: float = 1,
+    ) -> Optional[tp.Scope]:
+        """点击无人机加速按钮并确认加速面板打开，有界重试。
+
+        首次点击可能因界面未响应而未打开面板，此时仍停留在详情页；若不确认
+        all_in 出现就继续操作，会在详情页上误触。每次重试前重新识别加速按钮，
+        确认仍处于可点击的详情页后再点击。持续失败时抛出异常，让上层保留任务
+        并按既有策略退避，而不是把未执行的跑单当成已完成。
+        """
+        accelerate = self.find(accelerate_res)
+        for _ in range(max_retry):
+            if accelerate is None:
+                break
+            self.tap(accelerate, interval=interval)
+            all_in = self.find(all_in_res)
+            if all_in is not None:
+                return all_in
+            logger.debug(f"无人机加速面板未出现，重新识别 {accelerate_res} 后重试")
+            accelerate = self.find(accelerate_res)
+            if accelerate is None:
+                # 加速按钮消失通常意味着面板已打开：等一帧再确认 all_in，避免误判
+                self.sleep(0.5)
+                all_in = self.find(all_in_res)
+                if all_in is not None:
+                    return all_in
+                break
+        raise RecognizeError(f"无人机加速面板未出现：未识别到 {all_in_res}")
+
     def drone(
         self,
         room: str,
@@ -2424,8 +2457,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 logger.info(f"无人机数量小于{config.conf.drone_count_limit}->停止")
                 return
             logger.info("制造站加速")
-            self.tap(accelerate)
-            # self.tap_element('all_in')
+            all_in_scope = self._tap_drone_accelerate("factory_accelerate", "all_in")
             # 如果不是全部all in
             if all_in > 0:
                 tap_times = (
@@ -2434,14 +2466,14 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 for _count in range(tap_times):
                     self.tap((self.recog.w * 0.7, self.recog.h * 0.5), interval=0.1)
             else:
-                self.tap_element("all_in")
+                self.tap(all_in_scope)
             self.tap(accelerate, y_rate=1)
         else:
             accelerate = self.find("bill_accelerate")
             while accelerate and not adjust_time:
                 logger.info("贸易站加速")
-                self.tap(accelerate)
-                self.tap_element("all_in")
+                all_in_scope = self._tap_drone_accelerate("bill_accelerate", "all_in")
+                self.tap(all_in_scope)
                 self.tap((self.recog.w * 0.75, self.recog.h * 0.8))
                 if self.scene() in self.waiting_scene:
                     if not self.waiting_solver():
@@ -3576,6 +3608,10 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
     def agent_arrange(self, plan: tp.BasePlan, get_time=False):
         logger.info("基建：排班")
         rooms = list(plan.keys())
+        # 保存原班：#907 无人机加速失败时恢复，避免任务以空 plan 在下一轮被误消费
+        original_plan = (
+            copy.deepcopy(plan) if self.task.type == TaskTypes.RUN_ORDER else None
+        )
         new_plan = {}
         # 优先替换工作站再替换宿舍
         rooms.sort(
@@ -3591,7 +3627,13 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 if self.task.adjusted:
                     logger.info("检测到跑单已调整，强制使用无人机跑单")
                 logger.info("开始插拔")
-                self.drone(room, not_customize=True)
+                try:
+                    self.drone(room, not_customize=True)
+                except Exception:
+                    # #907：无人机加速失败时恢复原班，避免任务以空 plan 在下轮被误消费
+                    if original_plan is not None:
+                        self.task.plan = original_plan
+                    raise
             else:
                 # 葛朗台跑单模式
                 self._wait_drone_interface()

--- a/arknights_mower/tests/base_scheduler_tests.py
+++ b/arknights_mower/tests/base_scheduler_tests.py
@@ -17,8 +17,12 @@ from arknights_mower.solvers.base_schedule import (  # noqa: E402
 from arknights_mower.utils.logic_expression import LogicExpression  # noqa: E402
 from arknights_mower.utils.operators import Operator  # noqa: E402
 from arknights_mower.utils.plan import Plan, PlanConfig, Room  # noqa: E402
-from arknights_mower.utils.recognize import Scene  # noqa: E402
-from arknights_mower.utils.scheduler_task import TaskTypes, find_next_task  # noqa: E402
+from arknights_mower.utils.recognize import RecognizeError, Scene  # noqa: E402
+from arknights_mower.utils.scheduler_task import (  # noqa: E402
+    SchedulerTask,
+    TaskTypes,
+    find_next_task,
+)
 
 with patch.dict("sys.modules", {"RecruitSolver": MagicMock()}):
     pass
@@ -1694,6 +1698,171 @@ class TestGroupToFixPlan(unittest.TestCase):
         self.assertIn("train", fix_plan)
         self.assertEqual(fix_plan["train"][0], "褐果")
         self.assertNotIn("central", fix_plan)
+
+
+class TestDroneAccelerate(unittest.TestCase):
+    """#907：无人机加速面板首次点击未生效时不应误消费跑单任务。
+
+    复现点：BaseSchedulerSolver.drone() 点击 bill_accelerate 后未确认加速面板
+    打开就继续操作 all_in，首次点击未生效时会在详情页误触，甚至把未执行的跑单
+    当成已完成。修复后由 _tap_drone_accelerate 先确认面板出现（有界重试）再操作，
+    持续失败则抛异常，上层据此保留任务并按既有策略退避。
+    """
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
+    def test_tap_drone_accelerate_retries_when_first_attempt_fails(self):
+        """首次点击 bill_accelerate 未打开面板时，重试后成功。"""
+        solver = BaseSchedulerSolver()
+        solver.recog = MagicMock()
+        solver.recog.w = 1920
+        solver.recog.h = 1080
+        accelerate_scope = ((100, 100), (200, 200))
+        all_in_scope = ((300, 300), (400, 400))
+
+        find_results = [
+            accelerate_scope,  # find(bill_accelerate)
+            None,  # find(all_in) -> 面板未打开
+            accelerate_scope,  # 重试前重新识别 bill_accelerate
+            all_in_scope,  # find(all_in) -> 面板已打开
+        ]
+        taps = []
+
+        with patch.object(solver, "find", side_effect=find_results):
+            with patch.object(
+                solver, "tap", side_effect=lambda poly, **kw: taps.append(poly)
+            ):
+                result = solver._tap_drone_accelerate("bill_accelerate", "all_in")
+
+        self.assertEqual(result, all_in_scope)
+        # 两次点击都是加速按钮：一次首次、一次重试
+        self.assertEqual(taps, [accelerate_scope, accelerate_scope])
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
+    def test_tap_drone_accelerate_raises_after_bounded_retries(self):
+        """持续无法打开面板时，重试有界且抛出异常，上层据此保留任务。"""
+        solver = BaseSchedulerSolver()
+        solver.recog = MagicMock()
+        accelerate_scope = ((100, 100), (200, 200))
+        taps = []
+
+        def fake_find(res, *args, **kwargs):
+            return accelerate_scope if res == "bill_accelerate" else None
+
+        with patch.object(solver, "find", side_effect=fake_find):
+            with patch.object(
+                solver, "tap", side_effect=lambda poly, **kw: taps.append(poly)
+            ):
+                with self.assertRaises(RecognizeError):
+                    solver._tap_drone_accelerate(
+                        "bill_accelerate", "all_in", max_retry=3
+                    )
+
+        # 有界重试：加速按钮只被点击 max_retry 次
+        self.assertEqual(len(taps), 3)
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
+    def test_tap_drone_accelerate_confirms_all_in_when_button_disappears(self):
+        """加速按钮消失（面板已打开）时，确认 all_in 而非直接判失败。
+
+        面板打开后加速按钮会被遮挡，此时不应把「识别不到按钮」当作失败，
+        而是再确认一次 all_in。
+        """
+        solver = BaseSchedulerSolver()
+        solver.recog = MagicMock()
+        accelerate_scope = ((100, 100), (200, 200))
+        all_in_scope = ((300, 300), (400, 400))
+
+        find_sequence = [
+            accelerate_scope,  # find(bill_accelerate) 初始命中
+            None,  # find(all_in) -> 面板瞬时未识别到
+            None,  # find(bill_accelerate) -> 按钮消失（面板已打开）
+            all_in_scope,  # 再确认 find(all_in) -> 面板已打开
+        ]
+        taps = []
+
+        with patch.object(solver, "find", side_effect=find_sequence):
+            with patch.object(solver, "sleep"):
+                with patch.object(
+                    solver, "tap", side_effect=lambda poly, **kw: taps.append(poly)
+                ):
+                    result = solver._tap_drone_accelerate("bill_accelerate", "all_in")
+
+        self.assertEqual(result, all_in_scope)
+        self.assertEqual(taps, [accelerate_scope])
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
+    def test_drone_factory_route_confirms_panel_before_accelerate(self):
+        """制造站加速前同样确认加速面板打开（#907 建议一并检查制造站）。"""
+        solver = BaseSchedulerSolver()
+        solver.recog = MagicMock()
+        solver.recog.w = 1920
+        solver.recog.h = 1080
+        solver.recog.gray = "gray"
+        solver.op_data = MagicMock()
+        solver.op_data.run_order_rooms = []
+        solver.digit_reader = MagicMock()
+        solver.digit_reader.get_drone.return_value = 150
+        accelerate_scope = ((100, 100), (200, 200))
+        all_in_scope = ((300, 300), (400, 400))
+
+        with (
+            patch.object(solver, "enter_room"),
+            patch.object(
+                solver,
+                "find",
+                side_effect=lambda res, **kw: (
+                    accelerate_scope if res == "factory_accelerate" else None
+                ),
+            ),
+            patch.object(solver, "_wait_drone_interface"),
+            patch.object(solver, "tap"),
+            patch.object(
+                solver, "_tap_drone_accelerate", return_value=all_in_scope
+            ) as mock_helper,
+            patch.object(solver, "scene_graph_navigation"),
+        ):
+            solver.drone("factory", not_customize=True)
+
+        # 制造站走确认面板的 helper，避免在详情页误触
+        mock_helper.assert_called_once_with("factory_accelerate", "all_in")
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda x: None)
+    def test_infra_main_keeps_run_order_task_alive_across_two_passes(self):
+        """#907：无人机加速失败后跑单任务不被消费、计划保持非空。
+
+        真实路径是 agent_arrange_room 会 del plan[room] 清空 self.task.plan；若
+        drone() 失败仅保留任务而不恢复计划，下一轮该空计划任务会绕过排班分支在
+        infra_main 被误消费。本测试连续两轮验证任务留存且计划被恢复。
+        """
+        task = SchedulerTask(
+            time=datetime.now(),
+            task_plan={"trading_1": ["干员"]},
+            task_type=TaskTypes.RUN_ORDER,
+            adjusted=True,  # 强制走「开始插拔」无人机跑单分支
+        )
+        solver = BaseSchedulerSolver()
+        solver.error = False
+        solver.tasks = [task]
+
+        def fake_arrange_room(new_plan, room, plan, get_time=False):
+            del plan[room]  # 与真实 agent_arrange_room 一致：清空 self.task.plan
+            return {room: ["干员"]}
+
+        for _ in range(2):  # 连续两轮，验证第二轮不被误消费
+            solver.task = task
+            solver.refresh_connecting = True  # 跳过 run_order_grandet_mode 提前返回
+            with (
+                patch.object(solver, "find", return_value=((0, 0), (10, 10))),
+                patch.object(
+                    solver, "agent_arrange_room", side_effect=fake_arrange_room
+                ),
+                patch.object(solver, "drone", side_effect=RecognizeError("boom")),
+                patch.object(base_schedule, "save_exception"),
+            ):
+                solver.infra_main()
+            self.assertEqual(solver.tasks, [task])  # 任务未被消费
+            self.assertEqual(task.plan, {"trading_1": ["干员"]})  # 计划已恢复
+        self.assertTrue(solver.error)  # 失败已置位，走既有退避
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### 目标

修复无人机加速面板首次点击未生效时会误消费跑单任务的问题。

`BaseSchedulerSolver.drone()` 识别到无人机协助入口（`bill_accelerate`）并点击后，会立即调用 `tap_element("all_in")`。如果首次点击没有成功打开加速面板，下一帧仍停留在详情页，此时 `find("all_in")` 返回 `None`，触发 `RecognizeError("poly is empty")`。

问题不止于这一次异常：`agent_arrange_room` 在调用 `drone()` 之前已经 `del plan[room]` 清空了 `self.task.plan`。异常退出后任务虽被保留，却带着空计划，下一轮会在 `infra_main` 绕过排班分支被当作已完成而消费，实际没有执行跑单。

### 主要改动

- 新增 `_tap_drone_accelerate` helper：点击加速按钮后确认加速面板打开（识别到 `all_in`），有界重试；每次重试前重新识别加速按钮，确认仍处于可点击的详情页后再点击；面板已打开但按钮被遮挡时，再补一次 `all_in` 识别，避免误判。
- 无人机持续失败时，`agent_arrange` 按原班恢复 `self.task.plan` 后再抛出 `RecognizeError`，让任务保留有效计划供重试，不再把未执行的跑单当成已完成。
- 贸易站（`bill_accelerate`）与制造站（`factory_accelerate`）两个流程一并应用确认逻辑：复用识别到的 `all_in` 坐标后再点击，避免二次随机匹配。
- 新增回归测试，覆盖首次点击失败后重试成功、持续失败有界重试、失败时任务保留且计划非空（连续两轮 `infra_main`）、制造站路由确认面板。

关联 #907。

### 验证与风险

- `base_scheduler_tests.py` 全量 56 tests OK，新增/改写的用例通过。
- `ruff check` 与 `ruff format --check` 通过，`compileall` 通过。
- 行为变化：持续无法打开加速面板时，由「静默继续或抛 `poly empty` 后任务被误消费」改为「确认失败后恢复原班并抛 `RecognizeError`，任务保留计划供重试」；对正常打开面板的路径没有影响。
