### PR TITLE
fix(device): 修复 MuMu12 更新重启后设备未就绪导致连接失败的问题

### DIFF
--- a/arknights_mower/tests/adb_client_tests.py
+++ b/arknights_mower/tests/adb_client_tests.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from arknights_mower.utils import config
 from arknights_mower.utils.device.adb_client.core import Client
 
 
@@ -86,6 +87,109 @@ class TestAdbClientConnectionError(unittest.TestCase):
             result = client.check_server_alive()
 
         self.assertTrue(result)
+
+
+class TestInitDeviceWaitsForDevice(unittest.TestCase):
+    """模拟器重启/更新后设备未立即在 adb 就绪：__init_device 等待/重发现端口再探测。
+
+    此前只连接一次并立即检查一次，设备端点漂移或仍在注册时就误判失败。
+    """
+
+    def _client(self) -> Client:
+        client = object.__new__(Client)
+        client.device_id = None
+        client.connect = None
+        client.adb_bin = "adb"
+        return client
+
+    def test_succeeds_when_already_present_no_retry(self):
+        client = self._client()
+        client.device_id = "127.0.0.1:16928"
+        with (
+            patch.object(client, "_Client__exec"),
+            patch.object(client, "_Client__connect_device"),
+            patch.object(client, "refresh_target"),
+            patch.object(
+                client,
+                "_Client__available_devices",
+                return_value=["127.0.0.1:16928"],
+            ),
+            patch("arknights_mower.utils.device.adb_client.core.Session"),
+            patch("arknights_mower.utils.device.adb_client.core.csleep") as csleep,
+        ):
+            client._Client__init_device()
+        # 已就绪：仅初始 csleep(1)，未进入等待重试。
+        csleep.assert_called_once_with(1)
+
+    def test_waits_and_rediscovers_drifted_port(self):
+        client = self._client()
+        ready = {"flag": False}
+
+        def choose_devices(devices=None):
+            if ready["flag"]:
+                client.device_id = "127.0.0.1:16416"
+            return client.device_id
+
+        def available_devices():
+            return ["127.0.0.1:16416"] if ready["flag"] else []
+
+        with (
+            patch.object(client, "_Client__exec"),
+            patch.object(client, "_Client__connect_device"),
+            patch.object(client, "_Client__choose_devices", side_effect=choose_devices),
+            patch.object(
+                client, "_Client__available_devices", side_effect=available_devices
+            ),
+            patch(
+                "arknights_mower.utils.device.adb_client.core.Session"
+            ) as session_cls,
+            patch("arknights_mower.utils.device.adb_client.core.csleep") as csleep,
+        ):
+            # 端口在等待期间才被重新发现并让设备上线
+            session_cls.return_value.connect.side_effect = lambda *_: ready.update(
+                flag=True
+            )
+            client._Client__init_device()
+
+        # 重发现到新端口并建立连接
+        session_cls.return_value.connect.assert_called_with("127.0.0.1:16416")
+        # 等待窗口内重新探测：初始 csleep(1) + 至少一次 csleep(2)
+        self.assertGreaterEqual(csleep.call_count, 2)
+
+    def test_adopts_single_live_device_when_no_preferred_port(self):
+        client = self._client()
+        with (
+            patch.object(client, "_Client__exec"),
+            patch.object(client, "_Client__connect_device"),
+            patch.object(config.conf, "adb", ""),
+            patch.object(
+                client,
+                "_Client__available_devices",
+                return_value=["127.0.0.1:16928"],
+            ),
+            patch(
+                "arknights_mower.utils.device.adb_client.core.query_mumu_adb_port",
+                return_value=None,
+            ),
+            patch("arknights_mower.utils.device.adb_client.core.Session"),
+            patch("arknights_mower.utils.device.adb_client.core.csleep"),
+        ):
+            client._Client__init_device()
+        # 未配置首选端口时，认领唯一存活设备
+        self.assertEqual(client.device_id, "127.0.0.1:16928")
+
+    def test_raises_when_device_never_registers(self):
+        client = self._client()
+        with (
+            patch.object(client, "_Client__exec"),
+            patch.object(client, "_Client__connect_device"),
+            patch.object(client, "_Client__choose_devices", return_value=None),
+            patch.object(client, "_Client__available_devices", return_value=[]),
+            patch("arknights_mower.utils.device.adb_client.core.Session"),
+            patch("arknights_mower.utils.device.adb_client.core.csleep"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Device connection failure"):
+                client._Client__init_device()
 
 
 if __name__ == "__main__":

--- a/arknights_mower/utils/device/adb_client/core.py
+++ b/arknights_mower/utils/device/adb_client/core.py
@@ -94,6 +94,34 @@ class Client:
             self.__exec("start-server")
         except (subprocess.CalledProcessError, OSError) as e:
             raise RuntimeError("Can't start adb server") from e
+        self.__connect_device()
+        # 模拟器重启/更新后设备可能尚未在 adb 就绪：端点可能会漂移、设备短暂离线或仍在注册。
+        # 按配置的模拟器启动时间等待，期间反复重选/重连端口再探测，避免只连接一次就立即判定失败。
+        attempts = max(1, (int(config.conf.simulator.wait_time) + 1) // 2)
+        for _ in range(attempts):
+            devices = self.__available_devices()
+            if self.device_id in devices:
+                logger.info(devices)
+                return
+            logger.debug(
+                f"设备未就绪：{devices}，重新选择端口 {self.device_id or config.conf.adb}"
+            )
+            # 端口可能因模拟器重启/更新而漂移：重跑完整选择逻辑（重发现 + 认领存活设备）后重连。
+            self.device_id = self.__choose_devices(devices)
+            target = self.device_id or config.conf.adb
+            if target:
+                Session().connect(target)
+            csleep(2)
+        devices = self.__available_devices()
+        logger.info(devices)
+        if self.device_id not in devices:
+            logger.error(
+                "未检测到相应设备。请运行 `adb devices` 确认列表中列出了目标模拟器或设备。"
+            )
+            raise RuntimeError("Device connection failure")
+
+    def __connect_device(self) -> None:
+        """选定 device_id 并建立到对应端点的连接（原 __init_device 的选中/连接逻辑）。"""
         if self.device_id is None or self.device_id != config.conf.adb:
             self.device_id = self.__choose_devices()
         if self.device_id is None:
@@ -105,28 +133,15 @@ class Client:
         elif self.connect is None:
             Session().connect(self.device_id)
 
-        # if self.device_id is None or self.device_id not in config.ADB_DEVICE:
-        #     if self.connect is None or self.device_id not in config.ADB_CONNECT:
-        #         for connect in config.ADB_CONNECT:
-        #             Session().connect(connect)
-        #     else:
-        #         Session().connect(self.connect)
-        #     self.device_id = self.__choose_devices()
-        logger.info(self.__available_devices())
-        if self.device_id not in self.__available_devices():
-            logger.error(
-                "未检测到相应设备。请运行 `adb devices` 确认列表中列出了目标模拟器或设备。"
-            )
-            raise RuntimeError("Device connection failure")
-
-    def __choose_devices(self) -> Optional[str]:
+    def __choose_devices(self, devices: list[str] | None = None) -> Optional[str]:
         """choose available devices"""
-        devices = self.__available_devices()
+        if devices is None:
+            devices = self.__available_devices()
         if config.conf.adb in devices:
             return config.conf.adb
         # 配置端口不在线：重新发现模拟器当前真实 adb 端口（双模拟器下端口可能漂移或未连）
         target = self.refresh_target()
-        if target in self.__available_devices():
+        if target in devices:
             return target
         if len(devices) > 0 and config.conf.adb == "":
             logger.debug(devices[0])


### PR DESCRIPTION
## 变更

模拟器重启/更新后，adb 端点可能漂移，设备也可能在 `adb devices` 里短暂缺失或呈 offline。此前 `__init_device` 只连接并校验一次，设备未就绪时会被误判为连接失败，solver 层重试期间也没有重连动作。

本次改为在判定失败前等待，窗口长度取配置的模拟器启动时间（`simulator.wait_time`），期间每一轮都重新连接再探测，直到设备上线或窗口耗尽。并按模拟器类型区分：

- **MuMu12**：等待期间重跑完整选择逻辑——重发现真实端口（MuMuManager）、认领仍存活的设备、重连；
- **其他模拟器**：因 MuMuManager 不适用，仅等待并重试连接（不做端口漂移检测）。

同时把 `__choose_devices` 改为可传入已查询的设备列表，避免等待循环里对 `adb devices` 的重复往返查询。

## 限制与验证

- 非 MuMu12 的端口漂移检测不生效，仍需在 `Settings → 模拟器` 配置正确的 adb 地址。
- MuMu12 的重发现依赖管理器返回真实端口，要求名称（`MuMu12`）、安装路径与多开实例编号配置正确。
- 认领存活设备仅在未配置首选端口（`adb` 为空）时启用，避免多开场景下误连其他模拟器。
- 单元测试覆盖设备已就绪、漂移后重选、认领存活设备、窗口耗尽仍失败四条路径；本机 adb/device/simulator/solver 相关测试共 51 项通过，ruff 校验通过。