### PR TITLE
feat(ui): 窗口标题显示资源包版本并在资源更新后实时刷新

### DIFF
--- a/arknights_mower/tests/resource_pkg_tests.py
+++ b/arknights_mower/tests/resource_pkg_tests.py
@@ -218,10 +218,13 @@ class TestInstallResourcePkg(ResourcePkgTestBase):
         marker = self.overlay / "arknights_mower/data/version.json"
         marker.parent.mkdir(parents=True)
         marker.write_text('{"res_version":"v2026.08.23-aaaaaaa"}', encoding="utf-8")
-        rp._remember_loaded_resource()
-        marker.write_text('{"res_version":"v2026.08.24-bbbbbbb"}', encoding="utf-8")
-
-        self.assertTrue(rp.reload_resource_caches_if_changed())
+        # 用安装锁串行化「记住旧签名 → 改文件 → reload」这三步：server 模块 import 时会
+        # 启动后台资源监控线程（每秒 reload），若在该窗口内抢先 reload，会把
+        # _loaded_resource_signature 改成本测试正在写入的新值，导致本次 reload 返回 False。
+        with rp._install_lock:
+            rp._remember_loaded_resource()
+            marker.write_text('{"res_version":"v2026.08.24-bbbbbbb"}', encoding="utf-8")
+            self.assertTrue(rp.reload_resource_caches_if_changed())
         self.assertFalse(rp.reload_resource_caches_if_changed())
         self.reload_caches.assert_called_once_with()
 

--- a/arknights_mower/tests/server_notify_tests.py
+++ b/arknights_mower/tests/server_notify_tests.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest import mock
+
+import server
+
+
+class TestWebviewConn(unittest.TestCase):
+    """连接获取：进程存活才返回 parent_conn，未启动/已退出返回 None。"""
+
+    def test_returns_live_conn(self):
+        process = mock.Mock()
+        process.is_alive.return_value = True
+        conn = mock.Mock()
+        with (
+            mock.patch.object(server.config, "webview_process", process, create=True),
+            mock.patch.object(server.config, "parent_conn", conn, create=True),
+        ):
+            self.assertIs(server._webview_conn(), conn)
+
+    def test_none_when_process_not_started(self):
+        # 启动初期 webview_process 尚未创建，不应误取到连接
+        with mock.patch.object(server.config, "webview_process", None, create=True):
+            self.assertIsNone(server._webview_conn())
+
+    def test_none_when_process_dead(self):
+        process = mock.Mock()
+        process.is_alive.return_value = False
+        with mock.patch.object(server.config, "webview_process", process, create=True):
+            self.assertIsNone(server._webview_conn())
+
+
+class TestRequestTitleRefresh(unittest.TestCase):
+    """标题刷新：fire-and-forget 发 "title"，不 recv；进程不可用或发送失败均静默。"""
+
+    def test_sends_title_without_recv(self):
+        process = mock.Mock()
+        process.is_alive.return_value = True
+        conn = mock.Mock()
+        with (
+            mock.patch.object(server.config, "webview_process", process, create=True),
+            mock.patch.object(server.config, "parent_conn", conn, create=True),
+        ):
+            server._request_title_refresh()
+        conn.send.assert_called_once_with("title")
+        conn.recv.assert_not_called()
+
+    def test_noop_when_process_not_started(self):
+        # 进程未创建时不抛异常、不发送
+        with mock.patch.object(server.config, "webview_process", None, create=True):
+            server._request_title_refresh()
+
+    def test_noop_when_process_dead(self):
+        process = mock.Mock()
+        process.is_alive.return_value = False
+        with mock.patch.object(server.config, "webview_process", process, create=True):
+            server._request_title_refresh()
+
+    def test_send_error_is_swallowed(self):
+        # 子进程在发送瞬间退出（坏管道）时，异常被吞掉不外泄
+        process = mock.Mock()
+        process.is_alive.return_value = True
+        conn = mock.Mock()
+        conn.send.side_effect = OSError("broken pipe")
+        with (
+            mock.patch.object(server.config, "webview_process", process, create=True),
+            mock.patch.object(server.config, "parent_conn", conn, create=True),
+        ):
+            server._request_title_refresh()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/webview_ui_tests.py
+++ b/arknights_mower/tests/webview_ui_tests.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from arknights_mower import __version__
 from arknights_mower.utils.config import gui
 from webview_ui import (
     _LINUX_WEBVIEW_INSTALL_HINT,
@@ -11,6 +12,8 @@ from webview_ui import (
     linux_webview_backend_error,
     resolve_window_size,
     sanitize_window_size,
+    title_version,
+    window_title,
 )
 
 
@@ -113,6 +116,42 @@ class TestGuiWindowSize(unittest.TestCase):
             p.write_text("width: abc\nheight: 900\n", encoding="utf-8")
             with mock.patch.object(gui, "gui_path", p):
                 self.assertIsNone(gui.load_window_size())
+
+
+class TestWindowTitle(unittest.TestCase):
+    def test_composes_app_and_resource_version(self):
+        # 标题 = 应用版本 + 资源包版本 + 实例标识；资源包版本来自 title_version 的尽力读取。
+        with mock.patch(
+            "webview_ui.title_version", return_value="4.1.6-alpha.3 - 2026.09.05"
+        ):
+            self.assertEqual(
+                window_title("测试", 8080),
+                "arknights-mower 4.1.6-alpha.3 - 2026.09.05 - mower@8080(测试)",
+            )
+
+    def test_omits_resource_version_when_absent(self):
+        # 未装资源包时不显示资源包版本段（title_version 只返回应用版本）。
+        with mock.patch("webview_ui.title_version", return_value="4.1.6-alpha.3"):
+            self.assertEqual(
+                window_title("", 8080),
+                "arknights-mower 4.1.6-alpha.3 - mower@8080",
+            )
+
+    def test_title_version_appends_resource_when_present(self):
+        # 资源包展示版本非空时，title_version 在应用版本后追加资源包版本号。
+        with mock.patch(
+            "arknights_mower.utils.resource_version.check_resource_update",
+            return_value={"current_display": "2026.09.05"},
+        ):
+            self.assertEqual(title_version(), f"{__version__} - 2026.09.05")
+
+    def test_title_version_omits_resource_when_absent(self):
+        # 未装资源包时 title_version 只返回应用版本，不残留空号段。
+        with mock.patch(
+            "arknights_mower.utils.resource_version.check_resource_update",
+            return_value={"current_display": ""},
+        ):
+            self.assertEqual(title_version(), __version__)
 
 
 if __name__ == "__main__":

--- a/server.py
+++ b/server.py
@@ -473,7 +473,8 @@ def _watch_shared_resource_changes():
         if _mower_busy_response():
             continue
         try:
-            reload_resource_caches_if_changed()
+            if reload_resource_caches_if_changed():
+                _request_title_refresh()
         except Exception:
             logger.exception("刷新其他 mower 实例更新的共享资源失败")
             time.sleep(30)
@@ -876,14 +877,32 @@ def get_latest_screenshot():
     return ""
 
 
+def _webview_conn():
+    """返回当前存活的 WebView 子进程连接；未启动或已退出时返回 None。"""
+    process = getattr(config, "webview_process", None)
+    conn = getattr(config, "parent_conn", None)
+    if process is None or conn is None or not process.is_alive():
+        return None
+    return conn
+
+
+def _request_title_refresh():
+    """资源包变更后让 WebView 子进程重算并刷新窗口标题（fire-and-forget，不等待回执）。"""
+    conn = _webview_conn()
+    if conn is None:
+        return
+    try:
+        conn.send("title")
+    except Exception:
+        logger.exception("通知 WebView 刷新窗口标题失败")
+
+
 def conn_send(text):
-    from arknights_mower.utils import config
-
-    if not config.webview_process.is_alive():
+    conn = _webview_conn()
+    if conn is None:
         return ""
-
-    config.parent_conn.send(text)
-    return config.parent_conn.recv()
+    conn.send(text)
+    return conn.recv()
 
 
 @app.route("/dialog/file")
@@ -960,7 +979,10 @@ def hot_update_manual():
     update_file = request.files.get("update")
     if update_file is None:
         return {"ok": False, "message": "没有收到更新包文件"}
-    return apply_manual_update(update_file.read(), _mower_busy_response)
+    result = apply_manual_update(update_file.read(), _mower_busy_response)
+    if result.get("ok") and result.get("kind") == "resource":
+        _request_title_refresh()
+    return result
 
 
 @app.route("/dialog/save/img", methods=["POST"])
@@ -1712,6 +1734,7 @@ def install_resource():
         return {"ok": False, "message": "资源包下载失败，请检查网络"}
     if not install_resource_pkg(data):
         return {"ok": False, "message": "资源包安装失败（已回滚）"}
+    _request_title_refresh()
     return {
         "ok": True,
         "restart_required": False,

--- a/webview_ui.py
+++ b/webview_ui.py
@@ -160,6 +160,30 @@ def build_window_title(instance_name, port):
     return f"mower@{port}"
 
 
+def title_version():
+    """窗口标题里的版本串：软件版本后追加资源包版本号（尽力读取，失败只显示软件版本）。"""
+    from arknights_mower.__init__ import __version__
+
+    try:
+        from arknights_mower.utils.resource_version import check_resource_update
+
+        resource_version = (
+            check_resource_update(local_only=True).get("current_display") or ""
+        )
+    except Exception:
+        resource_version = ""
+    if resource_version:
+        return f"{__version__} - {resource_version}"
+    return __version__
+
+
+def window_title(instance_name, port):
+    """完整窗口标题：应用版本 + 资源包版本（若有）+ 实例标识。"""
+    return (
+        f"arknights-mower {title_version()} - {build_window_title(instance_name, port)}"
+    )
+
+
 def append_query_param(url, key, value):
     if not value:
         return url
@@ -221,7 +245,6 @@ def webview_window(child_conn, global_space, instance_name, host, port, url, tra
 
     webview.settings["ALLOW_DOWNLOADS"] = True
 
-    from arknights_mower.__init__ import __version__
     from arknights_mower.utils import path
 
     path.global_space = global_space
@@ -242,7 +265,7 @@ def webview_window(child_conn, global_space, instance_name, host, port, url, tra
             width, height = size
 
     window = webview.create_window(
-        f"arknights-mower {__version__} - {build_window_title(instance_name, port)}",
+        window_title(instance_name, port),
         url,
         text_select=True,
         confirm_close=not tray,
@@ -258,6 +281,9 @@ def webview_window(child_conn, global_space, instance_name, host, port, url, tra
                 window.confirm_close = False
                 window.destroy()
                 return
+            if msg == "title":
+                window.set_title(window_title(instance_name, port))
+                continue
             if msg == "file":
                 result = window.create_file_dialog(
                     dialog_type=webview.OPEN_DIALOG,


### PR DESCRIPTION
### 变更

窗口标题此前只显示应用版本与实例标识。此次让标题统一由 window_title 组装（应用版本、资源包版本、实例标识），资源包未安装时省略资源包版本段。资源包变更后，服务端向 WebView 子进程发送 title 消息，子进程据此重算并刷新标题，无需重启程序。

同时用安装锁串行化资源测试记录签名与 reload 之间的窗口，避免后台资源监控线程在测试期间抢先 reload 造成的偶发失败。

### 限制

其他实例的共享资源更新，在本地 mower 执行任务期间不刷新标题，需等待任务结束。这是沿用既有「任务运行时不切换资源缓存」的保护，避免标题与进程内已加载数据不一致。

### 验证

- 新增 TestWindowTitle、TestWebviewConn、TestRequestTitleRefresh，覆盖标题组装与刷新消息发送。
- 全量测试 906 项，仅一项既有的 version.json 内容哈希用例失败（与本次改动无关），另有 10 项跳过。
- ruff lint / format 与 Prettier 校验通过。