### PR TITLE
fix(schedule): 修复模拟器自动启动及设备就绪判断

### DIFF
--- a/arknights_mower/__main__.py
+++ b/arknights_mower/__main__.py
@@ -99,6 +99,8 @@ def simulate(saved, restart_after_mood_read=False):
             return
         except Exception as e:
             logger.exception(e)
+            if not config.conf.close_simulator_when_idle:
+                raise
             reconnect_tries += 1
             if reconnect_tries < 3:
                 restart_simulator()

--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -133,6 +133,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         self.recruit_time = None
         self.last_clue = None
         self.sleeping = False
+        self._simulator_closed_for_idle = False
         self.operators = {}
         self.last_execution = {"maa": None, "recruit": None, "todo": None}
         self.order_reader = TradingOrder()
@@ -4800,6 +4801,17 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     config.wake_scheduler.clear()
                     break
                 csleep(min(1, (end_time - datetime.now()).total_seconds()))
+            if config.stop_mower.is_set():
+                raise MowerExit
+            if (
+                config.conf.close_simulator_when_idle
+                and self._simulator_closed_for_idle
+            ):
+                logger.info("休眠结束，启动自动关闭的模拟器")
+                if not restart_simulator(stop=False, start=True):
+                    raise ConnectionError("休眠结束后模拟器启动失败")
+                self.device.reconnect()
+                self._simulator_closed_for_idle = False
             self.recog.update()
         finally:
             self.sleeping = False
@@ -4840,7 +4852,8 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
 
     def handle_idle_action(self, remaining_time=0):
         if config.conf.close_simulator_when_idle and remaining_time > 300:
-            restart_simulator(start=False)
+            if restart_simulator(start=False):
+                self._simulator_closed_for_idle = True
         elif config.conf.exit_game_when_idle and remaining_time > 300:
             self.device.exit()
         elif config.conf.return_home_when_idle:

--- a/arknights_mower/tests/adb_client_tests.py
+++ b/arknights_mower/tests/adb_client_tests.py
@@ -43,6 +43,15 @@ class TestAdbClientConnectionError(unittest.TestCase):
         self.assertEqual(exec_mock.call_args_list[1].args[0], "connect 127.0.0.1:16928")
         init_device_mock.assert_called_once_with()
 
+    def test_available_devices_excludes_offline_and_unauthorized(self):
+        with patch("arknights_mower.utils.device.adb_client.core.Session") as session:
+            session.return_value.devices_list.return_value = [
+                ("offline-device", "offline"),
+                ("unauthorized-device", "unauthorized"),
+                ("online-device", "device"),
+            ]
+            self.assertEqual(_client()._Client__available_devices(), ["online-device"])
+
     def test_run_reraises_connection_error_after_retries(self):
         client = _client()
         session_mock = MagicMock()

--- a/arknights_mower/tests/base_scheduler_tests.py
+++ b/arknights_mower/tests/base_scheduler_tests.py
@@ -1,6 +1,8 @@
 import sys
 import unittest
 from datetime import datetime, timedelta
+from threading import Event
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 # base_schedule 导入链（cultivate_depot→skland）会在 skland 模块加载时调用
@@ -26,6 +28,155 @@ from arknights_mower.utils.scheduler_task import (  # noqa: E402
 
 with patch.dict("sys.modules", {"RecruitSolver": MagicMock()}):
     pass
+
+
+class TestIdleSimulatorWake(unittest.TestCase):
+    def setUp(self):
+        self.solver = object.__new__(BaseSchedulerSolver)
+        self.solver._simulator_closed_for_idle = False
+        self.solver.device = MagicMock()
+        self.solver.recog = MagicMock()
+        self.now = datetime(2026, 9, 5, 13, 0)
+        self.wake = Event()
+        self.stop = Event()
+        self.conf = SimpleNamespace(
+            close_simulator_when_idle=True,
+            exit_game_when_idle=False,
+            return_home_when_idle=False,
+        )
+        self.enterContext(patch.object(base_schedule.config, "conf", self.conf))
+        self.enterContext(
+            patch.object(base_schedule.config, "wake_scheduler", self.wake)
+        )
+        self.enterContext(patch.object(base_schedule.config, "stop_mower", self.stop))
+        clock = self.enterContext(patch.object(base_schedule, "datetime"))
+        clock.now.side_effect = lambda: self.now
+        self.sleep = self.enterContext(
+            patch.object(base_schedule, "csleep", side_effect=self.advance)
+        )
+        self.restart = self.enterContext(
+            patch.object(base_schedule, "restart_simulator", return_value=True)
+        )
+        self.actions = MagicMock()
+        self.actions.attach_mock(self.restart, "simulator")
+        self.actions.attach_mock(self.solver.device.reconnect, "reconnect")
+        self.actions.attach_mock(self.solver.recog.update, "update")
+
+    def advance(self, seconds):
+        self.now += timedelta(seconds=seconds)
+
+    def test_deadline_starts_closed_simulator_before_device_use(self):
+        self.solver.handle_idle_action(600)
+        self.solver._idle_sleep(2)
+        self.assertEqual(self.now, datetime(2026, 9, 5, 13, 0, 2))
+        self.assertEqual(
+            self.actions.mock_calls,
+            [
+                call.simulator(start=False),
+                call.simulator(stop=False, start=True),
+                call.reconnect(),
+                call.update(),
+            ],
+        )
+        self.assertFalse(self.solver._simulator_closed_for_idle)
+        self.assertFalse(self.solver.sleeping)
+        self.solver._idle_sleep(0)
+        self.assertEqual(self.restart.call_count, 2)
+
+    def test_early_wake_restores_closed_simulator(self):
+        self.solver.handle_idle_action(600)
+        self.wake.set()
+        self.solver._idle_sleep(600)
+        self.sleep.assert_not_called()
+        self.restart.assert_called_with(stop=False, start=True)
+        self.solver.device.reconnect.assert_called_once_with()
+        self.assertFalse(self.wake.is_set())
+
+    def test_disabling_setting_during_sleep_skips_automatic_start(self):
+        self.solver.handle_idle_action(600)
+        self.conf.close_simulator_when_idle = False
+        self.solver._idle_sleep(0)
+        self.restart.assert_called_once_with(start=False)
+        self.solver.device.reconnect.assert_not_called()
+
+    def test_short_idle_does_not_start_simulator(self):
+        self.solver.handle_idle_action(300)
+        self.solver._idle_sleep(0)
+        self.restart.assert_not_called()
+        self.solver.device.reconnect.assert_not_called()
+
+    def test_disabled_setting_does_not_start_simulator(self):
+        self.conf.close_simulator_when_idle = False
+        self.solver.handle_idle_action(600)
+        self.solver._idle_sleep(0)
+        self.restart.assert_not_called()
+        self.solver.recog.update.assert_called_once_with()
+
+    def test_stop_during_sleep_does_not_start_simulator(self):
+        self.solver.handle_idle_action(600)
+        self.sleep.side_effect = base_schedule.MowerExit
+        with self.assertRaises(base_schedule.MowerExit):
+            self.solver._idle_sleep(600)
+        self.restart.assert_called_once_with(start=False)
+        self.solver.recog.update.assert_not_called()
+        self.assertFalse(self.solver.sleeping)
+
+    def test_stop_at_deadline_does_not_start_simulator(self):
+        self.solver.handle_idle_action(600)
+        self.stop.set()
+        with self.assertRaises(base_schedule.MowerExit):
+            self.solver._idle_sleep(0)
+        self.restart.assert_called_once_with(start=False)
+        self.solver.device.reconnect.assert_not_called()
+
+    def test_start_failure_does_not_use_device(self):
+        self.solver.handle_idle_action(600)
+        self.restart.return_value = False
+        with self.assertRaisesRegex(ConnectionError, "模拟器启动失败"):
+            self.solver._idle_sleep(0)
+        self.solver.device.reconnect.assert_not_called()
+        self.solver.recog.update.assert_not_called()
+        self.assertTrue(self.solver._simulator_closed_for_idle)
+        self.assertFalse(self.solver.sleeping)
+
+    def test_reconnect_failure_keeps_pending_wake(self):
+        self.solver.handle_idle_action(600)
+        self.solver.device.reconnect.side_effect = ConnectionError("offline")
+        with self.assertRaises(ConnectionError):
+            self.solver._idle_sleep(0)
+        self.solver.recog.update.assert_not_called()
+        self.assertTrue(self.solver._simulator_closed_for_idle)
+        self.assertFalse(self.solver.sleeping)
+
+
+class TestInitialSimulatorRecovery(unittest.TestCase):
+    def test_unchecked_option_does_not_restart_in_outer_startup_loop(self):
+        import arknights_mower.__main__ as main
+
+        with (
+            patch.object(base_schedule.config.conf, "close_simulator_when_idle", False),
+            patch.object(main, "initialize", side_effect=ConnectionError("no device")),
+            patch.object(main, "restart_simulator") as restart,
+        ):
+            with self.assertRaisesRegex(ConnectionError, "no device"):
+                main.simulate(None)
+        restart.assert_not_called()
+
+    def test_checked_option_keeps_startup_failure_recovery(self):
+        import arknights_mower.__main__ as main
+
+        with (
+            patch.object(base_schedule.config.conf, "close_simulator_when_idle", True),
+            patch.object(main, "base_scheduler", None),
+            patch.object(
+                main,
+                "initialize",
+                side_effect=[ConnectionError("no device"), base_schedule.MowerExit()],
+            ),
+            patch.object(main, "restart_simulator") as restart,
+        ):
+            main.simulate(None)
+        restart.assert_called_once_with()
 
 
 class TestBaseScheduler(unittest.TestCase):
@@ -228,6 +379,7 @@ class TestBaseScheduler(unittest.TestCase):
         from arknights_mower.utils import config as cfg
 
         solver = MagicMock()
+        solver._simulator_closed_for_idle = False
         cfg.wake_scheduler.clear()
         cfg.wake_scheduler.set()
         BaseSchedulerSolver._idle_sleep(solver, 3600)

--- a/arknights_mower/tests/device_tests.py
+++ b/arknights_mower/tests/device_tests.py
@@ -1,5 +1,7 @@
+import subprocess
 import unittest
 from contextlib import ExitStack
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from arknights_mower.utils import config
@@ -180,6 +182,83 @@ class TestStartDroidcast(unittest.TestCase):
         device.get_droidcast_classpath = MagicMock(return_value=None)
         device.client.cmd = MagicMock(side_effect=RuntimeError("device offline"))
         self.assertFalse(device.start_droidcast())
+
+    def setUp(self):
+        self.device = _device()
+        self.device.client.cmd.return_value = "Success"
+        self.runtime = SimpleNamespace(port=0, process=None)
+        self.enterContext(patch.object(config, "droidcast", self.runtime))
+        self.enterContext(
+            patch(
+                "arknights_mower.utils.device.device.get_new_port", return_value=54321
+            )
+        )
+
+    def test_missing_package_installs_then_starts(self):
+        self.device.client.cmd_shell.side_effect = [
+            "",
+            "package:/data/app/droidcast/base.apk\n",
+        ]
+        self.assertTrue(self.device.start_droidcast())
+        self.assertEqual(self.device.client.cmd.call_args_list[0].args[0][0], "install")
+        self.device.client.process.assert_called_once_with(
+            "CLASSPATH=/data/app/droidcast/base.apk",
+            ["app_process", "/", "com.rayworks.droidcast.Main", "--port=54321"],
+        )
+
+    def test_missing_package_exit_code_one_installs(self):
+        self.device.client.cmd_shell.side_effect = [
+            subprocess.CalledProcessError(1, "pm path", output=b""),
+            "package:/data/app/droidcast/base.apk\n",
+        ]
+        self.assertTrue(self.device.start_droidcast())
+        self.assertEqual(self.device.client.cmd.call_args_list[0].args[0][0], "install")
+
+    def test_existing_package_does_not_install(self):
+        self.device.client.cmd_shell.return_value = (
+            "package:/data/app/droidcast/base.apk"
+        )
+        self.assertTrue(self.device.start_droidcast())
+        self.device.client.cmd.assert_called_once_with("forward tcp:54321 tcp:54321")
+
+    def test_query_failure_does_not_install(self):
+        for error in (
+            ConnectionError("offline"),
+            subprocess.CalledProcessError(1, "pm path", output=b"device not found"),
+            subprocess.CalledProcessError(1, "pm path", output=None),
+            subprocess.CalledProcessError(2, "pm path", output=b""),
+        ):
+            with self.subTest(error=error):
+                self.device.client.cmd_shell.side_effect = error
+                with self.assertRaises(type(error)):
+                    self.device.start_droidcast()
+        self.device.client.cmd.assert_not_called()
+        self.device.client.process.assert_not_called()
+
+    def test_unexpected_query_output_does_not_install(self):
+        self.device.client.cmd_shell.return_value = "Error: package manager unavailable"
+        with self.assertRaises(ValueError):
+            self.device.start_droidcast()
+        self.device.client.cmd.assert_not_called()
+
+    def test_install_failure_does_not_start_server(self):
+        self.device.client.cmd_shell.return_value = ""
+        self.device.client.cmd.return_value = "Failure [INSTALL_FAILED_INTERNAL_ERROR]"
+        self.assertFalse(self.device.start_droidcast())
+        self.device.client.process.assert_not_called()
+
+    def test_reconnect_failure_does_not_start_touch_service(self):
+        self.device.control = MagicMock()
+        self.device.start_droidcast = MagicMock(return_value=False)
+        with (
+            patch.object(config.conf.droidcast, "enable", True),
+            patch.object(config.conf, "touch_method", "scrcpy"),
+            patch("arknights_mower.utils.device.device.Session"),
+            patch("arknights_mower.utils.device.device.Scrcpy") as scrcpy,
+        ):
+            with self.assertRaisesRegex(ConnectionError, "DroidCast启动失败"):
+                self.device.reconnect()
+        scrcpy.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/arknights_mower/tests/device_tests.py
+++ b/arknights_mower/tests/device_tests.py
@@ -2,7 +2,7 @@ import subprocess
 import unittest
 from contextlib import ExitStack
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from arknights_mower.utils import config
 from arknights_mower.utils.csleep import MowerExit
@@ -185,10 +185,14 @@ class TestStartDroidcast(unittest.TestCase):
 
     def setUp(self):
         self.device = _device()
+        self.device.client.device_id = "127.0.0.1:16384"
+        self.device.client.cmd_shell.return_value = (
+            "package:/data/app/droidcast/base.apk"
+        )
         self.device.client.cmd.return_value = "Success"
         self.runtime = SimpleNamespace(port=0, process=None)
         self.enterContext(patch.object(config, "droidcast", self.runtime))
-        self.enterContext(
+        self.new_port = self.enterContext(
             patch(
                 "arknights_mower.utils.device.device.get_new_port", return_value=54321
             )
@@ -219,7 +223,78 @@ class TestStartDroidcast(unittest.TestCase):
             "package:/data/app/droidcast/base.apk"
         )
         self.assertTrue(self.device.start_droidcast())
-        self.device.client.cmd.assert_called_once_with("forward tcp:54321 tcp:54321")
+        self.device.client.cmd.assert_called_once_with(
+            "forward --no-rebind tcp:54321 tcp:54321"
+        )
+
+    def test_reconnect_reuses_matching_forward(self):
+        self.runtime.port = 54321
+        self.device.client.cmd.return_value = (
+            "127.0.0.1:16416 tcp:54320 tcp:54320\n127.0.0.1:16384 tcp:54321 tcp:54321\n"
+        )
+        with patch(
+            "arknights_mower.utils.device.device.is_port_in_use", return_value=True
+        ):
+            self.assertTrue(self.device.start_droidcast())
+        self.device.client.cmd.assert_called_once_with("forward --list", True)
+        self.new_port.assert_not_called()
+        self.assertEqual(self.runtime.port, 54321)
+
+    def test_other_forward_is_not_rebound(self):
+        for mapping in (
+            "127.0.0.1:16416 tcp:54320 tcp:54320\n",
+            "127.0.0.1:16384 tcp:54320 tcp:12345\n",
+        ):
+            with self.subTest(mapping=mapping):
+                self.runtime.port = 54320
+                self.device.client.cmd.reset_mock()
+                self.device.client.cmd.return_value = mapping
+                with patch(
+                    "arknights_mower.utils.device.device.is_port_in_use",
+                    return_value=True,
+                ):
+                    self.assertTrue(self.device.start_droidcast())
+                self.assertEqual(
+                    self.device.client.cmd.call_args_list,
+                    [
+                        call("forward --list", True),
+                        call("forward --no-rebind tcp:54321 tcp:54321"),
+                    ],
+                )
+
+    def test_failed_forward_lookup_does_not_reuse_occupied_port(self):
+        self.runtime.port = 54320
+        self.device.client.cmd.side_effect = [ConnectionError("lookup failed"), ""]
+        with patch(
+            "arknights_mower.utils.device.device.is_port_in_use", return_value=True
+        ):
+            self.assertTrue(self.device.start_droidcast())
+        self.device.client.cmd.assert_called_with(
+            "forward --no-rebind tcp:54321 tcp:54321"
+        )
+
+    def test_port_race_retries_with_new_port_without_overwriting(self):
+        self.new_port.side_effect = [54321, 54322]
+        previous_process = MagicMock()
+        self.runtime.process = previous_process
+        self.device.client.cmd.side_effect = [
+            subprocess.CalledProcessError(1, "adb forward", output=b"cannot rebind"),
+            "",
+        ]
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.device.start_droidcast()
+        self.assertEqual(self.runtime.port, 0)
+        self.device.client.process.assert_not_called()
+        previous_process.terminate.assert_not_called()
+        self.assertTrue(self.device.start_droidcast())
+        self.assertEqual(self.runtime.port, 54322)
+        self.assertEqual(
+            self.device.client.cmd.call_args_list,
+            [
+                call("forward --no-rebind tcp:54321 tcp:54321"),
+                call("forward --no-rebind tcp:54322 tcp:54322"),
+            ],
+        )
 
     def test_query_failure_does_not_install(self):
         for error in (

--- a/arknights_mower/tests/simulator_tests.py
+++ b/arknights_mower/tests/simulator_tests.py
@@ -1,0 +1,75 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from arknights_mower.utils import config, simulator
+
+
+class TestSimulatorReady(unittest.TestCase):
+    def setUp(self):
+        self.old_target = "127.0.0.1:16384"
+        self.new_target = "127.0.0.1:16416"
+        self.conf = SimpleNamespace(
+            adb=self.old_target,
+            fix_mumu12_adb_disconnect=False,
+            simulator=SimpleNamespace(
+                name="MuMu12", index="0", simulator_folder="", wait_time=2, hotkey=""
+            ),
+        )
+        self.enterContext(patch.object(config, "conf", self.conf))
+        self.discover = self.enterContext(
+            patch.object(simulator, "query_mumu_adb_port", return_value=None)
+        )
+        self.session = self.enterContext(patch.object(simulator, "Session"))
+        self.session.return_value.devices_list.return_value = []
+        self.popen = self.enterContext(patch.object(simulator.subprocess, "Popen"))
+        self.popen.return_value.poll.return_value = 0
+        self.popen.return_value.returncode = 0
+        self.enterContext(patch.object(simulator, "csleep"))
+
+    def test_only_device_state_is_ready(self):
+        for target in (self.old_target, ""):
+            for state in ("offline", "unauthorized", "device"):
+                with self.subTest(target=target, state=state):
+                    self.conf.adb = target
+                    self.session.return_value.devices_list.return_value = [
+                        (self.old_target, state)
+                    ]
+                    self.assertEqual(simulator.adb_ready(), state == "device")
+
+    def test_other_online_device_does_not_make_target_ready(self):
+        self.session.return_value.devices_list.return_value = [
+            (self.old_target, "offline"),
+            (self.new_target, "device"),
+        ]
+        self.assertFalse(simulator.adb_ready())
+
+    def test_empty_device_list_is_not_ready(self):
+        self.conf.adb = ""
+        self.assertFalse(simulator.adb_ready())
+
+    def test_cold_start_discovers_new_port_without_extra_restart(self):
+        # 启动前及首轮等待尚无端口，第二轮等待才发现新端口。
+        self.discover.side_effect = [None, None, self.new_target]
+        self.session.return_value.devices_list.side_effect = [
+            [],
+            [(self.new_target, "device")],
+        ]
+        self.assertTrue(simulator.restart_simulator(stop=False, start=True))
+        self.assertEqual(self.conf.adb, self.new_target)
+        self.session.return_value.connect.assert_called_with(
+            self.new_target, throw_error=True
+        )
+        self.popen.assert_called_once()
+        self.assertIn("launch_player", self.popen.call_args.args[0])
+
+    def test_discovery_failure_keeps_configured_target(self):
+        self.session.return_value.devices_list.return_value = [
+            (self.old_target, "device")
+        ]
+        self.assertTrue(simulator.adb_ready())
+        self.assertEqual(self.conf.adb, self.old_target)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/solver_tests.py
+++ b/arknights_mower/tests/solver_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 from arknights_mower.utils import config
 from arknights_mower.utils.solver import BaseSolver
@@ -9,6 +9,9 @@ class TestSolverStartupLaunch(unittest.TestCase):
     """启动时目标设备未注册到 adb=模拟器未启动，直接启动模拟器而不是重连（修复点）。"""
 
     def setUp(self):
+        self.enterContext(patch.object(config.conf, "close_simulator_when_idle", True))
+        self.enterContext(patch.object(config.conf, "adb", "127.0.0.1:16384"))
+        self.enterContext(patch("arknights_mower.utils.solver.Scrcpy"))
         self.device_patch = patch("arknights_mower.utils.solver.Device")
         self.device_mock = self.device_patch.start()
         self.device_mock.side_effect = RuntimeError("Device connection failure")
@@ -17,9 +20,46 @@ class TestSolverStartupLaunch(unittest.TestCase):
         self.session_mock.return_value.devices_list.return_value = []
         self.restart_patch = patch("arknights_mower.utils.solver.restart_simulator")
         self.restart_mock = self.restart_patch.start()
+        self.restart_mock.return_value = True
         self.addCleanup(self.device_patch.stop)
         self.addCleanup(self.session_patch.stop)
         self.addCleanup(self.restart_patch.stop)
+
+    def test_first_task_starts_closed_simulator_then_connects(self):
+        device = MagicMock()
+        self.device_mock.side_effect = [
+            RuntimeError("Device connection failure"),
+            device,
+        ]
+        actions = MagicMock()
+        actions.attach_mock(self.device_mock, "device")
+        actions.attach_mock(self.restart_mock, "start")
+        with patch("arknights_mower.utils.solver.Recognizer") as recog:
+            solver = BaseSolver()
+        self.assertIs(solver.device, device)
+        self.assertEqual(
+            actions.mock_calls,
+            [call.device(), call.start(stop=False, start=True), call.device()],
+        )
+        recog.assert_called_once_with(device)
+
+    def test_unchecked_option_does_not_start_missing_simulator(self):
+        with patch.object(config.conf, "close_simulator_when_idle", False):
+            with self.assertRaises(ConnectionError):
+                BaseSolver()
+        self.restart_mock.assert_not_called()
+
+    def test_running_device_does_not_need_start(self):
+        self.device_mock.side_effect = None
+        with patch("arknights_mower.utils.solver.Recognizer"):
+            BaseSolver()
+        self.restart_mock.assert_not_called()
+
+    def test_failed_start_does_not_continue_device_initialization(self):
+        self.restart_mock.return_value = False
+        with self.assertRaisesRegex(ConnectionError, "首次任务启动模拟器失败"):
+            BaseSolver()
+        self.device_mock.assert_called_once_with()
 
     def test_no_device_launches_simulator(self):
         old_adb = config.conf.adb

--- a/arknights_mower/tests/solver_tests.py
+++ b/arknights_mower/tests/solver_tests.py
@@ -49,6 +49,48 @@ class TestSolverStartupLaunch(unittest.TestCase):
                 BaseSolver()
         self.restart_mock.assert_not_called()
 
+    def test_offline_device_is_started_on_first_failure(self):
+        device = MagicMock()
+        self.device_mock.side_effect = [RuntimeError("offline"), device]
+        self.session_mock.return_value.devices_list.return_value = [
+            (config.conf.adb, "offline")
+        ]
+        with patch("arknights_mower.utils.solver.Recognizer"):
+            solver = BaseSolver()
+        self.assertIs(solver.device, device)
+        self.assertEqual(self.device_mock.call_count, 2)
+        self.restart_mock.assert_called_once_with(stop=False, start=True)
+
+    def test_offline_device_with_unchecked_option_is_not_started(self):
+        self.session_mock.return_value.devices_list.return_value = [
+            (config.conf.adb, "offline")
+        ]
+        with patch.object(config.conf, "close_simulator_when_idle", False):
+            with self.assertRaises(ConnectionError):
+                BaseSolver()
+        self.restart_mock.assert_not_called()
+
+    def test_droidcast_failure_prevents_startup_success(self):
+        device = MagicMock()
+        device.start_droidcast.return_value = False
+        self.device_mock.side_effect = None
+        self.device_mock.return_value = device
+        self.session_mock.return_value.devices_list.return_value = [
+            (config.conf.adb, "device")
+        ]
+        with (
+            patch.object(config.conf.droidcast, "enable", True),
+            patch.object(config.conf, "touch_method", "scrcpy"),
+            patch("arknights_mower.utils.solver.Recognizer") as recog,
+            patch("arknights_mower.utils.solver.Scrcpy") as scrcpy,
+        ):
+            with self.assertRaises(ConnectionError):
+                BaseSolver()
+        self.assertEqual(device.start_droidcast.call_count, 3)
+        recog.assert_not_called()
+        scrcpy.assert_not_called()
+        self.restart_mock.assert_not_called()
+
     def test_running_device_does_not_need_start(self):
         self.device_mock.side_effect = None
         with patch("arknights_mower.utils.solver.Recognizer"):

--- a/arknights_mower/utils/device/adb_client/core.py
+++ b/arknights_mower/utils/device/adb_client/core.py
@@ -134,7 +134,7 @@ class Client:
 
     def __available_devices(self) -> list[str]:
         """return available devices"""
-        return [x[0] for x in Session().devices_list() if x[1] != "offline"]
+        return [x[0] for x in Session().devices_list() if x[1] == "device"]
 
     def refresh_target(self) -> str:
         """重新发现目标模拟器当前 adb 端点并同步到 device_id / config.conf.adb。

--- a/arknights_mower/utils/device/device.py
+++ b/arknights_mower/utils/device/device.py
@@ -204,8 +204,16 @@ class Device:
         # TODO: 退出时（并非结束mower线程时）关闭DroidCast进程、取消ADB转发
         try:
             out = self.client.cmd_shell("pm path com.rayworks.droidcast", decode=True)
+        except subprocess.CalledProcessError as e:
+            # Android 部分版本在包不存在时返回退出码 1，且没有输出。
+            if e.returncode == 1 and e.output is not None and not e.output.strip():
+                return None
+            logger.exception("无法获取CLASSPATH")
+            raise
         except Exception:
             logger.exception("无法获取CLASSPATH")
+            raise
+        if not out.strip():
             return None
         prefix = "package:"
         postfix = ".apk"
@@ -427,7 +435,8 @@ class Device:
         self.device_id = target
         Session().connect(target)
         if config.conf.droidcast.enable:
-            self.start_droidcast()
+            if not self.start_droidcast():
+                raise ConnectionError("DroidCast启动失败")
         if config.conf.touch_method == "scrcpy":
             self.control.scrcpy = Scrcpy(self.client)
 

--- a/arknights_mower/utils/device/device.py
+++ b/arknights_mower/utils/device/device.py
@@ -245,29 +245,31 @@ class Device:
                 logger.error(f"无法获取CLASSPATH：{out}")
                 return False
         port = config.droidcast.port
+        occupied_by_adb_forward = False
         if port != 0 and is_port_in_use(port):
             try:
-                occupied_by_adb_forward = False
-                forward_list = self.client.cmd("forward --list", True).strip().split()
-                for host, pc_port, android_port in forward_list:
-                    # 127.0.0.1:5555 tcp:60579 tcp:60579
-                    if pc_port != android_port:
-                        # 不是咱转发的，别乱动
-                        continue
-                    if pc_port == f"tcp:{port}":
-                        occupied_by_adb_forward = True
-                        break
-                if not occupied_by_adb_forward:
-                    port = 0
+                forward_list = self.client.cmd("forward --list", True).splitlines()
+                expected = [self.client.device_id, f"tcp:{port}", f"tcp:{port}"]
+                occupied_by_adb_forward = any(
+                    line.split() == expected for line in forward_list
+                )
             except Exception as e:
                 logger.exception(e)
+            if not occupied_by_adb_forward:
+                port = 0
         if port == 0:
             port = get_new_port()
             config.droidcast.port = port
             logger.info(f"更新DroidCast端口为{port}")
         else:
             logger.info(f"保持DroidCast端口为{port}")
-        self.client.cmd(f"forward tcp:{port} tcp:{port}")
+        if not occupied_by_adb_forward:
+            try:
+                self.client.cmd(f"forward --no-rebind tcp:{port} tcp:{port}")
+            except subprocess.CalledProcessError:
+                # 选端口后仍可能发生占用，交由连接恢复流程重新分配。
+                config.droidcast.port = 0
+                raise
         logger.info("ADB端口转发成功，启动DroidCast")
         if config.droidcast.process is not None:
             config.droidcast.process.terminate()

--- a/arknights_mower/utils/simulator.py
+++ b/arknights_mower/utils/simulator.py
@@ -217,11 +217,14 @@ def wait_for_adb(process: subprocess.Popen, wait_time: int) -> bool:
 
 
 def adb_ready() -> bool:
+    # 冷启动后端口才可能出现，等待期间也要重新发现，不能一直探测旧端口。
+    discovered = query_mumu_adb_port(config.conf.simulator)
+    if discovered is not None:
+        config.conf.adb = discovered
     target = config.conf.adb
-    if not target:
-        return len(Session().devices_list()) > 0
-    Session().connect(target, throw_error=True)
+    if target:
+        Session().connect(target, throw_error=True)
     devices = [
-        device for device, status in Session().devices_list() if status != "offline"
+        device for device, status in Session().devices_list() if status == "device"
     ]
-    return target in devices
+    return target in devices if target else bool(devices)

--- a/arknights_mower/utils/solver.py
+++ b/arknights_mower/utils/solver.py
@@ -62,7 +62,8 @@ class BaseSolver:
                     if not self.device.check_resolution():
                         raise MowerExit
                     if config.conf.droidcast.enable:
-                        self.device.start_droidcast()
+                        if not self.device.start_droidcast():
+                            raise ConnectionError("DroidCast启动失败")
                     if config.conf.touch_method == "scrcpy":
                         self.device.control.scrcpy = Scrcpy(self.device.client)
                     break
@@ -73,10 +74,14 @@ class BaseSolver:
                     logger.warning(f"设备连接失败：{e}")
                     # 自动关闭模式也负责首轮启动，无需用户提前打开模拟器。
                     try:
-                        registered = [d for d, _ in Session().devices_list()]
+                        available = [
+                            d
+                            for d, status in Session().devices_list()
+                            if status == "device"
+                        ]
                     except Exception:
-                        registered = []
-                    if config.conf.adb and config.conf.adb not in registered:
+                        available = []
+                    if config.conf.adb and config.conf.adb not in available:
                         if config.conf.close_simulator_when_idle:
                             logger.info("已启用任务结束后关闭模拟器，启动目标模拟器")
                             if not restart_simulator(stop=False, start=True):

--- a/arknights_mower/utils/solver.py
+++ b/arknights_mower/utils/solver.py
@@ -71,14 +71,16 @@ class BaseSolver:
                 except Exception as e:
                     last_exc = e
                     logger.warning(f"设备连接失败：{e}")
-                    # 启动时目标设备未注册到 adb=模拟器未启动，直接启动（只启动不关闭，
-                    # 误判也不会杀在跑的游戏）；已注册但瞬时故障才走重连重试
+                    # 自动关闭模式也负责首轮启动，无需用户提前打开模拟器。
                     try:
                         registered = [d for d, _ in Session().devices_list()]
                     except Exception:
                         registered = []
                     if config.conf.adb and config.conf.adb not in registered:
-                        restart_simulator(stop=False, start=True)
+                        if config.conf.close_simulator_when_idle:
+                            logger.info("已启用任务结束后关闭模拟器，启动目标模拟器")
+                            if not restart_simulator(stop=False, start=True):
+                                raise ConnectionError("首次任务启动模拟器失败") from e
                     elif hasattr(self, "device") and self.device.client:
                         self.device._safe_reconnect()
             else:


### PR DESCRIPTION
## 目标

修复首次启动和任务间唤醒时，模拟器未启动或设备尚未就绪却继续执行任务的问题。勾选“任务结束后关闭模拟器”后，首轮任务及后续唤醒都会在需要时自动启动模拟器；同时修复离线设备、启动后端口变化及 DroidCast 安装失败引发的重复重试。

## 主要改动

- 记录本轮休眠是否主动关闭了模拟器，在定时到点或提前唤醒后先启动模拟器、等待现有启动流程完成，再重连设备并继续任务。
- 首轮任务无需用户提前打开模拟器：目标设备缺失或离线时，仅在勾选“任务结束后关闭模拟器”后自动启动；首次初始化的外层重启也遵循此选项。
- 未实际关闭模拟器的短暂等待不重复启动；用户点击停止时不拉起模拟器，启动失败时不继续访问设备。
- ADB 就绪判断统一只接受 `device` 状态，排除 `offline` 和 `unauthorized`；未配置地址时也不会将只有离线设备的列表判为就绪。
- 等待模拟器启动时持续重新发现 MuMu12 目标端口，避免冷启动后端口变化仍探测旧地址，导致误判超时和额外重启。
- DroidCast 包路径为空时进入安装分支，并兼容包不存在时退出码为 1 且输出为空的 Android 行为；设备离线等查询错误继续抛出，不再误触发安装。
- 首次初始化和设备重连都会检查 DroidCast 启动结果，失败时进入连接恢复流程，不再按初始化成功继续执行。
- DroidCast 创建 ADB 转发时使用 `--no-rebind`，禁止覆盖已有绑定；按行解析转发列表，只有设备地址和两端端口完全匹配才复用。发现其他绑定或无法确认归属时改选端口；创建时发生冲突则清空端口记录，由现有连接恢复流程重新分配。
- 补充首轮启动、选项关闭、定时及提前唤醒、停止、离线与未授权设备、端口变化、DroidCast 首次安装及失败传播的回归测试。

## 验证

- 新增 4 项 DroidCast 转发测试，覆盖已有绑定复用、其他绑定冲突、归属查询失败和选端口后的竞争。
- 后端全量单元测试：941 项通过。
- 脚本测试：85 项，84 项通过、1 项跳过。
- `ruff check .` 与 `ruff format --check .`：通过。
- Python 源码编译检查：通过。
- `git diff --check`：通过。
- 模拟器相关测试使用 mock，未在运行中的远端实例部署或进行实机启停验证。
