### PR TITLE
fix(mastery): 修复训练室面板因 OCR 噪声导致干员名误判

### DIFF
--- a/arknights_mower/solvers/mastery_reader.py
+++ b/arknights_mower/solvers/mastery_reader.py
@@ -118,13 +118,24 @@ class RoomState:
 
 
 def _parse_panel_text(text):
-    """`[干员名]技能名` → (干员名, 技能名)。无方括号视为纯技能名。"""
+    """`[干员名]技能名` → (干员名, 技能名)。无方括号视为纯技能名。
+
+    OCR 常在括号前带噪声（前置引号/残缺字符/零宽字符），旧逻辑要求 `[` 恰为首字符，
+    噪声一前置就把整串 `[干员]技能` 当纯技能名返回 → 干员名被误判不可读 → 状态矩阵走
+    ocr_fail → 5 次重读仍不一致 → 保守训练中。改为「找第一个 `[`」：括号前的噪声丢弃，
+    括号内容作干员名、其后作技能名——信息 OCR 其实已读到，不因噪声丢失。
+    无 `[` 仍视为纯技能名（保持原语义）。
+    """
     if not text:
         return "", ""
     t = str(text).strip()
-    if t.startswith("[") and "]" in t:
-        name, _, rest = t[1:].partition("]")
-        return name.strip(), rest.strip()
+    start = t.find("[")
+    if start != -1:
+        end = t.find("]", start)
+        if end != -1:
+            name = t[start + 1 : end].strip()
+            rest = t[end + 1 :].strip()
+            return name, rest
     return "", t
 
 

--- a/arknights_mower/tests/mastery_reader_tests.py
+++ b/arknights_mower/tests/mastery_reader_tests.py
@@ -180,6 +180,21 @@ class TestPanelParse(unittest.TestCase):
     def test_parse_empty(self):
         self.assertEqual(reader._parse_panel_text(""), ("", ""))
 
+    def test_parse_leading_noise(self):
+        # OCR 在括号前带噪声（前置引号/残缺字符）时，干员名不应被整串丢弃
+        self.assertEqual(
+            reader._parse_panel_text('"[能天使]扫射模式'), ("能天使", "扫射模式")
+        )
+        self.assertEqual(
+            reader._parse_panel_text("×[能天使]扫射模式"), ("能天使", "扫射模式")
+        )
+
+    def test_parse_real_panel_curly_quotes(self):
+        # 实机面板 [珊比]“慢慢走~”（技能名带全角引号），主读取器应正确拆分
+        self.assertEqual(
+            reader._parse_panel_text("[珊比]“慢慢走~”"), ("珊比", "“慢慢走~”")
+        )
+
 
 class TestCountLitMainPanelIcons(unittest.TestCase):
     """主面板专精图标逐框判亮（MASTERY_ICON_PIPS）。"""


### PR DESCRIPTION
## 变更

训练室主面板文本形如 `[干员名]技能名`。`_parse_panel_text` 旧实现要求 `[` 恰好位于首字符，
OCR 在括号前读到噪声（前置引号、残缺字符、零宽字符）时，整串文本被当作纯技能名返回，
干员名被判为不可读。状态矩阵因此判定为 ocr_fail，重试 5 次后仍然不一致，只能保守地按
训练中处理，而干员名和技能名此时已经读到，却没有被采用。

本次把解析改成寻找第一个 `[`：括号前的噪声忽略，括号内容作为干员名，其后的内容作为
技能名；文本没有 `[` 时仍视为纯技能名，原有语义不变。

## 限制

采用「寻找第一个 `[`」之后，纯技能名的文本如果本身含有一个 `[`，可能被误拆分。训练室
面板的干员名固定用 `[干员名]` 包裹，实际不会出现这种情况，但这是本次为兼容噪声而接受
的取舍。

## 验证

- `arknights_mower/tests/mastery_reader_tests.py` 197 项全绿，新增两条回归用例（前置引号、
  实机全角引号面板）。
- `ruff check` 与 `ruff format --check` 通过。
- 对 1920×1080 实机截图用 RapidOCR 跑出 `[珊比]"慢慢走~"`，面板解析正确拆分为干员名与
  技能名。
