### PR TITLE
fix(depot): 修复仓库扫描遇到 MEMENTO 纪念品崩溃

### DIFF
--- a/arknights_mower/utils/depot.py
+++ b/arknights_mower/utils/depot.py
@@ -6,6 +6,7 @@ from arknights_mower.data import key_mapping, workshop_formula
 from arknights_mower.solvers.record import save_inventory_counts
 from arknights_mower.utils.config import atomic_write
 from arknights_mower.utils.csv_utils import read_csv_rows
+from arknights_mower.utils.log import logger
 from arknights_mower.utils.path import get_path
 
 
@@ -16,11 +17,17 @@ def 读取仓库():
     with open(path, "r", encoding="utf-8") as f:
         depotinfo = json.load(f)
     物品数量 = depotinfo["data"]["items"]
-    新物品1 = {
-        key_mapping[item["id"]][2]: int(item["count"])
-        for item in 物品数量
-        if int(item["count"]) != 0
-    }
+    新物品1 = {}
+    for item in 物品数量:
+        if int(item["count"]) == 0:
+            continue
+        entry = key_mapping.get(item["id"])
+        if entry is None:
+            # 活动/新素材 id 不在本地 key_mapping（资源包 vs 内置数据可能不同步），
+            # 跳过而不是让整个扫描 KeyError。
+            logger.warning(f"仓库扫描: 忽略未知物品 id {item['id']}")
+            continue
+        新物品1[entry[2]] = int(item["count"])
 
     csv_path = get_path("@app/tmp/depotresult.csv")
     if not os.path.exists(csv_path):
@@ -36,9 +43,15 @@ def 读取仓库():
     db_dict = {}
     for k in workshop_formula.keys():
         db_dict[k] = 0
-    for item in 新物品:
-        新物品json[key_mapping[item][0]] = 新物品[item]
-        db_dict[key_mapping[item][2]] = 新物品[item]
+    for item, count in 新物品.items():
+        entry = key_mapping.get(item)
+        if entry is None:
+            # 上一轮 CSV 里残留的旧物品名（key_mapping 更新后可能失效）也跳过，
+            # 避免合并历史数据时再次 KeyError。
+            logger.warning(f"仓库扫描: 忽略未知物品名 {item}")
+            continue
+        新物品json[entry[0]] = count
+        db_dict[entry[2]] = count
     time = depotinfo[-1][0]
     save_inventory_counts(db_dict)
     sort = {

--- a/auto_get_res_new.py
+++ b/auto_get_res_new.py
@@ -77,7 +77,14 @@ class Arknights数据处理器:
         self.游戏变量 = self.加载json(
             "./ArknightsGameResource/gamedata/excel/gamedata_const.json"
         )
-        self.装仓库物品的字典 = {"NORMAL": [], "CONSUME": [], "MATERIAL": []}
+        # 仓库物品分类。MEMENTO(纪念品/纪念券，如温泉度假村体验券)是森空岛仓库 API
+        # 会返回的物品，不放进白名单的话这些 id 不在 key_mapping，扫仓库时 KeyError。
+        self.装仓库物品的字典 = {
+            "NORMAL": [],
+            "CONSUME": [],
+            "MATERIAL": [],
+            "MEMENTO": [],
+        }
 
         self.所有buff = []
 


### PR DESCRIPTION
## 变更

- `auto_get_res_new.py`：仓库物品白名单补上 `MEMENTO` 分类，让纪念品的 id 能进 `key_mapping`。
- `arknights_mower/utils/depot.py`（读取仓库）：对森空岛 API 返回的、本地映射表里没有的 item id 或物品名，容错跳过并记一句警告，而不是让整个扫描抛 `KeyError`。

## 限制

- 仓库扫描的实机识别仍只加载 `NORMAL`/`CONSUME` 两个模型，`MEMENTO` 物品不在其识别范围内；本次改动不改变实机识别的覆盖面。

## 验证

- 定位：森空岛仓库 API 返回 `ark_odc_act53side_spitem_1`（温泉度假村体验券）时，`读取仓库` 在 `key_mapping[item_id]` 处抛 `KeyError`，中断整个仓库扫描。
- 结果：修复后实跑 `读取仓库` 不再崩，该物品被跳过并记警告；`ruff format`/`ruff check` 通过；相关 resource/data 测试 51 个全绿。
