### PR TITLE
fix(update): 多开实例共用资源包

### DIFF
--- a/arknights_mower/tests/resource_pkg_tests.py
+++ b/arknights_mower/tests/resource_pkg_tests.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from arknights_mower import __rootdir__
+from arknights_mower.utils import path as mower_path
 from arknights_mower.utils import resource_pkg as rp
 from build_assets import _collect_arknights_mower_datas
 
@@ -43,10 +44,27 @@ class ResourcePkgTestBase(unittest.TestCase):
         self._patch.enter_context(patch.object(rp, "RESOURCE_OVERLAY", self.overlay))
         self._patch.enter_context(patch.object(rp, "_STAGING", self.staging))
         self._patch.enter_context(patch.object(rp, "_OLD", self.old))
+        self._patch.enter_context(
+            patch.object(rp, "_INSTALL_LOCK_PATH", self.base / "resource_install.lock")
+        )
+        self.legacy = self.base / "instance" / "tmp" / "resource"
+        self._patch.enter_context(
+            patch.object(rp, "_LEGACY_RESOURCE_OVERLAY", self.legacy)
+        )
+        self._patch.enter_context(patch.object(rp, "_loaded_resource_signature", None))
         self.reload_caches = self._patch.enter_context(
             patch.object(rp, "reload_resource_caches")
         )
         self.addCleanup(self._patch.close)
+
+
+class TestSharedResourceScope(unittest.TestCase):
+    def test_overlay_uses_shared_app_space(self):
+        with patch.object(mower_path, "global_space", "instance-a"):
+            shared = mower_path.get_path("@app/tmp/resource", space="")
+            instance = mower_path.get_path("@app/tmp/resource")
+        self.assertEqual(rp.RESOURCE_OVERLAY, shared)
+        self.assertNotEqual(shared, instance)
 
 
 class TestResourcePkgPath(ResourcePkgTestBase):
@@ -73,6 +91,42 @@ class TestResourcePkgPath(ResourcePkgTestBase):
 
 
 class TestInstallResourcePkg(ResourcePkgTestBase):
+    def test_migrates_existing_instance_overlay(self):
+        marker = self.legacy / "arknights_mower/data/version.json"
+        marker.parent.mkdir(parents=True)
+        marker.write_text('{"res_version":"v2026.08.23-aaaaaaa"}', encoding="utf-8")
+
+        self.assertTrue(rp.migrate_legacy_resource_overlay())
+        self.assertEqual(
+            (self.overlay / "arknights_mower/data/version.json").read_text(
+                encoding="utf-8"
+            ),
+            marker.read_text(encoding="utf-8"),
+        )
+
+    def test_existing_shared_overlay_wins_over_legacy(self):
+        shared_marker = self.overlay / "arknights_mower/data/version.json"
+        shared_marker.parent.mkdir(parents=True)
+        shared_marker.write_text("shared", encoding="utf-8")
+        legacy_marker = self.legacy / "arknights_mower/data/version.json"
+        legacy_marker.parent.mkdir(parents=True)
+        legacy_marker.write_text("legacy", encoding="utf-8")
+
+        self.assertFalse(rp.migrate_legacy_resource_overlay())
+        self.assertEqual(shared_marker.read_text(encoding="utf-8"), "shared")
+
+    def test_process_lock_rejects_parallel_installer(self):
+        with rp._resource_install_guard():
+            with self.assertRaisesRegex(TimeoutError, "其他 mower 实例"):
+                with rp._resource_install_guard(timeout=0):
+                    pass
+
+    def test_process_lock_is_released(self):
+        with rp._resource_install_guard():
+            pass
+        with rp._resource_install_guard(timeout=0):
+            pass
+
     def test_missing_marker_rejected(self):
         self.assertFalse(rp.install_resource_pkg(_zip_bytes(marker=False)))
         self.assertFalse(self.overlay.exists())
@@ -159,6 +213,17 @@ class TestInstallResourcePkg(ResourcePkgTestBase):
         self.assertEqual(self.reload_caches.call_count, 2)
         self.assertFalse(self.staging.exists())
         self.assertFalse(self.old.exists())
+
+    def test_other_instance_change_reloads_once(self):
+        marker = self.overlay / "arknights_mower/data/version.json"
+        marker.parent.mkdir(parents=True)
+        marker.write_text('{"res_version":"v2026.08.23-aaaaaaa"}', encoding="utf-8")
+        rp._remember_loaded_resource()
+        marker.write_text('{"res_version":"v2026.08.24-bbbbbbb"}', encoding="utf-8")
+
+        self.assertTrue(rp.reload_resource_caches_if_changed())
+        self.assertFalse(rp.reload_resource_caches_if_changed())
+        self.reload_caches.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/arknights_mower/utils/resource_pkg.py
+++ b/arknights_mower/utils/resource_pkg.py
@@ -9,23 +9,35 @@
 """
 
 import os
+import time
 from collections.abc import Callable
+from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
-from shutil import rmtree
+from shutil import copytree, rmtree
 from threading import RLock
 from zipfile import ZipFile
 
 import requests
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
 
 from arknights_mower import __rootdir__
 from arknights_mower.utils.log import logger
 from arknights_mower.utils.path import get_path
 from arknights_mower.utils.zip_safe import is_unsafe_zip_member
 
-RESOURCE_OVERLAY = get_path("@app/tmp/resource")
-_STAGING = get_path("@app/tmp/resource_staging")
-_OLD = get_path("@app/tmp/resource_old")
+# 资源属于当前 mower 安装，而不是某个配置实例。manager.py 会把实例目录写入
+# path.global_space，因此这里必须显式覆盖为默认应用空间；自动检查、自动更新开关仍
+# 保存在各实例自己的 conf.yml 中。
+RESOURCE_OVERLAY = get_path("@app/tmp/resource", space="")
+_STAGING = get_path("@app/tmp/resource_staging", space="")
+_OLD = get_path("@app/tmp/resource_old", space="")
+_INSTALL_LOCK_PATH = get_path("@app/tmp/resource_install.lock", space="")
+_LEGACY_RESOURCE_OVERLAY = get_path("@app/tmp/resource")
 RESOURCE_REPO = "ArkMowers/MowerResource"
 RESOURCE_ZIP_URL = (
     f"https://github.com/{RESOURCE_REPO}/releases/latest/download/resource.zip"
@@ -35,6 +47,90 @@ _RESOURCE_MARKER = "arknights_mower/data/version.json"
 _PKG_PREFIX = "arknights_mower/"
 _install_lock = RLock()
 _reload_callbacks: dict[str, Callable[[], None]] = {}
+_loaded_resource_signature: tuple[str, bytes] | None = None
+_LOCK_POLL_INTERVAL = 0.05
+
+
+def _lock_file(lock) -> None:
+    if os.name == "nt":
+        lock.seek(0)
+        if not lock.read(1):
+            lock.write(b"\0")
+            lock.flush()
+        lock.seek(0)
+        msvcrt.locking(lock.fileno(), msvcrt.LK_NBLCK, 1)
+    else:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _unlock_file(lock) -> None:
+    if os.name == "nt":
+        lock.seek(0)
+        msvcrt.locking(lock.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _resource_install_guard(timeout: float = 60):
+    """用系统文件锁串行化共享资源切换；进程退出后锁会由系统自动释放。"""
+    deadline = time.monotonic() + timeout
+    _INSTALL_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with _INSTALL_LOCK_PATH.open("a+b") as lock:
+        while True:
+            try:
+                _lock_file(lock)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("等待其他 mower 实例完成资源更新超时")
+                time.sleep(_LOCK_POLL_INTERVAL)
+        try:
+            yield
+        finally:
+            _unlock_file(lock)
+
+
+def _resource_signature() -> tuple[str, bytes] | None:
+    """返回当前共享 overlay 标记；内容变化用于通知其他实例刷新缓存。"""
+    marker = RESOURCE_OVERLAY / _RESOURCE_MARKER
+    try:
+        return ("overlay", marker.read_bytes())
+    except OSError:
+        builtin = Path(__rootdir__) / "data/version.json"
+        try:
+            return ("builtin", builtin.read_bytes())
+        except OSError:
+            return None
+
+
+def _remember_loaded_resource() -> None:
+    global _loaded_resource_signature
+    _loaded_resource_signature = _resource_signature()
+
+
+def migrate_legacy_resource_overlay() -> bool:
+    """首次升级时把当前实例已有的资源复制到共享空间。"""
+    if _LEGACY_RESOURCE_OVERLAY == RESOURCE_OVERLAY:
+        return False
+    legacy_marker = _LEGACY_RESOURCE_OVERLAY / _RESOURCE_MARKER
+    if not legacy_marker.is_file():
+        return False
+
+    try:
+        with _resource_install_guard():
+            if RESOURCE_OVERLAY.exists():
+                return False
+            rmtree(_STAGING, ignore_errors=True)
+            copytree(_LEGACY_RESOURCE_OVERLAY, _STAGING)
+            os.replace(_STAGING, RESOURCE_OVERLAY)
+    except Exception as e:
+        rmtree(_STAGING, ignore_errors=True)
+        logger.warning(f"迁移实例资源到共享目录失败：{e}")
+        return False
+
+    logger.info(f"已将实例资源迁移到共享目录：{RESOURCE_OVERLAY}")
+    return True
 
 
 def register_resource_reload(callback: Callable[[], None]) -> Callable[[], None]:
@@ -48,6 +144,26 @@ def reload_resource_caches() -> None:
     """刷新当前进程里已经加载过的资源数据；任一失败都向上抛出。"""
     for callback in tuple(_reload_callbacks.values()):
         callback()
+
+
+def reload_resource_caches_if_changed() -> bool:
+    """共享资源被其他实例替换后刷新本进程缓存；无变化或正在安装时返回 False。"""
+    if _resource_signature() == _loaded_resource_signature:
+        return False
+    with _install_lock:
+        if _resource_signature() == _loaded_resource_signature:
+            return False
+        try:
+            with _resource_install_guard(timeout=0):
+                signature = _resource_signature()
+                if signature == _loaded_resource_signature:
+                    return False
+                reload_resource_caches()
+                _remember_loaded_resource()
+        except TimeoutError:
+            return False
+    logger.info("检测到其他 mower 实例更新了共享资源，已刷新当前进程缓存")
+    return True
 
 
 def resource_pkg_path(rel: str) -> Path:
@@ -71,8 +187,7 @@ def download_resource_pkg() -> bytes | None:
         return None
 
 
-def install_resource_pkg(data: bytes) -> bool:
-    """原子安装资源包并刷新进程内缓存；切换或加载失败均回滚。"""
+def _install_resource_pkg_locked(data: bytes) -> bool:
     with _install_lock:
         try:
             with ZipFile(BytesIO(data)) as z:
@@ -110,6 +225,7 @@ def install_resource_pkg(data: bytes) -> bool:
 
         try:
             reload_resource_caches()
+            _remember_loaded_resource()
         except Exception as e:
             logger.exception(f"资源包进程内加载失败，正在回滚：{e}")
             try:
@@ -118,6 +234,7 @@ def install_resource_pkg(data: bytes) -> bool:
                 if _OLD.exists():
                     os.replace(_OLD, RESOURCE_OVERLAY)
                 reload_resource_caches()
+                _remember_loaded_resource()
             except Exception as rollback_error:
                 logger.exception(f"资源包回滚后重新加载失败：{rollback_error}")
             rmtree(_STAGING, ignore_errors=True)
@@ -127,3 +244,17 @@ def install_resource_pkg(data: bytes) -> bool:
             rmtree(_OLD, ignore_errors=True)
         logger.info(f"资源包安装成功并已在当前进程生效：{RESOURCE_OVERLAY}")
         return True
+
+
+def install_resource_pkg(data: bytes) -> bool:
+    """串行切换共享资源并刷新当前进程缓存；切换或加载失败均回滚。"""
+    try:
+        with _resource_install_guard():
+            return _install_resource_pkg_locked(data)
+    except TimeoutError as e:
+        logger.warning(f"资源包安装失败：{e}")
+        return False
+
+
+migrate_legacy_resource_overlay()
+_remember_loaded_resource()

--- a/server.py
+++ b/server.py
@@ -464,6 +464,24 @@ def _check_hot_update_on_launch():
 Thread(target=_check_hot_update_on_launch, daemon=True).start()
 
 
+def _watch_shared_resource_changes():
+    """其他实例更新共享资源后，在本实例空闲时刷新进程内缓存。"""
+    from arknights_mower.utils.resource_pkg import reload_resource_caches_if_changed
+
+    while True:
+        time.sleep(1)
+        if _mower_busy_response():
+            continue
+        try:
+            reload_resource_caches_if_changed()
+        except Exception:
+            logger.exception("刷新其他 mower 实例更新的共享资源失败")
+            time.sleep(30)
+
+
+Thread(target=_watch_shared_resource_changes, daemon=True).start()
+
+
 def require_token(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
@@ -484,7 +502,7 @@ def serve_resource_overlay():
     """资源包 webp（depot/avatar/building_skill）overlay 优先，刷新即生效。"""
     path = request.path.lstrip("/")
     if path.startswith(("depot/", "avatar/", "building_skill/")):
-        base = Path(get_path("@app/tmp/resource/ui/public"))
+        base = Path(get_path("@app/tmp/resource/ui/public", space=""))
         p = (base / path).resolve()
         if base.resolve() in p.parents and p.is_file():
             response = send_file(p)

--- a/ui/src/components/ResourceUpdate.vue
+++ b/ui/src/components/ResourceUpdate.vue
@@ -152,7 +152,9 @@ function set_auto_update(checked) {
         <span>{{ install_message }}</span>
       </n-form-item>
       <n-form-item :show-label="false">
-        <span class="hint">资源包安装后会在当前进程内生效；仅软件版本更新需要重启 Mower</span>
+        <span class="hint">
+          同一套 mower 的所有实例共用资源包，空闲实例会自动加载新资源；仅软件版本更新需要重启 Mower
+        </span>
       </n-form-item>
       <n-form-item label="手动应用">
         <n-upload


### PR DESCRIPTION
## 目标

修复通过多开管理器启动时资源包被实例目录隔离的问题。同一套 mower 安装下的多个实例共用一份已安装资源，同时继续保留各实例独立的自动检查、自动更新配置和任务状态。

## 主要改动

- 将资源 overlay、安装暂存目录和回滚目录固定到应用级共享空间，不再跟随实例 `global_space`。
- 保留远程版本检查缓存及自动检查、自动更新配置的实例隔离行为。
- 首次升级时将当前实例已有的资源包迁移到共享目录，避免切换路径后退回内置版本。
- 增加 Windows 与 POSIX 通用的跨进程文件锁，防止多个实例同时替换共享资源目录。
- 其他实例检测到共享资源版本变化后，会在自身任务空闲时刷新 JSON、识别模型及专精数据缓存。
- 资源图片 overlay 改为读取共享目录，并更新设置页说明。

## 验证

- `ruff check .`：通过。
- `ruff format --check .`：通过。
- 后端测试：881 项通过。
- 脚本测试：84 项通过，1 项跳过。
- 前端测试：39 项通过。
- `npm run build`：通过。
- Prettier 检查：通过。
- `git diff --check`：通过。
- 已检查提交内容，不包含本机用户目录等绝对路径。
