### PR TITLE
fix(skland): 修复设备指纹服务不可达时森空岛认证误报设备信息无效

### DIFF
--- a/arknights_mower/tests/skland_tests.py
+++ b/arknights_mower/tests/skland_tests.py
@@ -1,6 +1,9 @@
 import datetime
+import json
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 # mastery_view_tests 等模块收集期会先往 sys.modules 塞 skland 的 MagicMock 桩
@@ -155,26 +158,85 @@ class TestLoginSyncsServerTime(unittest.TestCase):
         self.assertEqual(skland.server_time_offset, SERVER_EPOCH - LOCAL_EPOCH)
         self.assertEqual(skland.header_login["dId"], fake_did)
 
+    def test_login_fails_fast_when_no_did(self):
+        # 取不到 dId 时不以空串继续请求，提前抛错而非误报「设备信息无效」
+        account = Mock(account="13800000000", password="pw")
+        with patch.object(skland, "_ensure_device_id", return_value=""):
+            with self.assertRaises(Exception):
+                skland.log(account)
+
 
 class TestEnsureDeviceId(unittest.TestCase):
     def setUp(self):
         skland._device_id = ""
         skland._device_id_failed = False
+        # 隔离落盘路径：不触碰真实配置目录
+        self._tmp = tempfile.TemporaryDirectory()
+        self._did_file = Path(self._tmp.name) / "skland_device_id.json"
+        self._patch_file = patch.object(skland, "_DEVICE_ID_FILE", self._did_file)
+        self._patch_file.start()
+        self.addCleanup(self._patch_file.stop)
 
-    def test_degraded_to_empty_on_failure(self):
-        # 设备信息服务不可达 → 降级为空串，不抛异常；且失败一次后不再重试
-        with patch.object(
-            skland, "get_d_id", side_effect=Exception("fp-it down")
-        ) as get_d:
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_uses_persisted_did(self):
+        # 有落盘 dId 直接复用、不再联网去取
+        self._did_file.write_text(json.dumps({"dId": "Bpersisted"}), "utf-8")
+        with patch.object(skland, "get_d_id") as get_d:
+            self.assertEqual(skland._ensure_device_id(), "Bpersisted")
+            get_d.assert_not_called()
+
+    def test_fetches_and_persists_when_no_persisted(self):
+        # 无落盘时才去 fp-it 取，成功后落盘
+        with (
+            patch.object(skland, "get_d_id", return_value="B123"),
+            patch("time.sleep"),
+        ):
+            self.assertEqual(skland._ensure_device_id(), "B123")
+        self.assertEqual(json.loads(self._did_file.read_text("utf-8")), {"dId": "B123"})
+
+    def test_degraded_to_empty_after_retries(self):
+        # 设备信息服务持续不可达 → 重试几次后降级为空串，不抛异常；且失败后不再重试
+        with (
+            patch.object(
+                skland, "get_d_id", side_effect=Exception("fp-it down")
+            ) as get_d,
+            patch("time.sleep"),
+        ):
             self.assertEqual(skland._ensure_device_id(), "")
-            self.assertEqual(get_d.call_count, 1)
+            self.assertEqual(get_d.call_count, skland._DEVICE_ID_RETRIES)
             # 再次触发：应为惰性短路，不再访问设备信息服务
             self.assertEqual(skland._ensure_device_id(), "")
-            self.assertEqual(get_d.call_count, 1)
+            self.assertEqual(get_d.call_count, skland._DEVICE_ID_RETRIES)
+
+    def test_retries_until_success(self):
+        # 服务偶发超时：前几次失败、最后一次成功 → 返回真实 dId，而非降级为空串
+        side = [Exception("timeout"), Exception("timeout"), "B123"]
+        with (
+            patch.object(skland, "get_d_id", side_effect=side) as get_d,
+            patch("time.sleep"),
+        ):
+            self.assertEqual(skland._ensure_device_id(), "B123")
+            self.assertEqual(get_d.call_count, skland._DEVICE_ID_RETRIES)
+            self.assertFalse(skland._device_id_failed)
 
     def test_returns_device_id(self):
         with patch.object(skland, "get_d_id", return_value="B123"):
             self.assertEqual(skland._ensure_device_id(), "B123")
+
+    def test_get_cred_invalidates_did_on_device_invalid(self):
+        # 换 cred 遇「设备信息无效」→ 清掉内存与落盘 dId，避免连续复用同一个失效 dId
+        self._did_file.write_text(json.dumps({"dId": "Bbad"}), "utf-8")
+        skland._device_id = "Bbad"
+        fake = Mock()
+        fake.json = Mock(return_value={"code": 10001, "message": "设备信息无效"})
+        with patch("requests.post", return_value=fake):
+            with self.assertRaises(Exception):
+                skland.get_cred("grant")
+        self.assertEqual(skland._device_id, "")
+        self.assertFalse(skland._device_id_failed)
+        self.assertFalse(self._did_file.exists())
 
 
 class TestSignHeaderFields(unittest.TestCase):

--- a/arknights_mower/utils/skland.py
+++ b/arknights_mower/utils/skland.py
@@ -7,7 +7,9 @@ from urllib import parse
 
 import requests
 
+from arknights_mower.utils.config import atomic_write
 from arknights_mower.utils.log import logger
+from arknights_mower.utils.path import get_path
 from arknights_mower.utils.SecuritySm import get_d_id
 
 app_code = "4ca99fa6b56cc2ba"
@@ -58,29 +60,76 @@ header_login = {
 header_for_sign = {"platform": "1", "timestamp": "", "dId": "", "vName": SKLAND_VERSION}
 
 # 模块级状态：设备指纹与服务器时钟偏移，均由下列函数惰性维护。
-# 设备指纹导入时不联网（fp-it 服务不可达也不会导致导入崩溃），首次登录前取、失败降级为空串，
-# 且失败一次后本程序不再重试（_device_id_failed 短路），避免反复捶打不可达服务、重复刷警告；
+# 设备指纹导入时不联网（fp-it 服务不可达也不会导致导入崩溃），首次登录前取，
+# 重试几次仍失败才降级为空串，随后本程序运行期间不再重试（_device_id_failed 短路），
+# 避免反复捶打不可达服务、重复刷警告；
 # 时钟偏移由 _sync_server_time 从每次响应校准，签名时间戳用它落在服务器时间上。
 _device_id = ""
 _device_id_failed = False
 server_time_offset = 0
 
+# 设备指纹（dId）落盘文件：dId 是数美（fp-it）签发的设备身份，设备级且长期稳定。
+# 复用上次签发的结果能扛住指纹服务临时不可达/被阻断（正是「设备信息无效」的根因），
+# 不必每次运行都重新联网去要。
+_DEVICE_ID_FILE = get_path("@app/config/skland_device_id.json", space="")
+# 指纹服务偶发超时：取不到时重试几次再放弃，避免一次瞬时故障就让整个运行期的森空岛认证落空。
+_DEVICE_ID_RETRIES = 3
+
+
+def _read_persisted_did() -> str:
+    """读上次落盘的 dId；文件缺失或内容非法时返回空串。"""
+    try:
+        data = json.loads(_DEVICE_ID_FILE.read_text("utf-8"))
+        did = data.get("dId", "")
+        return did if isinstance(did, str) else ""
+    except Exception:
+        return ""
+
+
+def _write_persisted_did(did: str) -> None:
+    """幂等写落盘 dId；写入失败不影响本次运行（仅下次无法复用）。"""
+    try:
+        atomic_write(_DEVICE_ID_FILE, lambda f: json.dump({"dId": did}, f))
+    except Exception:
+        pass
+
+
+def _invalidate_device_id() -> None:
+    """认证因设备指纹被拒（设备信息无效）时清掉内存与落盘 dId，下次重新取。"""
+    global _device_id, _device_id_failed
+    _device_id = ""
+    _device_id_failed = False
+    try:
+        _DEVICE_ID_FILE.unlink()
+    except Exception:
+        pass
+
 
 def _ensure_device_id() -> str:
-    """取森空岛设备指纹；设备信息服务不可达时降级为空串，不抛异常。
+    """取森空岛设备指纹；服务不可达时降级为空串，不抛异常。
 
-    失败一次后本程序运行期间不再尝试取（_device_id_failed 短路），
-    避免每次生成签名都重打一次不可达的设备信息服务、重复刷警告。
+    优先用上次落盘的 dId（不再联网）；没有才去 fp-it 取，重试几次仍失败才放弃，
+    并在本次运行期间不再尝试（_device_id_failed 短路）。
     """
     global _device_id, _device_id_failed
     if _device_id_failed:
         return _device_id
     if not _device_id:
-        try:
-            _device_id = get_d_id()
-        except Exception:
-            _device_id_failed = True
-            logger.warning("设备指纹获取失败（设备信息服务不可达），设备校验可能被拒")
+        _device_id = _read_persisted_did()
+    if not _device_id:
+        for attempt in range(_DEVICE_ID_RETRIES):
+            try:
+                _device_id = get_d_id()
+                _write_persisted_did(_device_id)
+                break
+            except Exception:
+                if attempt == _DEVICE_ID_RETRIES - 1:
+                    _device_id_failed = True
+                    logger.warning(
+                        "设备指纹获取失败（设备信息服务不可达），设备校验可能被拒"
+                    )
+                else:
+                    time.sleep(1)
     return _device_id
 
 
@@ -183,6 +232,10 @@ def get_cred(grant):
     ).json()
 
     if resp["code"] != 0:
+        # 「设备信息无效」是 dId 失效/丢失的信号：清掉内存与落盘缓存，
+        # 让下次认证重新取一个新的，避免连续复用同一个失效 dId
+        if resp.get("message") == "设备信息无效":
+            _invalidate_device_id()
         raise Exception(f"获得cred失败：{resp['message']}")
 
     return resp["data"]
@@ -221,6 +274,10 @@ def get_cred_by_token(token):
 
 def log(account):
     header_login["dId"] = _ensure_device_id()
+    if not header_login["dId"]:
+        # 取不到 dId 时不应以空串继续请求：森空岛后端在换 cred 时会把空 dId 视为无效设备，
+        # 误报「设备信息无效」。提前中止，明确报指纹服务不可达。
+        raise Exception("设备指纹服务不可达，无法认证森空岛")
     resp = requests.post(
         token_password_url,
         json={"phone": account.account, "password": account.password},


### PR DESCRIPTION
**目标**

森空岛的认证流程（仓库扫描、签到等都会用到）此前会因设备指纹服务偶发不可达而失败：取不到 dId 时程序会发出空串，而服务器在「换 cred」这一步会把空串视作无效设备，于是返回「设备信息无效」。这次修改让认证在指纹服务不可达时也能照常拿到 cred——只要拿到过真实的 dId 就复用它，不必每一次都依赖指纹服务在线。

这一修改是 #938 的跟进。当时为了让指纹服务不可达时不再在模块导入阶段崩溃，把 dId 改成了失败时降级为空串，但也留下了空串在「换 cred」时被误判的缝隙。

**主要改动**

- 设备指纹（dId）落盘到 `@app/config/skland_device_id.json`，认证时优先用落盘值，不再每次联网向指纹服务索取。
- 首次获取失败时重试几次再放弃，扛住指纹服务瞬时波动。
- 「换 cred」返回「设备信息无效」时清掉内存与落盘的 dId，下次认证重新获取，避免一直复用同一个失效 dId。
- 实在取不到 dId 时提前中止并提示「设备指纹服务不可达」，不再带着空串去撞「设备信息无效」。

**验证与风险**

- 单测：`skland_tests` 新增复用落盘 dId、取到即落盘、重试直到成功、遇「设备信息无效」自愈、取不到 dId 快速失败等用例，28 条通过；`ruff` 也通过。
- 实机：用配置账号走 login→grant→cred 成功拿到 cred；并确认指纹服务不可达时能复用缓存。
- 风险：首次运行碰上指纹服务断开时仍会失败（此时还没有可复用的 dId）；本次修改只是降低发生概率、并去掉误导性的报错，不改变「换 cred 必须提供真实 dId」这个前提。
