### PR TITLE
fix(maa): 修复打包后测试 Maa 连接时配置文件加载报错的问题

### DIFF
--- a/arknights_mower/tests/maa_check_tests.py
+++ b/arknights_mower/tests/maa_check_tests.py
@@ -1,12 +1,16 @@
 import json
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
 from arknights_mower.utils.maa_check import (
     MAA_CHECK_SCRIPT,
+    maa_check_command,
     maa_check_params,
     maa_check_timeout_result,
     parse_maa_check_output,
+    run_maa_check,
+    worker_main,
 )
 
 
@@ -63,6 +67,68 @@ class TestMaaCheck(unittest.TestCase):
             params = maa_check_params()
 
         json.dumps(params)
+
+    def test_command_uses_c_for_source_mode(self):
+        with patch("arknights_mower.utils.maa_check.frozen", return_value=False):
+            command = maa_check_command({"adb": "device"})
+        self.assertEqual(command[0], sys.executable)
+        self.assertEqual(command[1], "-c")
+        self.assertEqual(command[2], MAA_CHECK_SCRIPT)
+        self.assertEqual(command[3], json.dumps({"adb": "device"}, ensure_ascii=False))
+
+    def test_command_routes_frozen_to_worker_subcommand(self):
+        with patch("arknights_mower.utils.maa_check.frozen", return_value=True):
+            command = maa_check_command({"adb": "device"})
+        self.assertEqual(
+            command,
+            [
+                sys.executable,
+                "--maa-check-worker",
+                json.dumps({"adb": "device"}, ensure_ascii=False),
+            ],
+        )
+
+    def test_run_maa_check_reports_error_when_asst_missing(self):
+        # run_maa_check must load `asst` from maa_path/Python; a bogus path makes
+        # the import fail, and the en-route exception becomes an "error" result.
+        before = list(sys.path)
+        result = run_maa_check(
+            {
+                "maa_path": "/missing",
+                "maa_adb_path": "adb",
+                "adb": "device",
+                "maa_conn_preset": "CompatMac",
+                "maa_touch_option": "maatouch",
+            }
+        )
+        self.assertEqual(result["status"], "error")
+        # The MAA dir is only needed to load `asst`; it must not leak onto the
+        # shared sys.path of a process that keeps running (e.g. the test runner).
+        self.assertEqual(sys.path, before)
+
+    def test_run_maa_check_tolerates_missing_maa_path(self):
+        # A payload lacking "maa_path" must surface as an "error" result, not a
+        # NameError from the sys.path cleanup in the finally block.
+        result = run_maa_check({"adb": "device"})
+        self.assertEqual(result["status"], "error")
+
+    def test_worker_main_prints_json_result(self):
+        payload = json.dumps(
+            {
+                "maa_path": "/missing",
+                "maa_adb_path": "adb",
+                "adb": "device",
+                "maa_conn_preset": "CompatMac",
+                "maa_touch_option": "maatouch",
+            }
+        )
+        with patch("builtins.print") as mock_print:
+            worker_main(payload)
+        text = mock_print.call_args.args[0]
+        self.assertEqual(json.loads(text)["status"], "error")
+        # ensure_ascii keeps the payload pure-ASCII so a windowed frozen launcher
+        # with a locale-dependent (e.g. GBK) console still round-trips.
+        self.assertTrue(text.isascii())
 
 
 if __name__ == "__main__":

--- a/arknights_mower/utils/maa_check.py
+++ b/arknights_mower/utils/maa_check.py
@@ -1,7 +1,10 @@
 import json
+import os
+import pathlib
 import sys
 
 from arknights_mower.utils import config
+from arknights_mower.utils.update_runtime import frozen
 
 MAA_CHECK_TIMEOUT = 30
 
@@ -35,7 +38,7 @@ try:
 except Exception as e:
     result = {"status": "error", "message": "Maa测试异常：" + str(e)}
 
-print(json.dumps(result, ensure_ascii=False))
+print(json.dumps(result, ensure_ascii=True))
 """
 
 
@@ -49,13 +52,77 @@ def maa_check_params(adb: str | None = None) -> dict[str, str]:
     }
 
 
+def run_maa_check(params: dict) -> dict[str, str]:
+    """Run the MAA connectivity check against ``params`` and return the result.
+
+    This mirrors ``MAA_CHECK_SCRIPT`` (the source-mode ``-c`` snippet) so the
+    frozen launcher's ``--maa-check-worker`` sub-command can reuse the same
+    logic through :func:`worker_main` instead of having to spawn a Python
+    interpreter that does not exist in a frozen build.
+    """
+    try:
+        python_dir = None
+        maa_path = pathlib.Path(params["maa_path"])
+        python_dir = str(maa_path / "Python")
+        sys.path.append(python_dir)
+
+        from asst.asst import Asst
+
+        def callback(msg, details, arg):
+            pass
+
+        callback_func = Asst.CallBackType(callback)
+        Asst.load(path=maa_path, incremental_path=maa_path / "cache")
+        asst = Asst(callback=callback_func)
+        version = asst.get_version()
+        asst.set_instance_option(2, params["maa_touch_option"])
+        if asst.connect(
+            params["maa_adb_path"], params["adb"], params["maa_conn_preset"]
+        ):
+            return {"status": "success", "message": f"Maa {version} 连接成功"}
+        return {"status": "connection_failed", "message": "连接失败，请检查Maa日志！"}
+    except Exception as e:
+        return {"status": "error", "message": "Maa测试异常：" + str(e)}
+    finally:
+        # Only needed while loading `asst`; drop it so a process that re-runs the
+        # check (or the test runner) does not leak the MAA dir onto sys.path.
+        # Guard against python_dir being unset (e.g. params["maa_path"] missing)
+        # so a NameError here never masks the real exception above.
+        if python_dir is not None:
+            try:
+                sys.path.remove(python_dir)
+            except ValueError:
+                pass
+
+
+def worker_main(payload_json: str) -> None:
+    """Entry point for ``webview_ui.py --maa-check-worker``.
+
+    The frozen launcher is the only runnable (``sys.executable`` is ``mower.exe``,
+    not a Python interpreter), so a check executed with ``-c`` would spawn a whole
+    second desktop window. Routing it here runs in a sub-process that exits before
+    opening any window, while still giving the parent a process to time out.
+    """
+    result = run_maa_check(json.loads(payload_json))
+    # ensure_ascii keeps the payload pure-ASCII so it survives a windowed frozen
+    # launcher whose console encoding varies with the host locale (e.g. GBK/Win).
+    text = json.dumps(result, ensure_ascii=True)
+    if sys.stdout is None:
+        # Windowed frozen exe may leave sys.stdout unset, but the inherited fd 1
+        # (server's pipe) stays valid — write there instead of dropping the result.
+        os.write(1, (text + "\n").encode("utf-8"))
+    else:
+        print(text, flush=True)
+
+
 def maa_check_command(params: dict[str, str] | None = None) -> list[str]:
-    return [
-        sys.executable,
-        "-c",
-        MAA_CHECK_SCRIPT,
-        json.dumps(params or maa_check_params(), ensure_ascii=False),
-    ]
+    payload = json.dumps(params or maa_check_params(), ensure_ascii=False)
+    if frozen():
+        # sys.executable is the mower launcher, so "-c <script>" would launch a
+        # whole second Mower window (with "-c" read as the config space). Route the
+        # check through the launcher's --maa-check-worker sub-command instead.
+        return [sys.executable, "--maa-check-worker", payload]
+    return [sys.executable, "-c", MAA_CHECK_SCRIPT, payload]
 
 
 def parse_maa_check_output(

--- a/webview_ui.py
+++ b/webview_ui.py
@@ -18,6 +18,15 @@ if __name__ == "__main__" and sys.argv[1:2] == ["--software-update-worker"]:
     update_main(sys.argv[2])
     sys.exit()
 
+# The frozen launcher has no standalone Python, so a MAA connectivity check that
+# asked for "-c <script>" would spawn a second desktop window. Route it here
+# instead; the process runs the check and exits before opening any window.
+if __name__ == "__main__" and sys.argv[1:2] == ["--maa-check-worker"]:
+    from arknights_mower.utils.maa_check import worker_main
+
+    worker_main(sys.argv[2])
+    sys.exit()
+
 # Linux 版独立包运行期需要宿主提供 GTK/WebKit2 原生库与 typelib，PyInstaller 只把
 # pywebview 的 Python 依赖打进包。这份提示在窗口后端初始化失败时展示，直接给出
 # 三个发行版的安装命令，避免用户对着裸 ImportError 无从下手。
@@ -386,7 +395,14 @@ def run_desktop():
     if background or not runtime.frozen():
         runtime.hide_macos_dock_icon()
     exit_if_webview_backend_missing()
-    path.global_space = sys.argv[1] if len(sys.argv) >= 2 else None
+    space = sys.argv[1] if len(sys.argv) >= 2 else None
+    if space is not None and space.startswith("-"):
+        # A CLI option (e.g. "-c") reached us via argv rather than a config-space
+        # name. Spaces are always a filesystem path or data-dir label, which can
+        # never start with "-" (Windows drive letter / POSIX "/"), so treat it as
+        # absent instead of resolving "@app/..." under an "install/-c" directory.
+        space = None
+    path.global_space = space
     instance_name = sys.argv[2] if len(sys.argv) >= 3 else ""
     from arknights_mower.utils.log import init_file_logging, start_mp_listener
 


### PR DESCRIPTION
## 变更

打包版（PyInstaller）里 `sys.executable` 指向 `mower.exe` 启动器而非 python。原 `maa_check_command` 用 `[sys.executable, "-c", script, json]` 执行连通性检测，等于把整个桌面程序再启动一次：`run_desktop` 把 `argv[1]`（即 `-c`）当作配置空间，`@app/...` 全部落到 `D:\mower\-c\config`，配置文件加载即报 `FileNotFoundError`。用户在前端 Maa 设置页点「测试连接」就弹出一个新的 Mower 窗口并报错。

改为在打包版经 `mower.exe` 的 `--maa-check-worker` 子命令执行检测（沿用 `--process-control-worker` / `--software-update-worker` 同一套路），进程在打开任何窗口前退出，父进程仍保留一个可超时终止的检测进程。源码版保持原 `-c` 路径不变。

顺带几处加固：`run_desktop` 把形如 `-c` 的 `argv[1]` 视为缺失（配置空间永远是文件路径，绝不会以 `-` 开头），避免该症状从任意传参路径复现；检测结果 JSON 以 `ensure_ascii` 输出，保证在受宿主区域设置影响的窗口化控制台上也能被父进程正确解析；若窗口化打包版未给 `sys.stdout`，结果写入继承的 fd 1（服务端管道）而非丢弃；`run_maa_check` 的 `sys.path` 清理对 `python_dir` 判空，缺失参数只落到 error 结果而非被 `NameError` 掩盖。

## 限制

- 打包版子进程仍会经 `maa_check` 触发一次 `load_conf()`，主进程已证明配置可加载，实际风险低，可后续改成惰性导入进一步解耦。
- `MAA_CHECK_SCRIPT`（`-c` 内联脚本）与 `run_maa_check` 存在一次受迫复制：内联脚本必须自包含、只依赖标准库；若 MAA asst 接口变更，两处需同步修改。

## 验证

- `maa_check_tests` + `webview_ui_tests` 共 34 项全绿。
- `ruff check` / `ruff format --check` / `compileall` 干净。
- 手动以 `--maa-check-worker` 调用：返回 `error` 结果、输出为纯 ASCII、不弹出窗口。