### PR TITLE
feat(ui): 资源包展示版本号日期改为构建日期

### DIFF
--- a/arknights_mower/tests/res_version_tests.py
+++ b/arknights_mower/tests/res_version_tests.py
@@ -178,6 +178,15 @@ class TestDisplayVersion(unittest.TestCase):
         }
         self.assertEqual(display_version(info), "新卡池#0822")
 
+    def test_构建日期优先于开启日期(self):
+        # res_version 的日期（构建日期）优先于 activity/gacha 开启日期
+        info = {
+            "res_version": "v2026.09.05-12ab34",
+            "activity": {"name": "活动甲", "time": 1787342400, "endTime": 0},
+            "gacha": {"name": "卡池乙", "time": 1785538800, "endTime": 0},
+        }
+        self.assertEqual(display_version(info), "活动甲#0905")
+
     def test_空表返回空(self):
         self.assertEqual(display_version({}), "")
         self.assertEqual(display_version({"activity": {}, "gacha": {}}), "")

--- a/arknights_mower/tests/resource_version_tests.py
+++ b/arknights_mower/tests/resource_version_tests.py
@@ -197,7 +197,7 @@ class TestReadLocalVersion(unittest.TestCase):
                 got = rv.check_resource_update(local_only=True)
 
         self.assertEqual(got["current_version"], "2026.09.04-bbbbbbb")
-        self.assertEqual(got["current_display"], "墟·复刻#0822")
+        self.assertEqual(got["current_display"], "墟·复刻#0904")
 
     def test_builtin_version_hash_matches_bundled_resources(self):
         project_root = Path(__rootdir__).parent

--- a/arknights_mower/utils/res_version.py
+++ b/arknights_mower/utils/res_version.py
@@ -111,17 +111,23 @@ def pick_latest_gacha(gacha_table: dict) -> dict:
 
 
 def display_version(version_info: dict) -> str:
-    """客户端展示用可读版本号：较晚开启的 activity/gacha 的 name + #MMDD（北京时区）。"""
+    """客户端展示用可读版本号：较晚开启的 activity/gacha 的 name + #构建日期（MMDD）。"""
     later = max(
         (version_info.get("activity") or {}, version_info.get("gacha") or {}),
         key=lambda e: e.get("time", 0),
     )
     name = later.get("name")
-    if not name or not later.get("time"):
+    if not name:
         return ""
-    mmdd = datetime.fromtimestamp(
-        later["time"], tz=timezone(timedelta(hours=8))
-    ).strftime("%m%d")
+    parsed = parse_version(version_info.get("res_version") or "")
+    if parsed:
+        mmdd = f"{parsed[1]:02d}{parsed[2]:02d}"
+    elif later.get("time"):
+        mmdd = datetime.fromtimestamp(
+            later["time"], tz=timezone(timedelta(hours=8))
+        ).strftime("%m%d")
+    else:
+        return ""
     return f"{name}#{mmdd}"
 
 


### PR DESCRIPTION
## 目标

展示用的资源包版本号此前取活动或卡池的开启日期拼成 `活动名#MMDD`，窗口标题等处显示的日期实际来自活动开启时间，并不反映资源包本身的构建时间。此次把它改成优先取 `res_version` 的构建日期，让 `#` 后面的数字对应资源包真正的构建时间。

## 主要改动

- `display_version`：`#MMDD` 优先从 `res_version`（`vYYYY.MM.DD-hash`）解析出构建日期，`res_version` 缺失时才退回活动或卡池的开启日期；`name` 仍取较晚开启的 activity / gacha 名。
- 更新 `resource_version_tests` 中 overlay 版本展示的期望日期，并新增一条「构建日期优先于开启日期」的用例。

## 验证与风险

- `res_version_tests` 与 `resource_version_tests` 通过（本地有一条哈希一致性用例因 Windows 行尾差异失败，属于既有平台问题，CI 上正常，与本改动无关）。
- ruff 检查通过。
