### PR TITLE
fix(log)：修复日志文件被多进程占用导致写入失败的问题

### DIFF
--- a/arknights_mower/tests/log_tests.py
+++ b/arknights_mower/tests/log_tests.py
@@ -1,0 +1,66 @@
+import tempfile
+import unittest
+from queue import Queue
+
+from arknights_mower.utils import log, path
+
+
+class MultiProcessLogTestBase(unittest.TestCase):
+    """每次测试隔离到临时 space，避免在仓库 log/ 下留下 runtime.log，并复位多进程句柄。"""
+
+    def setUp(self):
+        if log.fhlr is not None:
+            log.fhlr.close()
+            log.fhlr = None
+        self._orig_space = path.global_space
+        self._tmp = tempfile.mkdtemp()
+        path.global_space = self._tmp
+
+    def tearDown(self):
+        if log.mp_listener is not None:
+            log.mp_listener.stop()
+            log.mp_listener = None
+        if log.mp_queue_handler is not None:
+            log.logger.removeHandler(log.mp_queue_handler)
+            log.mp_queue_handler = None
+        if log.fhlr is not None:
+            log.fhlr.close()
+            log.fhlr = None
+        path.global_space = self._orig_space
+
+
+class LogFileHandlerTest(MultiProcessLogTestBase):
+    def test_no_file_handler_created_on_import(self):
+        # 回归：GUI 子进程（webview_window）经 title_version→resource_version import
+        # log.py 时不应再新建指向 runtime.log 的文件句柄，否则 Windows 整点滚转
+        # （os.rename 需独占移动文件）会因多进程同时持有该文件而失败（WinError 32）。
+        self.assertIsNone(log.fhlr)
+
+    def test_init_file_logging_creates_runtime_log_handler(self):
+        log.init_file_logging()
+        self.assertIsNotNone(log.fhlr)
+        self.assertEqual(
+            log.fhlr.baseFilename,
+            str(log.get_path("@app/log").joinpath("runtime.log")),
+        )
+
+
+class MultiProcessLoggingTest(MultiProcessLogTestBase):
+    def test_bind_mp_queue_adds_queue_handler_to_logger(self):
+        q = Queue()
+        log.bind_mp_queue(q)
+        self.assertIsNotNone(log.mp_queue_handler)
+        self.assertIn(log.mp_queue_handler, log.logger.handlers)
+
+    def test_start_mp_listener_creates_file_handler(self):
+        log.start_mp_listener(Queue())
+        self.assertIsNotNone(log.mp_listener)
+        self.assertIsNotNone(log.fhlr)
+
+    def test_bind_mp_queue_forwards_record_to_queue(self):
+        # 子进程侧：bind 后 emit 的记录应被 QueueHandler 送进共享队列（不对本进程写文件）
+        q = Queue()
+        log.bind_mp_queue(q)
+        log.logger.info("forwarded-msg")
+        record = q.get(timeout=2)
+        self.assertEqual(record.getMessage(), "forwarded-msg")

--- a/arknights_mower/utils/log.py
+++ b/arknights_mower/utils/log.py
@@ -44,9 +44,6 @@ dhlr.setFormatter(color_formatter)
 dhlr.setLevel(logging.DEBUG)
 dhlr.addFilter(filter)
 
-# f(ile)hlr: 文件记录
-fhlr = None
-
 
 class Handler(logging.StreamHandler):
     def emit(self, record: logging.LogRecord):
@@ -61,20 +58,72 @@ whlr = Handler()
 whlr.setLevel(logging.INFO)
 
 log_queue = Queue()
-listener = None
-
-folder = Path(get_path("@app/log"))
-folder.mkdir(exist_ok=True, parents=True)
-fhlr = TimedRotatingFileHandler(
-    folder.joinpath("runtime.log"), encoding="utf8", backupCount=168
-)
-fhlr.setFormatter(basic_formatter)
-fhlr.setLevel("DEBUG")
-fhlr.addFilter(filter)
 queue_handler = QueueHandler(log_queue)
 logger.addHandler(queue_handler)
-listener = QueueListener(log_queue, dhlr, fhlr, whlr, respect_handler_level=True)
+listener = QueueListener(log_queue, dhlr, whlr, respect_handler_level=True)
 listener.start()
+
+# f(ile)hlr: 文件记录（整点滚转）。不在导入时建立，避免 GUI 子进程（webview_window
+# 等）import 本模块时也各建一个指向同一 runtime.log 的文件句柄。Windows 的 os.rename
+# 需要独占移动文件，两个进程都持有该文件时，任一进程整点滚转都会因另一进程仍占用而
+# 抛 PermissionError [WinError 32]，且失败后该进程之后所有日志都会重复失败、全部丢失。
+# 因此文件日志交由主进程显式 init_file_logging() 建立，子进程不调用。
+fhlr = None
+
+
+def init_file_logging() -> None:
+    global fhlr
+    if fhlr is not None:
+        return
+    folder = Path(get_path("@app/log"))
+    folder.mkdir(exist_ok=True, parents=True)
+    fhlr = TimedRotatingFileHandler(
+        folder.joinpath("runtime.log"), encoding="utf8", backupCount=168
+    )
+    fhlr.setFormatter(basic_formatter)
+    fhlr.setLevel("DEBUG")
+    fhlr.addFilter(filter)
+    logger.addHandler(fhlr)
+
+
+# 多进程集中式日志：mower 主进程独占 runtime.log 文件句柄（init_file_logging），
+# mp.Process 子进程（如 webview_window）经 title_version→resource_version import log.py 时
+# 不建 fhlr，而是用 QueueHandler 把 LogRecord 经共享的 multiprocessing.Queue 上行到主进程，
+# 由主进程的 start_mp_listener 消费后写入 fhlr。这样既保留子进程日志落盘，又避免多个进程
+# 各自持有 runtime.log 导致 Windows 整点滚转（os.rename 需独占）抛 PermissionError
+# [WinError 32]。两个通过 subprocess.Popen 拉起的 worker（进程控制 / 软件更新）与主进程
+# 之间没有共享的 mp.Queue，走不进这条路，它们各自把输出写进 process.log / update.log。
+mp_queue_handler = None  # 子进程侧：把本进程的 logger 记录送上共享队列
+mp_listener = None  # 主进程侧：把共享队列里的记录写入 fhlr
+
+
+def bind_mp_queue(queue) -> None:
+    """mp.Process 子进程使用：把本进程日志上行到主进程的共享队列。
+
+    子进程不调用 init_file_logging（不建 fhlr），只把 logger 挂到 QueueHandler(queue)，
+    记录由主进程的 start_mp_listener 消费后写入 runtime.log。
+    """
+    global mp_queue_handler
+    if mp_queue_handler is not None:
+        return
+    mp_queue_handler = QueueHandler(queue)
+    logger.addHandler(mp_queue_handler)
+
+
+def start_mp_listener(queue) -> None:
+    """主进程使用：消费共享队列，把子进程上行的记录写入 runtime.log。
+
+    QueueHandler.prepare 会把 message 连同异常栈一起格式化进 record.message，随后清空
+    args / exc_info / exc_text，因此跨进程 pickle 安全，子进程的异常栈会随 message 落盘。
+    须在能取得 fhlr 之后调用（内部会兜底 init_file_logging）。
+    """
+    global mp_listener
+    if mp_listener is not None:
+        return
+    init_file_logging()
+    mp_listener = QueueListener(queue, fhlr, respect_handler_level=True)
+    mp_listener.start()
+
 
 screenshot_folder = get_path("@app/screenshot")
 screenshot_store = ScreenshotStore(

--- a/webview_ui.py
+++ b/webview_ui.py
@@ -257,7 +257,9 @@ def start_tray(queue: mp.Queue, instance_name, port, url):
     icon.run()
 
 
-def webview_window(child_conn, global_space, instance_name, host, port, url, tray):
+def webview_window(
+    child_conn, global_space, instance_name, host, port, url, tray, log_queue=None
+):
     import sys
     from threading import Thread
 
@@ -268,6 +270,11 @@ def webview_window(child_conn, global_space, instance_name, host, port, url, tra
     from arknights_mower.utils import path
 
     path.global_space = global_space
+
+    if log_queue is not None:
+        from arknights_mower.utils import log as mower_log
+
+        mower_log.bind_mp_queue(log_queue)
 
     from arknights_mower.utils.config.gui import load_window_size, save_window_size
 
@@ -381,6 +388,12 @@ def run_desktop():
     exit_if_webview_backend_missing()
     path.global_space = sys.argv[1] if len(sys.argv) >= 2 else None
     instance_name = sys.argv[2] if len(sys.argv) >= 3 else ""
+    from arknights_mower.utils.log import init_file_logging, start_mp_listener
+
+    # 文件日志只由主进程建立。子进程（webview_window 等）不调用 init_file_logging，
+    # 否则它们经 title_version→resource_version import log.py 时会各自打开
+    # runtime.log，Windows 上整点切换日志文件（os.rename 需独占）就会因多进程同时持有而失败。
+    init_file_logging()
     splash_queue = Queue() if background else mp.Queue()
     splash_process = None
     tray_process = None
@@ -399,6 +412,12 @@ def run_desktop():
     conf = config.conf
     tray = conf.webview.tray or (background and sys.platform != "darwin")
     keep_running = tray or background or sys.platform == "darwin"
+    # webview_window 等 mp.Process 子进程把日志上行到这里，由主进程统一写入 runtime.log。
+    # 只有会拉起 webview_window（前台启动，或后台且有托盘可开关窗口）时才需要这条队列；
+    # 后台 macOS 无托盘时既不拉起窗口也不需要它，避免凭空创建 mp.Queue。
+    if not background or tray:
+        mp_log_queue = mp.Queue()
+        start_mp_listener(mp_log_queue)
     token = conf.webview.token
     host = "0.0.0.0" if token else "127.0.0.1"
     restart_port = os.environ.get("MOWER_RESTART_PORT", "")
@@ -457,6 +476,7 @@ def run_desktop():
                 port,
                 url,
                 keep_running,
+                mp_log_queue,
             ),
             daemon=True,
         )


### PR DESCRIPTION
## 变更

- `arknights_mower/utils/log.py`：文件日志只由主进程 `init_file_logging()` 建立；新增 `bind_mp_queue` / `start_mp_listener` —— 让 `mp.Process` 子进程（如 webview_window）用 `QueueHandler` 把 `LogRecord` 经共享的 `multiprocessing.Queue` 上行到主进程，由主进程的监听线程消费后写入 `fhlr`。
- `webview_ui.py`：主进程 `run_desktop()` 在会拉起 `webview_window` 时（前台启动，或后台且有托盘可开关窗口）创建这条共享队列并启动消费监听；`webview_window` 收到队列后调用 `bind_mp_queue`，把本进程日志上行。
- 保持仅主进程持有 `runtime.log`（单写者）不变，整点滚转不再因多进程同时持有文件抛 `PermissionError [WinError 32]`；子进程日志在单写者模式下重新落盘。

## 为什么造成 / 导致了什么

半修复（原 #961）为避免子进程各自打开 `runtime.log` 导致 Windows 整点滚转（`os.rename` 需独占文件）的多进程 `WinError 32`，把文件日志改为仅主进程 `init_file_logging()` 建立。这使 `mp.Process` 子进程（webview_window 等）经 title_version→resource_version import log.py 时不再持有该文件，其日志只落到 stdout/websocket，不再写入 `runtime.log` —— 窗口子进程的异常与 UI 事件日志从 runtime.log 缺失，遇到窗口问题无文件可查。本 PR（顶替原 #961）在保留单写者的同时，用共享队列把子进程日志重新写入 runtime.log，一并解决「子进程日志不再落盘」与「整点滚转仍可能失败」两个问题。

## 限制

- 该路径只覆盖 `mp.Process` 拉起的子进程。进程控制（`--process-control-worker`）与软件更新（`--software-update-worker`）两个 worker 由 `subprocess.Popen` 作为独立进程拉起，与主进程之间没有共享的 `mp.Queue`，走不进这条路径；它们各自把输出写入 `process.log` / `update.log`。
- 子进程日志写入 `runtime.log`，但不进入前端 websocket 日志面板（与改动前一致，前端日志面板仍只显示主进程日志）。

## 验证

- `log_tests` 5 项通过（新增 3 项：`bind_mp_queue` 给 logger 挂 handler、`start_mp_listener` 建文件句柄、`bind_mp_queue` 把记录转发进队列）。
- `webview_ui_tests` 23 项、`server_notify_tests` 7 项、`software_update_tests.ArchiveAndLauncherTests` 6 项通过。
- `py_compile`、`ruff check`、`ruff format` 对改动文件均通过。
- 用真实 `arknights_mower.utils.log` + `mp.Process` 子进程做了端到端验证：子进程的 info / warning / 异常栈记录都落入 `runtime.log`，且子进程的 `fhlr` 保持 `None`（未重复打开文件）。
- CI（ruff / actionlint / prettier / recognition-equivalence / unittest）全部通过。
