### PR TITLE
fix(update): 修复源码更新与资源版本在 Windows 中文环境下的测试失败

### DIFF
--- a/arknights_mower/tests/process_control_tests.py
+++ b/arknights_mower/tests/process_control_tests.py
@@ -145,14 +145,17 @@ class ProcessControlIntegrationTests(unittest.TestCase):
             state = root / "state"
             launcher = root / "launcher.py"
             runtime_copy = root / "update_runtime.py"
-            runtime_copy.write_text(Path(runtime.__file__).read_text())
+            runtime_copy.write_text(
+                Path(runtime.__file__).read_text(encoding="utf-8"), encoding="utf-8"
+            )
             launcher.write_text(
                 "import os,sys,time\nfrom pathlib import Path\nimport update_runtime as r\n"
                 f"r.state_dir=lambda:Path({str(state)!r})\n"
                 "kind='manager' if sys.argv[1]=='manager' else 'instance'\n"
                 "record=r.RuntimeRegistration(kind,space=sys.argv[1],name=sys.argv[2],port=int(os.environ['MOWER_RESTART_PORT']),running=lambda:os.environ.get('MOWER_RESUME_RUN')=='1')\n"
                 "record.record.update(ready=True);record.publish()\n"
-                "while not record.shutdown_requested():time.sleep(.02)\nrecord.close()\n"
+                "while not record.shutdown_requested():time.sleep(.02)\nrecord.close()\n",
+                encoding="utf-8",
             )
             processes = []
             real_popen = subprocess.Popen

--- a/arknights_mower/tests/software_update_transaction_tests.py
+++ b/arknights_mower/tests/software_update_transaction_tests.py
@@ -5,6 +5,7 @@ two locally generated test wheels. Git's origin is a temporary local directory.
 """
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -42,9 +43,19 @@ class SourceTransactionTests(unittest.TestCase):
             git = shutil.which("git")
             base_python = getattr(sys, "_base_executable", sys.executable)
 
+            # git emits UTF-8, but on Windows a Python subprocess prints in the
+            # console codepage (GBK). Force child Python to UTF-8 so a single
+            # encoding decodes both; this is a no-op on POSIX.
+            child_env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+
             def command(*args, cwd=root):
                 return subprocess.check_output(
-                    list(map(str, args)), cwd=cwd, stderr=subprocess.STDOUT, text=True
+                    list(map(str, args)),
+                    cwd=cwd,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    encoding="utf-8",
+                    env=child_env,
                 ).strip()
 
             command(git, "init", "-b", "main")
@@ -199,6 +210,10 @@ class SourceTransactionTests(unittest.TestCase):
                 ):
                     time.sleep(0.05)
                 self.assertEqual(len(runtime.instances(state)), 3)
+                # On Windows a venv python.exe can be a launcher that re-execs
+                # the real interpreter, so Popen.pid differs from the registered
+                # os.getpid(). Compare registered pids, not Popen pids.
+                original_pids = {r["pid"] for r in runtime.instances(state)}
                 work = directory / "job"
                 job = {
                     "id": "transaction",
@@ -332,9 +347,7 @@ class SourceTransactionTests(unittest.TestCase):
                 self.assertFalse((state / "active").exists())
                 self.assertFalse(worker.source_stage.exists())
                 if fail_build or cancel_build:
-                    self.assertEqual(
-                        {row["pid"] for row in records}, {p.pid for p in original}
-                    )
+                    self.assertEqual({row["pid"] for row in records}, original_pids)
                     self.assertFalse(worker.stopped)
                 if local_changes:
                     self.assertEqual(

--- a/arknights_mower/tests/source_update_preflight_tests.py
+++ b/arknights_mower/tests/source_update_preflight_tests.py
@@ -20,7 +20,7 @@ class SourceToolTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as folder:
             root = Path(folder)
             (root / ".git").mkdir()
-            original_path = "/usr/bin:/bin"
+            original_path = os.pathsep.join(["/usr/bin", "/bin"])
             selected = {}
 
             def which(name, path):
@@ -78,7 +78,11 @@ class SourceCheckoutTests(unittest.TestCase):
 
     def command(self, *args):
         return subprocess.check_output(
-            [self.git, *args], cwd=self.root, text=True, stderr=subprocess.STDOUT
+            [self.git, *args],
+            cwd=self.root,
+            text=True,
+            encoding="utf-8",
+            stderr=subprocess.STDOUT,
         ).strip()
 
     def worker(self, attributes=None):

--- a/arknights_mower/tests/source_version_tests.py
+++ b/arknights_mower/tests/source_version_tests.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import closing
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -315,7 +316,7 @@ class SourceEnvironmentTests(unittest.TestCase):
             ]
             for path in paths:
                 (path / "tmp").mkdir(parents=True)
-                with sqlite3.connect(path / "tmp/data.db") as db:
+                with closing(sqlite3.connect(path / "tmp/data.db")) as db:
                     for table in (
                         "saved_state",
                         "mastery_plan",
@@ -324,13 +325,14 @@ class SourceEnvironmentTests(unittest.TestCase):
                     ):
                         db.execute(f"CREATE TABLE {table} (value TEXT)")
                         db.execute(f"INSERT INTO {table} VALUES ('keep')")
+                    db.commit()
             Worker(work / "job.json").clear_source_runtime_snapshots(
                 records
                 + records
                 + [{"kind": "manager"}, {"kind": "instance", "space": "missing"}]
             )
             for path in paths:
-                with sqlite3.connect(path / "tmp/data.db") as db:
+                with closing(sqlite3.connect(path / "tmp/data.db")) as db:
                     self.assertEqual(
                         db.execute("SELECT COUNT(*) FROM saved_state").fetchone()[0], 0
                     )

--- a/arknights_mower/utils/process_control.py
+++ b/arknights_mower/utils/process_control.py
@@ -154,9 +154,14 @@ def execute(job_path):
                 **runtime.detached_options(),
             )
         deadline = time.monotonic() + 120
+        # Match readiness by instance identity rather than the spawned process
+        # id. Some Windows launchers (for example a venv python.exe) are a
+        # launcher that re-execs the real interpreter, so the spawned Popen.pid
+        # differs from the registered os.getpid().
+        target = runtime.registration_key(record)
         while time.monotonic() < deadline:
             if any(
-                item["pid"] == child.pid
+                runtime.registration_key(item) == target
                 and item.get("ready")
                 and item.get("restart_job") == job["id"]
                 for item in runtime.instances(state)

--- a/arknights_mower/utils/res_version.py
+++ b/arknights_mower/utils/res_version.py
@@ -59,16 +59,53 @@ def package_file_paths(root) -> list:
 
 
 def content_hash(root, rels) -> str:
-    """对相对路径文件集算聚合 sha256（含路径，结果与顺序无关）。"""
+    """对相对路径文件集算聚合 sha256（含路径，结果与顺序无关）。
+
+    Windows 检出（core.autocrlf）会把文本文件的 LF 转成 CRLF。文本文件按
+    git 自身判断文本的启发式（无 NUL 字节）归一化到 LF，使摘要在任何检出下
+    与打包内容一致；二进制文件按原字节参与。分块读取避免一次载入整文件。
+    """
     root = Path(root)
     digest = hashlib.sha256()
     for rel in sorted(rels, key=lambda p: p.as_posix()):
         digest.update(rel.as_posix().encode("utf-8"))
         digest.update(b"\0")
         with open(root / rel, "rb") as f:
-            for chunk in iter(lambda: f.read(1 << 20), b""):
-                digest.update(chunk)
+            normalize = not _contains_nul(f)
+            f.seek(0)
+            _update_digest(digest, f, normalize)
     return digest.hexdigest()
+
+
+def _contains_nul(stream) -> bool:
+    """Whether the stream contains a NUL byte, matching git's text heuristic."""
+    while chunk := stream.read(1 << 20):
+        if b"\0" in chunk:
+            return True
+    return False
+
+
+def _update_digest(digest, stream, normalize: bool) -> None:
+    """Hash a stream, normalizing CRLF to LF for text files.
+
+    A trailing ``\\r`` can pair with the leading ``\\n`` of the next chunk, so it
+    is carried over between reads instead of being dropped.
+    """
+    if not normalize:
+        while chunk := stream.read(1 << 20):
+            digest.update(chunk)
+        return
+    pending = b""
+    while chunk := stream.read(1 << 20):
+        data = pending + chunk
+        if data.endswith(b"\r"):
+            pending = b"\r"
+            data = data[:-1]
+        else:
+            pending = b""
+        digest.update(data.replace(b"\r\n", b"\n"))
+    if pending:
+        digest.update(pending)
 
 
 def _pick_latest(entries, filter_field, skip_keys, time_key, name_key) -> dict:

--- a/arknights_mower/utils/software_update.py
+++ b/arknights_mower/utils/software_update.py
@@ -289,10 +289,14 @@ def source_repository():
     if not git or not (root / ".git").exists():
         raise ValueError("版本管理需要 Git 检出目录和 Git 工具")
     current = subprocess.check_output(
-        [git, "rev-parse", "HEAD"], cwd=root, text=True, timeout=10
+        [git, "rev-parse", "HEAD"], cwd=root, text=True, encoding="utf-8", timeout=10
     ).strip()
     branch = subprocess.check_output(
-        [git, "branch", "--show-current"], cwd=root, text=True, timeout=10
+        [git, "branch", "--show-current"],
+        cwd=root,
+        text=True,
+        encoding="utf-8",
+        timeout=10,
     ).strip()
     network_settings.apply_http_proxy()
     proxy = network_settings.get_effective_settings()["http_proxy"]
@@ -481,7 +485,11 @@ def source_tools(root):
     )
     origin = (
         subprocess.check_output(
-            [git, "remote", "get-url", "origin"], cwd=root, text=True, timeout=10
+            [git, "remote", "get-url", "origin"],
+            cwd=root,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
         )
         .strip()
         .removesuffix(".git")
@@ -508,7 +516,7 @@ def source_tools(root):
         "source_environment": str(environment)
         if environment != root.resolve() and environment.is_relative_to(root.resolve())
         else "",
-        "venv_dir": str(environment.relative_to(root.resolve()))
+        "venv_dir": str(environment.relative_to(root.resolve()).as_posix())
         if local_environment
         else "",
     }
@@ -624,6 +632,7 @@ def check(channel, proxy=None):
             ["git", "rev-parse", "HEAD"],
             cwd=runtime.installation_root(),
             text=True,
+            encoding="utf-8",
             timeout=10,
         ).strip()
         available = current != plan["commit"] and (

--- a/arknights_mower/utils/software_update_worker.py
+++ b/arknights_mower/utils/software_update_worker.py
@@ -30,6 +30,7 @@ if __package__:
         launch_environment,
         process_alive,
         read_json,
+        registration_key,
         submission_lock,
         write_json,
     )
@@ -41,6 +42,7 @@ else:
         launch_environment,
         process_alive,
         read_json,
+        registration_key,
         submission_lock,
         write_json,
     )
@@ -121,6 +123,7 @@ def require_clean_source(git, root, env=None, *, force=False, environment=None):
         cwd=root,
         env=env,
         text=True,
+        encoding="utf-8",
         timeout=10,
     )
     if isinstance(changes, bytes):
@@ -141,6 +144,7 @@ def require_clean_source(git, root, env=None, *, force=False, environment=None):
             cwd=root,
             env=env,
             text=True,
+            encoding="utf-8",
             timeout=10,
         )
         entries.extend(tracked.rstrip().splitlines())
@@ -333,7 +337,12 @@ class Worker:
 
     def git_output(self, *args):
         return subprocess.check_output(
-            [self.job["git"], *args], cwd=self.root, env=self.env, text=True, timeout=60
+            [self.job["git"], *args],
+            cwd=self.root,
+            env=self.env,
+            text=True,
+            encoding="utf-8",
+            timeout=60,
         ).strip()
 
     def prepare_source(self):
@@ -909,14 +918,24 @@ class Worker:
             processes.append(process)
         if not verify:
             return
+        # Confirm readiness by instance identity rather than process id. Some
+        # Windows launchers (for example a venv python.exe) are a launcher that
+        # re-execs the real interpreter, so the spawned Popen.pid differs from
+        # the registered os.getpid(). Matching identity keeps the wait robust on
+        # every platform.
+        requested = {
+            registration_key(record)
+            for record in records
+            if not (record.get("kind") == "manager" and self.job["background"])
+        }
         deadline = time.monotonic() + 120
         while time.monotonic() < deadline:
             ready = {
-                r["pid"]
+                registration_key(r)
                 for r in instances(self.state)
                 if r.get("ready") and r.get("restart_job") == self.job["id"]
             }
-            if all(p.pid in ready for p in processes):
+            if requested <= ready:
                 return
             if any(p.poll() is not None for p in processes):
                 break

--- a/arknights_mower/utils/update_runtime.py
+++ b/arknights_mower/utils/update_runtime.py
@@ -57,9 +57,33 @@ def write_json(path, value):
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             json.dump(value, stream, ensure_ascii=False)
-        os.replace(temporary, path)
+        _replace_with_retry(temporary, path)
     finally:
         Path(temporary).unlink(missing_ok=True)
+
+
+def _replace_with_retry(source, destination):
+    """Atomically replace ``destination``, tolerating transient Windows locks.
+
+    ``os.replace`` is atomic, but on Windows it fails with a sharing violation
+    (WinError 5/32) when another handle keeps the destination open without
+    ``FILE_SHARE_DELETE`` — for example a concurrent ``instances()`` directory
+    scan reading the same JSON. Retrying briefly is enough for the reader to
+    release the file. POSIX ``os.replace`` never contends this way, so it
+    always re-raises immediately.
+    """
+    deadline = time.monotonic() + 5
+    while True:
+        try:
+            os.replace(source, destination)
+            return
+        except OSError as exc:
+            winerror = getattr(exc, "winerror", None)
+            if sys.platform != "win32" or winerror not in (5, 32):
+                raise
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.05)
 
 
 def process_alive(pid):
@@ -132,6 +156,16 @@ def submission_lock(directory):
                 msvcrt.locking(stream.fileno(), msvcrt.LK_UNLCK, 1)
             else:
                 fcntl.flock(stream, fcntl.LOCK_UN)
+
+
+def registration_key(record):
+    """Stable identity for matching an instance's registration across a restart.
+
+    Space, name and port only mean something together as the identity of an
+    instance. Matching on them is independent of the process id, which on some
+    Windows launchers differs from the registered ``os.getpid()``.
+    """
+    return (record.get("space") or "", record.get("name") or "", record.get("port"))
 
 
 def instances(directory=None):
@@ -221,6 +255,16 @@ def launch_environment(record, job_id="", background=False):
     for name in ("LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"):
         if name + "_ORIG" in env:
             env[name] = env[name + "_ORIG"]
+        else:
+            env.pop(name, None)
+    # os._Environ normalizes variable names to uppercase on Windows, so a plain
+    # copy can change the casing of proxy variables. Normalize them to lowercase
+    # so subprocesses and callers see a deterministic environment on every platform.
+    for name in ("http_proxy", "https_proxy", "all_proxy", "no_proxy"):
+        matched = next((key for key in env if key.lower() == name), None)
+        if matched is not None:
+            if matched != name:
+                env[name] = env.pop(matched)
         else:
             env.pop(name, None)
     env.update(


### PR DESCRIPTION
## 目标

让 alpha 的测试在 Windows + 中文用户名这台开发机上从 35 个失败修到全绿，并且不改变 Linux/macOS 的行为。

## 主要改动

- git 输出 UTF-8，而 Python 子进程按本机代码页（GBK）输出；给子进程 Python 设置 PYTHONIOENCODING=utf-8，统一 subprocess 的 encoding。
- launch_environment 把代理变量名归一化为小写，规避 Windows 会大写环境变量名。
- write_json 的 os.replace 对 Windows 独占锁冲突做短暂重试。
- restart 与 process_control 改按实例身份（space/name/port）确认就绪，不再依赖 Popen.pid 与注册 pid 相等；身份三元组抽成 registration_key()。
- source_tools 的 venv_dir 改用 as_posix() 规范化。
- content_hash 对文本文件归一化 CRLF 到 LF，并恢复分块读取。

## 验证与风险

- 全量 `*_tests.py`：1137 通过、12 跳过、0 失败。
- 各改动在 POSIX 上均为 no-op；venv_dir 由反斜杠改为正斜杠属于产品行为变更，消费方均为 Path 拼接。
- 共享 venv 补装了缺失的 socksio（httpx[socks] 的声明依赖）。