### PR TITLE
fix(skland): 修复森空岛瞬时网络错误导致仓库扫描中断

### DIFF
--- a/arknights_mower/solvers/cultivate_depot.py
+++ b/arknights_mower/solvers/cultivate_depot.py
@@ -1,7 +1,5 @@
 import json
 
-import requests
-
 from arknights_mower.utils import config
 from arknights_mower.utils.config import atomic_write
 from arknights_mower.utils.path import get_path
@@ -11,6 +9,7 @@ from arknights_mower.utils.skland import (
     get_sign_header,
     header,
     log,
+    request_with_retry,
 )
 
 
@@ -30,10 +29,10 @@ class cultivate:
             if i.get("gameId") == 1 and item.cultivate_select == i.get("isOfficial"):
                 body = {"gameId": 1, "uid": i.get("uid")}
                 ingame = f"https://zonai.skland.com/api/v1/game/cultivate/player?uid={i.get('uid')}"
-                resp = requests.get(
+                resp = request_with_retry(
+                    "get",
                     ingame,
                     headers=get_sign_header(ingame, "get", body, self.sign_token),
-                    timeout=30,
                 ).json()
 
                 def dump(file):

--- a/arknights_mower/tests/skland_tests.py
+++ b/arknights_mower/tests/skland_tests.py
@@ -6,6 +6,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import requests
+
 # mastery_view_tests 等模块收集期会先往 sys.modules 塞 skland 的 MagicMock 桩
 # （历史原因：skland 导入时 get_d_id 会联网）。本测试需要真实模块：删桩后导入
 # （导入已惰性化、不再联网），测试结束恢复桩，避免影响后续依赖该桩的测试。
@@ -237,6 +239,108 @@ class TestEnsureDeviceId(unittest.TestCase):
         self.assertEqual(skland._device_id, "")
         self.assertFalse(skland._device_id_failed)
         self.assertFalse(self._did_file.exists())
+
+
+class TestAuthChainNetworkRetry(unittest.TestCase):
+    """认证链路网络重试：瞬时网络错误重试、认证被拒不重试。"""
+
+    def setUp(self):
+        skland.server_time_offset = 0
+
+    def _resp(self, body, status_code=200):
+        fake = Mock()
+        fake.headers = {}
+        fake.status_code = status_code
+        fake.json = Mock(return_value=body)
+        return fake
+
+    def test_get_cred_retries_transient_then_succeeds(self):
+        # zonai.skland.com 瞬时连接超时 → 重试一次后成功，而非直接抛错中断任务
+        good = self._resp({"code": 0, "data": {"cred": "c", "token": "t"}})
+        with (
+            patch(
+                "requests.post",
+                side_effect=[requests.exceptions.ConnectTimeout(), good],
+            ),
+            patch("time.sleep"),
+        ):
+            self.assertEqual(skland.get_cred("grant"), {"cred": "c", "token": "t"})
+
+    def test_get_cred_raises_after_retries_exhausted(self):
+        # 网络持续不可达 → 重试耗尽后抛出最后的瞬时异常，不静默吞掉
+        with (
+            patch(
+                "requests.post", side_effect=requests.exceptions.ConnectTimeout()
+            ) as post,
+            patch("time.sleep"),
+        ):
+            with self.assertRaises(requests.exceptions.ConnectTimeout):
+                skland.get_cred("grant")
+        self.assertEqual(post.call_count, skland._AUTH_NETWORK_RETRIES)
+
+    def test_get_grant_code_retries_transient_then_succeeds(self):
+        # as.hypergryph.com 瞬时拒连 → 重试一次后成功
+        good = self._resp({"status": 0, "data": {"code": "g"}})
+        with (
+            patch(
+                "requests.post",
+                side_effect=[requests.exceptions.ConnectionError(), good],
+            ),
+            patch("time.sleep"),
+        ):
+            self.assertEqual(skland.get_grant_code("tok"), "g")
+
+    def test_get_cred_sets_request_timeout(self):
+        # 回归护栏：cred 请求必须带超时，避免 connect timeout=None 无限期悬挂
+        good = self._resp({"code": 0, "data": {"cred": "c", "token": "t"}})
+        with patch("requests.post", return_value=good) as post:
+            skland.get_cred("grant")
+        self.assertEqual(
+            post.call_args.kwargs.get("timeout"), skland._AUTH_REQUEST_TIMEOUT
+        )
+        self.assertEqual(post.call_count, 1)
+
+    def test_login_retries_transient_then_succeeds(self):
+        # 登录请求（as.hypergryph.com）瞬时连接超时 → 重试一次后成功
+        fake = self._resp({"status": 0, "data": {"token": "tok"}})
+        fake.headers = {"Date": SERVER_DATE}
+        account = Mock(account="13800000000", password="pw")
+        with (
+            patch(
+                "requests.post",
+                side_effect=[requests.exceptions.ConnectTimeout(), fake],
+            ),
+            patch("time.time", return_value=LOCAL_EPOCH),
+            patch.object(skland, "_ensure_device_id", return_value="B" + "0" * 16),
+            patch("time.sleep"),
+        ):
+            self.assertEqual(skland.log(account), "tok")
+
+    def test_get_binding_list_retries_transient_then_succeeds(self):
+        # 仓库扫描取绑定角色列表也是 zonai.skland.com 的直连 GET，瞬时超时同样重试
+        body = {
+            "code": 0,
+            "data": {
+                "list": [
+                    {
+                        "appCode": "arknights",
+                        "bindingList": [{"gameId": 1, "uid": "u1"}],
+                    },
+                ]
+            },
+        }
+        good = self._resp(body)
+        with (
+            patch(
+                "requests.get",
+                side_effect=[requests.exceptions.ConnectTimeout(), good],
+            ),
+            patch.object(skland, "_ensure_device_id", return_value="B123"),
+            patch("time.sleep"),
+        ):
+            self.assertEqual(
+                skland.get_binding_list("tok"), [{"gameId": 1, "uid": "u1"}]
+            )
 
 
 class TestSignHeaderFields(unittest.TestCase):

--- a/arknights_mower/utils/skland.py
+++ b/arknights_mower/utils/skland.py
@@ -205,8 +205,39 @@ def get_sign_header(url: str, method, body, sign_token, old_header=header):
     return h
 
 
+# 森空岛认证与仓库数据请求的远端服务（as.hypergryph.com / zonai.skland.com）偶发瞬时不可达：
+# 给每次请求设超时并对连接层瞬时错误重试几次，避免一次网络抖动就中断认证、连带仓库扫描等任务失败。
+# 重试节奏与 _ensure_device_id 一致；认证被拒（如「设备信息无效」）是语义性失败，不在重试范围内。
+_AUTH_REQUEST_TIMEOUT = 30
+_AUTH_NETWORK_RETRIES = 3
+
+
+def request_with_retry(
+    method, url, *, json=None, headers, timeout=_AUTH_REQUEST_TIMEOUT
+):
+    """带超时发起请求；连接层瞬时错误（连接超时/拒连/重置/响应体截断或损坏）重试几次再抛出。
+
+    只重试连接层瞬时错误，不重试认证被拒（如「设备信息无效」）这类语义性失败。
+    """
+    for attempt in range(_AUTH_NETWORK_RETRIES):
+        try:
+            if method.lower() == "post":
+                return requests.post(url, json=json, headers=headers, timeout=timeout)
+            return requests.get(url, headers=headers, timeout=timeout)
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.ChunkedEncodingError,
+            requests.exceptions.ContentDecodingError,
+        ):
+            if attempt == _AUTH_NETWORK_RETRIES - 1:
+                raise
+            time.sleep(1)
+
+
 def get_grant_code(token):
-    response = requests.post(
+    response = request_with_retry(
+        "post",
         grant_code_url,
         json={"appCode": app_code, "token": token, "type": 0},
         headers=header_login,
@@ -227,8 +258,8 @@ def get_cred(grant):
     :param header_login: 登录请求头
     :return: cred
     """
-    resp = requests.post(
-        cred_code_url, json={"code": grant, "kind": 1}, headers=header_login
+    resp = request_with_retry(
+        "post", cred_code_url, json={"code": grant, "kind": 1}, headers=header_login
     ).json()
 
     if resp["code"] != 0:
@@ -243,7 +274,8 @@ def get_cred(grant):
 
 def get_binding_list(sign_token):
     v = []
-    resp = requests.get(
+    resp = request_with_retry(
+        "get",
         binding_url,
         headers=get_sign_header(
             binding_url,
@@ -251,7 +283,6 @@ def get_binding_list(sign_token):
             None,
             sign_token,
         ),
-        timeout=30,
     )
     _sync_server_time(resp)
     body = resp.json()
@@ -278,11 +309,11 @@ def log(account):
         # 取不到 dId 时不应以空串继续请求：森空岛后端在换 cred 时会把空 dId 视为无效设备，
         # 误报「设备信息无效」。提前中止，明确报指纹服务不可达。
         raise Exception("设备指纹服务不可达，无法认证森空岛")
-    resp = requests.post(
+    resp = request_with_retry(
+        "post",
         token_password_url,
         json={"phone": account.account, "password": account.password},
         headers=header_login,
-        timeout=30,
     )
     _sync_server_time(resp)
     r = resp.json()


### PR DESCRIPTION
### 变更

森空岛认证与仓库数据请求（login / grant / cred / 绑定列表 / 仓库数据）此前未统一设置超时，个别请求甚至没有超时。一次瞬时网络抖动就会抛 ConnectTimeout，把整个「仓库扫描」任务中断，且这个问题常在登录成功后几十秒才暴露，容易被判成反复修不好。

本次新增 request_with_retry，给这些请求统一加 timeout=30，并对连接层瞬时错误（连接超时、拒连、重置、响应体截断或损坏）重试 3 次、间隔 1 秒，重试完仍失败才抛出。认证被拒（如「设备信息无效」、密码错误）这类语义性失败不参与重试，仍直接抛出。

### 限制

- 响应体解析（.json()）在重试循环之外，非预期内容（如网关错误页、损坏的 gzip）不参与重试；本次覆盖的是「连接层瞬时错误」。
- 最坏情况（多端点同时不可达）每次请求最多 3×30 秒，调度线程可能阻塞更久；这是「成功优先」的取舍，正常连接下不受影响。

### 验证

- arknights_mower.tests.skland_tests：24 项通过（新增 6 项针对瞬时网络重试的回归测试）。
- arknights_mower.tests.base_scheduler_tests：67 项通过。
- ruff check / ruff format：通过。
