### PR TITLE
feat(ui): 基建技能数据改为运行时下发

### DIFF
--- a/arknights_mower/data/version.json
+++ b/arknights_mower/data/version.json
@@ -1,5 +1,5 @@
 {
-  "res_version": "v2026.09.03-3e4ac10",
+  "res_version": "v2026.09.03-ad8cd71",
   "last_updated": "",
   "activity": {
     "name": "直到大地变成一颗酸橙",

--- a/arknights_mower/tests/basement_skill_route_tests.py
+++ b/arknights_mower/tests/basement_skill_route_tests.py
@@ -1,0 +1,35 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import server
+
+
+class TestBasementSkillRoute(unittest.TestCase):
+    """基建技能数据运行时下发路由：资源包安装后返回最新 JSON，未安装返回 404。"""
+
+    def setUp(self):
+        self.client = server.app.test_client()
+        self.temp = tempfile.TemporaryDirectory()
+        self.base = Path(self.temp.name)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_returns_json_with_no_cache_when_resource_installed(self):
+        (self.base / "skill.json").write_text('{"name": "sample"}', encoding="utf-8")
+        with patch("server.get_path", return_value=self.base):
+            resp = self.client.get("/basement_skill/skill.json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_data(as_text=True), '{"name": "sample"}')
+        self.assertEqual(resp.headers["Cache-Control"], "no-cache")
+
+    def test_404_when_resource_not_installed(self):
+        with patch("server.get_path", return_value=self.base):
+            resp = self.client.get("/basement_skill/skill.json")
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/utils/res_version.py
+++ b/arknights_mower/utils/res_version.py
@@ -37,6 +37,9 @@ RES_PACKAGE_DATA = (
     "arknights_mower/data/recruit_result.json",
     "arknights_mower/data/skill_data.json",
     "arknights_mower/data/workshop_formula.json",
+    # 前端基建技能数据：静态 import 作内置兜底，运行时由资源包下发
+    "ui/src/pages/basement_skill/skill.json",
+    "ui/src/pages/basement_skill/buffer.json",
 )
 
 

--- a/server.py
+++ b/server.py
@@ -497,17 +497,42 @@ def serve_index(path):
     return send_from_directory("ui/dist", path)
 
 
+def _serve_resource(base_dir: Path, relative: str):
+    """serve 资源包目录下的单个文件；不存在则返回 None，由调用方决定兜底。
+
+    资源包装到 ``@app/tmp/resource`` 后按仓库相对路径存放，这里从 base 下取出一个文件并
+    打 ``no-cache`` 保证刷新即生效。resolve 后校验仍位于 base 之下，避免路径穿越读到目录外。
+    """
+    base = base_dir.resolve()
+    p = (base / relative).resolve()
+    if base in p.parents and p.is_file():
+        response = send_file(p)
+        response.headers["Cache-Control"] = "no-cache"
+        return response
+    return None
+
+
 @app.before_request
 def serve_resource_overlay():
     """资源包 webp（depot/avatar/building_skill）overlay 优先，刷新即生效。"""
     path = request.path.lstrip("/")
     if path.startswith(("depot/", "avatar/", "building_skill/")):
-        base = Path(get_path("@app/tmp/resource/ui/public", space=""))
-        p = (base / path).resolve()
-        if base.resolve() in p.parents and p.is_file():
-            response = send_file(p)
-            response.headers["Cache-Control"] = "no-cache"
-            return response
+        return _serve_resource(
+            Path(get_path("@app/tmp/resource/ui/public", space="")), path
+        )
+
+
+@app.route("/basement_skill/<filename>")
+def serve_basement_skill(filename):
+    """基建技能数据（skill.json/buffer.json）运行时下发，资源包优先、无则 404。
+
+    注意不要用 abort(404)：@app.errorhandler(404) 会把它兜底成 index.html(200)，
+    前端拉不到资源会拿到 HTML 而非 JSON；直接返回 (…, 404) 才能被 axios 当失败处理。
+    """
+    return _serve_resource(
+        Path(get_path("@app/tmp/resource/ui/src/pages/basement_skill", space="")),
+        filename,
+    ) or ("", 404)
 
 
 @app.after_request

--- a/ui/src/components/buffer.vue
+++ b/ui/src/components/buffer.vue
@@ -48,7 +48,9 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { richText2HTML } from '@/stores/richText2HTML'
-import buffer from '@/pages/basement_skill/buffer.json'
+import { useBasementSkill } from '@/stores/basementSkill'
+
+const { buffer } = useBasementSkill()
 
 const props = defineProps({
   avatar: String,

--- a/ui/src/components/bufferinfo.vue
+++ b/ui/src/components/bufferinfo.vue
@@ -21,7 +21,9 @@
 <script setup>
 import { ref, computed } from 'vue'
 import { richText2HTML, findTerm } from '@/stores/richText2HTML'
-import buffer1 from '@/pages/basement_skill/buffer.json'
+import { useBasementSkill } from '@/stores/basementSkill'
+
+const { buffer: buffer1 } = useBasementSkill()
 const showModal = ref(false)
 const props = defineProps({
   des: String,

--- a/ui/src/pages/BasementSkill.vue
+++ b/ui/src/pages/BasementSkill.vue
@@ -32,26 +32,28 @@
 </template>
 
 <script setup>
-import skill from '@/pages/basement_skill/skill.json'
 import CustomComponent from '@/components/buffer.vue'
-import { ref, computed } from 'vue'
-const skillData = ref(skill)
-const skillData_length = skillData.value.length
-const skill_items = Array.from({ length: skillData_length }, (_, i) => {
-  // 确保 skillData.value[i] 存在并且有 child_skill 属性
-
-  const name = skillData.value[i].name
-  const span = skillData.value[i].span
-  const childSkill = skillData.value[i].child_skill
-  return {
-    key: `${i}`,
-    value: i,
-    avatar: name,
-    span: span,
-    childSkill: childSkill
-  }
-})
+import { ref, computed, onMounted } from 'vue'
+import { useBasementSkill } from '@/stores/basementSkill'
 import { match } from 'pinyin-pro'
+
+const { skill, load } = useBasementSkill()
+onMounted(load)
+
+const skill_items = computed(() =>
+  Array.from({ length: skill.value.length }, (_, i) => {
+    const name = skill.value[i].name
+    const span = skill.value[i].span
+    const childSkill = skill.value[i].child_skill
+    return {
+      key: `${i}`,
+      value: i,
+      avatar: name,
+      span: span,
+      childSkill: childSkill
+    }
+  })
+)
 
 const name_select = ref('')
 const buiding_select = ref('')
@@ -61,12 +63,10 @@ const filteredItems = computed(() => {
   const buidingValue = buiding_select.value
   const desValue = des_select.value
   if (!nameValue && !buidingValue && !desValue) {
-    return skill_items
+    return skill_items.value
   }
-  return skill_items.filter((item) => {
+  return skill_items.value.filter((item) => {
     const itemName = item['avatar']
-    const itemRoomType = item['roomType']
-    const itemDes = item['childSkill'].some((skill) => skill.des.includes(desValue)) // 检查 des 是否包含筛选条件
     const itemDesMatches = item.childSkill.some((skill) => {
       const itemDes = skill.des
       return (

--- a/ui/src/stores/basementSkill.js
+++ b/ui/src/stores/basementSkill.js
@@ -1,0 +1,29 @@
+import { ref } from 'vue'
+import axios from 'axios'
+import skillBundled from '@/pages/basement_skill/skill.json'
+import bufferBundled from '@/pages/basement_skill/buffer.json'
+
+// 基建技能页数据：构建期内联的 JSON 作为内置兜底，运行时优先用资源包下发的版本。
+// 模块级 ref 单一实例，三个消费组件（BasementSkill.vue / buffer.vue / bufferinfo.vue）共用一次加载，
+// 避免 buffer.vue 在虚拟列表里被实例化多次而重复请求，也保证各处数据一致。
+const skill = ref(skillBundled)
+const buffer = ref(bufferBundled)
+let loaded = false
+
+export function useBasementSkill() {
+  const load = async () => {
+    if (loaded) return
+    try {
+      const [sk, bf] = await Promise.all([
+        axios.get(`${import.meta.env.VITE_HTTP_URL}/basement_skill/skill.json`),
+        axios.get(`${import.meta.env.VITE_HTTP_URL}/basement_skill/buffer.json`)
+      ])
+      skill.value = sk.data
+      buffer.value = bf.data
+      loaded = true // 拉取成功才置位；失败则本次保留内置兜底，下次进入页面会重试
+    } catch {
+      // 资源包未安装或加载失败：保留内置兜底，下次进入页面再试
+    }
+  }
+  return { skill, buffer, load }
+}


### PR DESCRIPTION
## 目标

基建技能页的数据此前直接打包进前端构建产物，更新数据必须重新构建前端；而该页引用的图片走的是运行时资源包，换图不用重建，两者机制不一致。此次把这两份数据也改成运行时下发，更新数据不再依赖重建前端。

## 主要改动

- 前端：基建技能页改为启动后从接口拉取 skill.json 与 buffer.json，构建时打包进产物里的那份 JSON 只作兜底；并抽出一个共享加载器，页面与两个组件共用一次加载，避免虚拟列表多实例化时重复请求。
- 后端：新增只读接口，从已安装的资源包读取这两份 JSON，取不到则返回 404，前端随即回退到内置兜底；同时抽出一个资源包文件服务，供图片 overlay 与基建技能接口复用。
- 资源包：把这两份 JSON 加入资源包文件集，并按更新后的包内容重算资源版本号。resource_build.py 依该集合把数据打包进资源包，装入新资源包后刷新页面即见新数据。

## 验证与风险

- 相关单测皆通过（资源包版本、打包、基建技能接口相关的测试），其中一项专门断言 version.json 的 res_version 哈希与包内文件内容一致。
- 前端可通过 vite 构建，ruff 与 prettier 检查通过。
- 一处边界值得留意：首次进入页面时若资源包尚未安装，接口返回 404，前端保留内置兜底；以后再装入资源包，需要重新进入该页才会拉取到新数据，因为加载只在进入页面时触发一次，没有额外做加载门控。
