### PR TITLE
修复窗口子进程占用 runtime.log 导致每小时切换日志文件失败、后续日志全部丢失的问题

### DIFF
--- a/arknights_mower/tests/log_tests.py
+++ b/arknights_mower/tests/log_tests.py
@@ -1,0 +1,35 @@
+import tempfile
+import unittest
+
+from arknights_mower.utils import log, path
+
+
+class LogFileHandlerTest(unittest.TestCase):
+    def setUp(self):
+        # 隔离到临时 space，避免在仓库 log/ 下留下 runtime.log
+        if log.fhlr is not None:
+            log.fhlr.close()
+            log.fhlr = None
+        self._orig_space = path.global_space
+        self._tmp = tempfile.mkdtemp()
+        path.global_space = self._tmp
+
+    def tearDown(self):
+        if log.fhlr is not None:
+            log.fhlr.close()
+            log.fhlr = None
+        path.global_space = self._orig_space
+
+    def test_no_file_handler_created_on_import(self):
+        # 回归：GUI 子进程（webview_window）经 title_version→resource_version import
+        # log.py 时不应再新建指向 runtime.log 的文件句柄，否则 Windows 整点滚转
+        # （os.rename 需独占移动文件）会因多进程同时持有该文件而失败（WinError 32）。
+        self.assertIsNone(log.fhlr)
+
+    def test_init_file_logging_creates_runtime_log_handler(self):
+        log.init_file_logging()
+        self.assertIsNotNone(log.fhlr)
+        self.assertEqual(
+            log.fhlr.baseFilename,
+            str(log.get_path("@app/log").joinpath("runtime.log")),
+        )

--- a/arknights_mower/utils/log.py
+++ b/arknights_mower/utils/log.py
@@ -61,20 +61,33 @@ whlr = Handler()
 whlr.setLevel(logging.INFO)
 
 log_queue = Queue()
-listener = None
-
-folder = Path(get_path("@app/log"))
-folder.mkdir(exist_ok=True, parents=True)
-fhlr = TimedRotatingFileHandler(
-    folder.joinpath("runtime.log"), encoding="utf8", backupCount=168
-)
-fhlr.setFormatter(basic_formatter)
-fhlr.setLevel("DEBUG")
-fhlr.addFilter(filter)
 queue_handler = QueueHandler(log_queue)
 logger.addHandler(queue_handler)
-listener = QueueListener(log_queue, dhlr, fhlr, whlr, respect_handler_level=True)
+listener = QueueListener(log_queue, dhlr, whlr, respect_handler_level=True)
 listener.start()
+
+# f(ile)hlr: 文件记录（整点滚转）。不在导入时建立，避免 GUI 子进程（webview_window
+# 等）import 本模块时也各建一个指向同一 runtime.log 的文件句柄。Windows 的 os.rename
+# 需要独占移动文件，两个进程都持有该文件时，任一进程整点滚转都会因另一进程仍占用而
+# 抛 PermissionError [WinError 32]，且失败后该进程之后所有日志都会重复失败、全部丢失。
+# 因此文件日志交由主进程显式 init_file_logging() 建立，子进程不调用。
+fhlr = None
+
+
+def init_file_logging() -> None:
+    global fhlr
+    if fhlr is not None:
+        return
+    folder = Path(get_path("@app/log"))
+    folder.mkdir(exist_ok=True, parents=True)
+    fhlr = TimedRotatingFileHandler(
+        folder.joinpath("runtime.log"), encoding="utf8", backupCount=168
+    )
+    fhlr.setFormatter(basic_formatter)
+    fhlr.setLevel("DEBUG")
+    fhlr.addFilter(filter)
+    logger.addHandler(fhlr)
+
 
 screenshot_folder = get_path("@app/screenshot")
 screenshot_store = ScreenshotStore(

--- a/webview_ui.py
+++ b/webview_ui.py
@@ -381,6 +381,12 @@ def run_desktop():
     exit_if_webview_backend_missing()
     path.global_space = sys.argv[1] if len(sys.argv) >= 2 else None
     instance_name = sys.argv[2] if len(sys.argv) >= 3 else ""
+    from arknights_mower.utils.log import init_file_logging
+
+    # 文件日志只由主进程建立。子进程（webview_window 等）不调用 init_file_logging，
+    # 否则它们经 title_version→resource_version import log.py 时会各自打开
+    # runtime.log，Windows 上整点切换日志文件（os.rename 需独占）就会因多进程同时持有而失败。
+    init_file_logging()
     splash_queue = Queue() if background else mp.Queue()
     splash_process = None
     tray_process = None


### PR DESCRIPTION
## 变更

mower 的 webview_ui 用 multiprocessing 派生 webview_window 子进程。子进程在构建窗口标题时，会经由 title_version → resource_version 导入 log.py，于是子进程自身也会新建一个指向同一个 runtime.log 的 TimedRotatingFileHandler。Windows 的 os.rename 需要独占地移动文件，只要还有其它进程持有 runtime.log，任一进程在整点切换日志文件时都会抛出 PermissionError [WinError 32]；而且切换失败后，该进程随后的所有日志都会因为每次都先尝试切换、又一再失败而全部丢弃。

本次把文件日志的建立，从「导入 log 模块时就创建」改为「主进程显式调用 init_file_logging()」：子进程导入 log.py 时只会拿到 stdout/websocket 通道，不再打开 runtime.log。这样运行时全程只有主进程持有该文件，切换日志文件不再被其它进程占用。

## 限制

文件日志由主进程独占后，子进程自身的日志（大多是 webview 启动失败时的兜底报错）不再写入 runtime.log，而是走 stdout / websocket 通道。主进程的日志写入行为不受影响。

## 验证

- 新增 log_tests，覆盖「导入 log 不建文件句柄」「init_file_logging 建立 runtime.log 句柄」两个行为。
- webview_ui_tests、server_notify_tests 等相关测试通过。
- ruff lint 与 format 通过，py_compile 通过。
- 附带说明：resource_version_tests 中的 test_builtin_version_hash_matches_bundled_resources 在本地失败，但在本次改动前的干净基上也同样失败——那是 Windows 本地 CRLF/LF 行尾差异导致的既有环境问题，与本次改动无关。
