### PR TITLE
fix(update): 完善实例扫描、日志与三端兼容

### DIFF
--- a/.github/workflows/format-check-and-test.yml
+++ b/.github/workflows/format-check-and-test.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     env:
-      MOWER_DATA_DIR: ${{ runner.temp }}/mower-update-tests
+      MOWER_DATA_DIR: ${{ github.workspace }}/.cache/update-tests
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/format-check-and-test.yml
+++ b/.github/workflows/format-check-and-test.yml
@@ -113,6 +113,10 @@ jobs:
           uv --version
       - name: Run native update and resource regressions
         shell: bash
+        env:
+          # Unit tests also call Worker methods directly, outside its CLI entry.
+          # Legacy-encoding child tests explicitly override this value.
+          PYTHONIOENCODING: utf-8
         run: |
           python -m unittest -v \
             arknights_mower.tests.update_runtime_tests \

--- a/.github/workflows/format-check-and-test.yml
+++ b/.github/workflows/format-check-and-test.yml
@@ -74,3 +74,52 @@ jobs:
         run: ./venv/bin/python3 -c "import scipy, skimage, sklearn"
       - name: Compare vision_np against upstream implementations
         run: ./venv/bin/python3 -m unittest arknights_mower.tests.vision_np_tests -v
+
+  update-compatibility:
+    name: Update compatibility (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    env:
+      MOWER_DATA_DIR: ${{ runner.temp }}/mower-update-tests
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - uses: astral-sh/setup-uv@v6
+      - name: Install Linux system libraries
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libzbar0 libgl1 libglib2.0-0
+      - name: Install macOS system library
+        if: runner.os == 'macOS'
+        run: brew install zbar
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements.txt
+      - name: Require transaction tools
+        shell: bash
+        run: |
+          python -c "import os; from pathlib import Path; Path(os.environ['MOWER_DATA_DIR']).mkdir(parents=True, exist_ok=True)"
+          python -c "import shutil; missing = [name for name in ('git', 'node', 'npm', 'uv') if not shutil.which(name)]; assert not missing, f'Missing required tools: {missing}'"
+          git --version
+          node --version
+          npm --version
+          uv --version
+      - name: Run native update and resource regressions
+        shell: bash
+        run: |
+          python -m unittest -v \
+            arknights_mower.tests.update_runtime_tests \
+            arknights_mower.tests.update_compat_tests \
+            arknights_mower.tests.res_version_tests \
+            arknights_mower.tests.resource_version_tests \
+            arknights_mower.tests.resource_pkg_tests \
+            arknights_mower.tests.software_update_progress_tests \
+            arknights_mower.tests.process_control_tests \
+            arknights_mower.tests.software_update_transaction_tests

--- a/arknights_mower/tests/res_version_tests.py
+++ b/arknights_mower/tests/res_version_tests.py
@@ -126,6 +126,31 @@ class TestContentHash(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             content_hash(self.dir, [Path("nope.bin")])
 
+    def test_declared_text_normalizes_crlf_across_chunk_boundary(self):
+        rel = Path(RES_PACKAGE_DATA[0])
+        path = self.dir / rel
+        path.parent.mkdir(parents=True)
+        crlf = b"x" * ((1 << 20) - 1) + b"\r\nnext\r\nlast\r"
+        path.write_bytes(crlf)
+        windows_hash = content_hash(self.dir, [rel])
+        path.write_bytes(crlf.replace(b"\r\n", b"\n"))
+        self.assertEqual(windows_hash, content_hash(self.dir, [rel]))
+
+    def test_binary_without_nul_and_undeclared_text_keep_exact_bytes(self):
+        for name in (
+            RES_PACKAGE_MODELS[0],
+            "ui/public/avatar/test.webp",
+            "unknown.json",
+        ):
+            with self.subTest(name=name):
+                rel = Path(name)
+                path = self.dir / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"\x01\r\n\x02")
+                original = content_hash(self.dir, [rel])
+                path.write_bytes(b"\x01\n\x02")
+                self.assertNotEqual(original, content_hash(self.dir, [rel]))
+
 
 class TestPackageFilePaths(unittest.TestCase):
     def setUp(self):

--- a/arknights_mower/tests/resource_pkg_tests.py
+++ b/arknights_mower/tests/resource_pkg_tests.py
@@ -247,7 +247,7 @@ rp._active_resource = None
 rp._loaded_resource_signature = None
 def report():
     path = rp.resource_pkg_path(rp._RESOURCE_MARKER)
-    print('RESOURCE_TEST ' + json.dumps({{'version': json.loads(path.read_text())['res_version'], 'path': str(path)}}), flush=True)
+    print('RESOURCE_TEST ' + json.dumps({{'version': json.loads(path.read_text(encoding='utf-8'))['res_version'], 'path': str(path)}}), flush=True)
 with rp.resource_task_session():
     report()
     for command in sys.stdin:
@@ -261,11 +261,16 @@ with rp.resource_task_session():
                 (self.base / f"child{i}").mkdir()
                 process = subprocess.Popen(
                     [sys.executable, "-c", script],
-                    env=dict(os.environ, MOWER_DATA_DIR=str(self.base / f"child{i}")),
+                    env=dict(
+                        os.environ,
+                        MOWER_DATA_DIR=str(self.base / f"child{i}"),
+                        PYTHONIOENCODING="utf-8",
+                    ),
                     stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     text=True,
+                    encoding="utf-8",
                 )
                 replies = queue.Queue()
                 logs = []

--- a/arknights_mower/tests/software_update_transaction_tests.py
+++ b/arknights_mower/tests/software_update_transaction_tests.py
@@ -36,7 +36,7 @@ class SourceTransactionTests(unittest.TestCase):
         unchanged=False,
         fail_install=False,
     ):
-        with tempfile.TemporaryDirectory(prefix="mower-transaction-") as temporary:
+        with tempfile.TemporaryDirectory(prefix="mower-transaction-中文 ") as temporary:
             directory = Path(temporary)
             root, state = directory / "install", directory / "state"
             root.mkdir()

--- a/arknights_mower/tests/update_compat_tests.py
+++ b/arknights_mower/tests/update_compat_tests.py
@@ -1,6 +1,7 @@
 """Failure-path integration for update admission, restart and resource indexes."""
 
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -166,6 +167,24 @@ class UpdateCompatibilityTests(unittest.TestCase):
                 self.assertIn(
                     "🧪", (self.job_path.parent / filename).read_text(encoding="utf-8")
                 )
+
+    def test_real_worker_entry_reconfigures_redirected_legacy_stdout(self):
+        code = (
+            "import sys\n"
+            "from unittest.mock import patch\n"
+            "from arknights_mower.utils.software_update_worker import Worker, main\n"
+            "with patch.object(Worker, 'execute', side_effect=lambda: print('正在更新 🧪', flush=True)):\n"
+            "    main(sys.argv[1])\n"
+        )
+        for encoding in ("gbk", "cp1252"):
+            with self.subTest(encoding=encoding):
+                output = subprocess.check_output(
+                    [sys.executable, "-c", code, str(self.job_path)],
+                    env={**os.environ, "PYTHONUTF8": "0", "PYTHONIOENCODING": encoding},
+                    stderr=subprocess.STDOUT,
+                    timeout=30,
+                )
+                self.assertEqual(output.decode("utf-8").strip(), "正在更新 🧪")
 
     def test_resource_index_retries_windows_sharing_error_and_keeps_old_on_failure(
         self,

--- a/arknights_mower/tests/update_compat_tests.py
+++ b/arknights_mower/tests/update_compat_tests.py
@@ -1,0 +1,202 @@
+"""Failure-path integration for update admission, restart and resource indexes."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from flask import Flask
+
+from arknights_mower.utils import process_control as control
+from arknights_mower.utils import resource_pkg as resources
+from arknights_mower.utils import software_update_worker as installer
+from arknights_mower.utils import update_runtime as runtime
+from arknights_mower.views.process_control import process_control_bp
+from arknights_mower.views.software_update import software_update_bp
+
+
+class UpdateCompatibilityTests(unittest.TestCase):
+    def setUp(self):
+        folder = tempfile.TemporaryDirectory(prefix="mower 更新 ")
+        self.addCleanup(folder.cleanup)
+        self.root = Path(folder.name)
+        self.state = self.root / "state"
+        self.job_path = self.root / "job/job.json"
+        self.job = {
+            "id": "compat",
+            "root": str(self.root),
+            "state_dir": str(self.state),
+            "deployment": "source",
+            "version": "fixture",
+            "background": True,
+            "python": sys.executable,
+        }
+        runtime.write_json(self.job_path, self.job)
+        self.record = {
+            "id": "fixture",
+            "pid": os.getpid(),
+            "kind": "instance",
+            "space": "中文 空间",
+            "name": "实例",
+            "port": 1234,
+            "executable": sys.executable,
+            "argv": ["webview_ui.py", "中文 空间", "实例"],
+            "cwd": str(self.root),
+            "ready": True,
+            "restart_job": "compat",
+        }
+
+    def test_settings_apis_report_unreadable_registration_without_server_error(self):
+        app = Flask(__name__)
+        app.register_blueprint(software_update_bp)
+        app.register_blueprint(process_control_bp)
+        with (
+            patch.object(
+                runtime,
+                "instances",
+                side_effect=runtime.InstanceScanError("登记文件被占用"),
+            ),
+            patch.object(runtime, "state_dir", return_value=self.state),
+            patch.object(runtime, "installation_root", return_value=self.root),
+            patch.object(runtime, "frozen", return_value=True),
+        ):
+            response = app.test_client().get("/software-update/info")
+            self.assertEqual(response.status_code, 200)
+            self.assertIn("登记文件被占用", response.json["blockers"])
+            response = app.test_client().get("/process-control/info")
+            self.assertEqual(response.status_code, 200)
+            self.assertFalse(response.json["supported"])
+            self.assertEqual(response.json["message"], "登记文件被占用")
+
+    def test_incomplete_snapshot_aborts_before_shutdown_or_installation(self):
+        worker = installer.Worker(self.job_path)
+        registration = self.state / "instances/fixture.json"
+        runtime.write_json(registration, self.record)
+        with (
+            patch.object(worker, "prepare_source"),
+            patch.object(worker, "prepare_source_payload"),
+            patch.object(worker, "cleanup_preparation"),
+            patch.object(
+                installer,
+                "instances",
+                side_effect=runtime.InstanceScanError("登记文件被占用"),
+            ),
+            patch.object(worker, "install_source") as install,
+            patch.object(worker, "restart") as restart,
+            patch.object(worker, "rollback") as rollback,
+        ):
+            worker.execute()
+        self.assertEqual(worker.status["status"], "failed")
+        self.assertIn("登记文件被占用", worker.status["message"])
+        self.assertFalse((self.state / "shutdown").exists())
+        self.assertEqual(runtime.read_json(registration), self.record)
+        install.assert_not_called()
+        restart.assert_not_called()
+        rollback.assert_not_called()
+
+    def test_software_restart_retries_scan_and_keeps_original_identity(self):
+        worker = installer.Worker(self.job_path)
+        with (
+            patch.object(
+                installer.subprocess,
+                "Popen",
+                return_value=Mock(poll=Mock(return_value=None)),
+            ) as spawn,
+            patch.object(
+                installer,
+                "instances",
+                side_effect=[runtime.InstanceScanError("locked"), [self.record]],
+            ) as scan,
+            patch.object(installer.time, "sleep"),
+        ):
+            worker.restart([self.record])
+        self.assertEqual(scan.call_count, 2)
+        self.assertEqual(spawn.call_args.kwargs["env"]["MOWER_RESTART_PORT"], "1234")
+        self.assertEqual(spawn.call_args.kwargs["env"]["PYTHONIOENCODING"], "utf-8")
+
+    def test_current_instance_restart_retries_scan(self):
+        self.job.update(action="restart", record=self.record, frozen=False)
+        runtime.write_json(self.job_path, self.job)
+        with (
+            patch.object(
+                control.subprocess,
+                "Popen",
+                return_value=Mock(poll=Mock(return_value=None)),
+            ),
+            patch.object(runtime, "process_alive", return_value=False),
+            patch.object(
+                runtime,
+                "instances",
+                side_effect=[runtime.InstanceScanError("locked"), [self.record]],
+            ) as scan,
+            patch.object(control.time, "sleep"),
+        ):
+            control.execute(self.job_path)
+        self.assertEqual(scan.call_count, 2)
+        self.assertEqual(
+            runtime.read_json(self.job_path.parent / "status.json")["status"],
+            "succeeded",
+        )
+
+    def test_both_windowed_worker_entrypoints_open_utf8_logs(self):
+        for entry, target, filename in (
+            (installer.main, "installer", "update.log"),
+            (control.worker_main, "control", "process.log"),
+        ):
+            with self.subTest(entry=entry):
+                execute = (
+                    patch.object(
+                        installer.Worker,
+                        "execute",
+                        side_effect=lambda: print("更新 🧪"),
+                    )
+                    if target == "installer"
+                    else patch.object(
+                        control, "execute", side_effect=lambda _: print("重启 🧪")
+                    )
+                )
+                with (
+                    execute,
+                    patch.object(sys, "stdout", None),
+                    patch.object(sys, "stderr", None),
+                ):
+                    entry(self.job_path)
+                self.assertIn(
+                    "🧪", (self.job_path.parent / filename).read_text(encoding="utf-8")
+                )
+
+    def test_resource_index_retries_windows_sharing_error_and_keeps_old_on_failure(
+        self,
+    ):
+        index = self.root / "resources/index.json"
+        with patch.object(resources, "RESOURCE_OVERLAY", index.parent):
+            resources._write_index(["old"])
+            replace = os.replace
+            attempts = []
+
+            def replace_once(source, destination):
+                attempts.append(destination)
+                if len(attempts) == 1:
+                    error = PermissionError("sharing violation")
+                    error.winerror = 32
+                    raise error
+                return replace(source, destination)
+
+            with (
+                patch.object(runtime.sys, "platform", "win32"),
+                patch.object(runtime.os, "replace", side_effect=replace_once),
+            ):
+                resources._write_index(["new"])
+            self.assertEqual(len(attempts), 2)
+            self.assertEqual(runtime.read_json(index), {"packages": ["new"]})
+            with patch.object(runtime.os, "replace", side_effect=OSError("disk error")):
+                with self.assertRaises(OSError):
+                    resources._write_index(["failed"])
+            self.assertEqual(runtime.read_json(index), {"packages": ["new"]})
+            self.assertEqual(list(index.parent.iterdir()), [index])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/update_runtime_tests.py
+++ b/arknights_mower/tests/update_runtime_tests.py
@@ -1,0 +1,326 @@
+"""Cross-platform update coordination; all processes and files are test-owned."""
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+from urllib.request import getproxies_environment
+
+from arknights_mower.utils import update_runtime as runtime
+
+
+class ProxyEnvironmentTests(unittest.TestCase):
+    def test_lowercase_wins_even_when_empty_regardless_of_insertion_order(self):
+        for name in ("http_proxy", "https_proxy", "all_proxy", "no_proxy"):
+            for value in ("socks5h://127.0.0.1:7897", ""):
+                for reverse in (False, True):
+                    items = [(name.upper(), "old"), (name, value)]
+                    if reverse:
+                        items.reverse()
+                    # A plain mapping deliberately models POSIX duplicate keys,
+                    # even when this regression test runs on Windows.
+                    with self.subTest(name=name, value=value, reverse=reverse):
+                        with patch.object(runtime.os, "environ", dict(items)):
+                            result = runtime.launch_environment({})
+                        self.assertEqual(result[name], value)
+                        self.assertNotIn(name.upper(), result)
+
+    def test_only_uppercase_and_absent_variables(self):
+        with patch.object(runtime.os, "environ", {"HTTPS_PROXY": "https://proxy:7897"}):
+            result = runtime.launch_environment({})
+        self.assertEqual(result["https_proxy"], "https://proxy:7897")
+        self.assertNotIn("http_proxy", result)
+        self.assertNotIn("HTTPS_PROXY", result)
+
+    def test_real_environment_keeps_platform_proxy_semantics(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ["HTTP_PROXY"] = "http://127.0.0.1:18080"
+            os.environ["http_proxy"] = "http://127.0.0.1:17897"
+            before = getproxies_environment()
+            result = runtime.launch_environment({})
+            if os.name == "nt":
+                self.assertEqual(os.environ["HTTP_PROXY"], os.environ["http_proxy"])
+            else:
+                self.assertNotEqual(os.environ["HTTP_PROXY"], os.environ["http_proxy"])
+        with patch.dict(os.environ, result, clear=True):
+            self.assertEqual(getproxies_environment(), before)
+
+    def test_saved_proxy_override_and_clearing_restore_inherited_environment(self):
+        from arknights_mower.utils import network_settings as network
+
+        for proxy in (
+            "http://127.0.0.1:7897",
+            "socks5://127.0.0.1:7897",
+            "socks5h://127.0.0.1:7897",
+        ):
+            with (
+                self.subTest(proxy=proxy),
+                patch.dict(
+                    os.environ,
+                    {
+                        "HTTPS_PROXY": "http://inherited:7897",
+                        "NO_PROXY": "internal.example",
+                    },
+                    clear=True,
+                ),
+                patch.object(network, "_base_environment", None),
+                patch.object(network, "_effective_settings", None),
+                patch.object(
+                    network,
+                    "get_settings",
+                    return_value={"http_proxy": proxy, "github_proxy": ""},
+                ) as settings,
+            ):
+                network.apply_http_proxy()
+                result = runtime.launch_environment({})
+                for name in ("http_proxy", "https_proxy", "all_proxy"):
+                    self.assertEqual(result[name], proxy)
+                self.assertIn("127.0.0.1", result["no_proxy"])
+                settings.return_value = {"http_proxy": "", "github_proxy": ""}
+                network.apply_http_proxy()
+                result = runtime.launch_environment({})
+                self.assertEqual(result["https_proxy"], "http://inherited:7897")
+                self.assertNotIn("all_proxy", result)
+                self.assertIn("internal.example", result["no_proxy"])
+
+
+class InstanceScanTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory(prefix="mower 登记 ")
+        self.addCleanup(temporary.cleanup)
+        self.directory = Path(temporary.name)
+        self.path = self.directory / "instances/live.json"
+        self.record = {"id": "live", "pid": os.getpid(), "kind": "instance"}
+        runtime.write_json(self.path, self.record)
+
+    def test_transient_read_error_recovers_without_deleting_live_record(self):
+        read_text = Path.read_text
+        calls = []
+
+        def read(path, *args, **kwargs):
+            calls.append(path)
+            if len(calls) == 1:
+                raise PermissionError("temporarily locked")
+            return read_text(path, *args, **kwargs)
+
+        with patch.object(Path, "read_text", read):
+            self.assertEqual(runtime.instances(self.directory), [self.record])
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(self.path.exists())
+
+    def test_read_failures_share_one_scan_budget_and_preserve_all_files(self):
+        other = self.path.with_name("second.json")
+        runtime.write_json(other, self.record)
+        clock = [0.0]
+        with (
+            patch.object(Path, "read_text", side_effect=PermissionError("locked")),
+            patch.object(runtime.time, "monotonic", side_effect=lambda: clock[0]),
+            patch.object(
+                runtime.time,
+                "sleep",
+                side_effect=lambda seconds: clock.__setitem__(0, clock[0] + seconds),
+            ),
+        ):
+            with self.assertRaisesRegex(
+                runtime.InstanceScanError, "无法完整读取实例登记"
+            ):
+                runtime.instances(self.directory)
+        self.assertAlmostEqual(clock[0], 5)
+        self.assertTrue(self.path.exists())
+        self.assertTrue(other.exists())
+
+    def test_invalid_content_is_preserved(self):
+        for value in ("{", "[]", "{}", '{"pid":true}', '{"pid":0}', '{"pid":"123"}'):
+            with self.subTest(value=value):
+                self.path.write_text(value, encoding="utf-8")
+                with self.assertRaises(runtime.InstanceScanError):
+                    runtime.instances(self.directory, timeout=0)
+                self.assertEqual(self.path.read_text(encoding="utf-8"), value)
+
+    def test_file_removed_by_exiting_instance_is_ignored(self):
+        with patch.object(Path, "read_text", side_effect=FileNotFoundError):
+            self.assertEqual(runtime.instances(self.directory), [])
+        self.assertTrue(self.path.exists())  # The scanner did not delete it.
+
+    def test_only_confirmed_dead_process_is_cleaned_up(self):
+        with patch.object(runtime, "process_alive", return_value=False):
+            self.assertEqual(runtime.instances(self.directory), [])
+        self.assertFalse(self.path.exists())
+
+    def test_unreadable_directory_is_not_an_empty_snapshot(self):
+        with patch.object(
+            Path, "iterdir", side_effect=PermissionError("directory locked")
+        ):
+            with self.assertRaises(runtime.InstanceScanError):
+                runtime.instances(self.directory, timeout=0)
+
+    def test_tray_best_effort_scan_does_not_delete_unknown_registrations(self):
+        self.path.write_text("{", encoding="utf-8")
+        self.assertEqual(runtime.managed_instances(self.directory), [])
+        self.assertEqual(runtime.unified_managers(self.directory), [])
+        self.assertTrue(self.path.exists())
+
+
+@contextmanager
+def windows_read_handle(path):
+    """Hold a real Windows handle which allows reads but denies replacement."""
+    import ctypes
+    from ctypes import wintypes
+
+    kernel = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    kernel.CreateFileW.restype = wintypes.HANDLE
+    kernel.CloseHandle.argtypes = [wintypes.HANDLE]
+    handle = kernel.CreateFileW(str(path), 0x80000000, 1, None, 3, 0x80, None)
+    if handle == ctypes.c_void_p(-1).value:
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        yield
+    finally:
+        kernel.CloseHandle(handle)
+
+
+class AtomicJsonTests(unittest.TestCase):
+    def test_nonsharing_errors_are_not_retried_on_any_platform(self):
+        with tempfile.TemporaryDirectory() as folder:
+            path = Path(folder) / "index.json"
+            runtime.write_json(path, {"packages": ["old"]})
+            with patch.object(
+                runtime.os, "replace", side_effect=OSError("disk error")
+            ) as replace:
+                with self.assertRaises(OSError):
+                    runtime.write_json(path, {"packages": ["new"]})
+            self.assertEqual(replace.call_count, 1)
+            self.assertEqual(runtime.read_json(path), {"packages": ["old"]})
+            self.assertEqual(list(Path(folder).iterdir()), [path])
+
+    @unittest.skipIf(os.name == "nt", "POSIX open-file replacement semantics")
+    def test_posix_can_replace_file_while_reader_keeps_old_handle(self):
+        with tempfile.TemporaryDirectory() as folder:
+            path = Path(folder) / "index.json"
+            runtime.write_json(path, {"version": "old"})
+            with path.open(encoding="utf-8") as old:
+                runtime.write_json(path, {"version": "new"})
+                self.assertEqual(json.load(old), {"version": "old"})
+            self.assertEqual(runtime.read_json(path), {"version": "new"})
+
+    @unittest.skipUnless(os.name == "nt", "Windows native sharing locks")
+    def test_windows_retries_until_reader_releases_handle(self):
+        with tempfile.TemporaryDirectory() as folder:
+            path = Path(folder) / "index.json"
+            runtime.write_json(path, {"version": "old"})
+            attempted = threading.Event()
+            errors = []
+            replace = os.replace
+
+            def observed_replace(source, destination):
+                try:
+                    return replace(source, destination)
+                except OSError:
+                    attempted.set()
+                    raise
+
+            def publish():
+                try:
+                    runtime.write_json(path, {"version": "new"})
+                except Exception as exc:
+                    errors.append(exc)
+
+            with patch.object(runtime.os, "replace", side_effect=observed_replace):
+                with windows_read_handle(path):
+                    thread = threading.Thread(target=publish)
+                    thread.start()
+                    seen = attempted.wait(3)
+                thread.join(10)
+            self.assertTrue(seen, "writer never encountered the real sharing lock")
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(errors, [])
+            self.assertEqual(runtime.read_json(path), {"version": "new"})
+
+    @unittest.skipUnless(os.name == "nt", "Windows native sharing locks")
+    def test_windows_persistent_lock_keeps_old_json_and_cleans_temporary(self):
+        with tempfile.TemporaryDirectory() as folder:
+            path = Path(folder) / "index.json"
+            runtime.write_json(path, {"version": "old"})
+            with windows_read_handle(path):
+                with self.assertRaises(PermissionError):
+                    runtime.write_json(path, {"version": "new"})
+            self.assertEqual(runtime.read_json(path), {"version": "old"})
+            self.assertEqual(list(Path(folder).iterdir()), [path])
+
+
+class Utf8OutputTests(unittest.TestCase):
+    def test_existing_gbk_streams_are_reconfigured(self):
+        buffers = [io.BytesIO(), io.BytesIO()]
+        streams = [io.TextIOWrapper(buffer, encoding="gbk") for buffer in buffers]
+        try:
+            with (
+                patch.object(sys, "stdout", streams[0]),
+                patch.object(sys, "stderr", streams[1]),
+            ):
+                with runtime.utf8_output("unused.log"):
+                    print("中文路径 🧪", flush=True)
+                    print("更新错误 🧪", file=sys.stderr, flush=True)
+            self.assertEqual(
+                buffers[0].getvalue().decode("utf-8").strip(), "中文路径 🧪"
+            )
+            self.assertEqual(
+                buffers[1].getvalue().decode("utf-8").strip(), "更新错误 🧪"
+            )
+        finally:
+            for stream in streams:
+                stream.close()
+
+    def test_windowed_worker_uses_utf8_file_and_restores_missing_streams(self):
+        with tempfile.TemporaryDirectory() as folder:
+            path = Path(folder) / "更新 日志.log"
+            with patch.object(sys, "stdout", None), patch.object(sys, "stderr", None):
+                with runtime.utf8_output(path):
+                    print("正在更新 🧪")
+                    print("错误详情", file=sys.stderr)
+                self.assertIsNone(sys.stdout)
+                self.assertIsNone(sys.stderr)
+            self.assertEqual(
+                path.read_text(encoding="utf-8"), "正在更新 🧪\n错误详情\n"
+            )
+
+    def test_source_child_overrides_gbk_and_keeps_explicit_gbk_csv(self):
+        with tempfile.TemporaryDirectory(prefix="mower 中文 路径 ") as folder:
+            csv_path = Path(folder) / "report.csv"
+            csv_path.write_text(",作战录像,赤金\n2026-09-05,10,20\n", encoding="gbk")
+            code = (
+                "import sys\n"
+                "from arknights_mower.utils.csv_utils import append_dated_row, read_dicts\n"
+                "append_dated_row(sys.argv[1], '2026-09-06', {'作战录像': 30, '赤金': 40}, encoding='gbk')\n"
+                "rows = read_dicts(sys.argv[1], encoding='gbk')\n"
+                "assert len(rows) == 2 and rows[0]['赤金'] == '20' and rows[1]['赤金'] == '40'\n"
+                "print(sys.argv[1] + ' 更新成功 🧪', flush=True)\n"
+            )
+            with patch.dict(os.environ, PYTHONIOENCODING="gbk", PYTHONUTF8="0"):
+                output = subprocess.check_output(
+                    [sys.executable, "-c", code, str(csv_path)],
+                    env=runtime.launch_environment({}),
+                    stderr=subprocess.STDOUT,
+                    timeout=30,
+                )
+            self.assertIn(str(csv_path) + " 更新成功 🧪", output.decode("utf-8"))
+            self.assertIn("作战录像", csv_path.read_bytes().decode("gbk"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/update_runtime_tests.py
+++ b/arknights_mower/tests/update_runtime_tests.py
@@ -105,9 +105,10 @@ class InstanceScanTests(unittest.TestCase):
         calls = []
 
         def read(path, *args, **kwargs):
-            calls.append(path)
-            if len(calls) == 1:
-                raise PermissionError("temporarily locked")
+            if path == self.path:
+                calls.append(path)
+                if len(calls) == 1:
+                    raise PermissionError("temporarily locked")
             return read_text(path, *args, **kwargs)
 
         with patch.object(Path, "read_text", read):

--- a/arknights_mower/utils/process_control.py
+++ b/arknights_mower/utils/process_control.py
@@ -23,7 +23,10 @@ def current_instance():
 
 
 def info():
-    record = current_instance()
+    try:
+        record = current_instance()
+    except runtime.InstanceScanError as exc:
+        return {"ok": True, "supported": False, "name": "", "message": str(exc)}
     return {
         "ok": True,
         "supported": record is not None,
@@ -160,11 +163,15 @@ def execute(job_path):
         # differs from the registered os.getpid().
         target = runtime.registration_key(record)
         while time.monotonic() < deadline:
+            try:
+                records = runtime.instances(state, timeout=0)
+            except runtime.InstanceScanError:
+                records = []  # A transient read failure is not a failed restart.
             if any(
                 runtime.registration_key(item) == target
                 and item.get("ready")
                 and item.get("restart_job") == job["id"]
-                for item in runtime.instances(state)
+                for item in records
             ):
                 report("当前实例已重启，原运行状态将自动恢复", "succeeded")
                 return
@@ -182,4 +189,5 @@ def execute(job_path):
 
 
 def worker_main(job_path):
-    execute(job_path)
+    with runtime.utf8_output(Path(job_path).parent / "process.log"):
+        execute(job_path)

--- a/arknights_mower/utils/res_version.py
+++ b/arknights_mower/utils/res_version.py
@@ -61,9 +61,9 @@ def package_file_paths(root) -> list:
 def content_hash(root, rels) -> str:
     """对相对路径文件集算聚合 sha256（含路径，结果与顺序无关）。
 
-    Windows 检出（core.autocrlf）会把文本文件的 LF 转成 CRLF。文本文件按
-    git 自身判断文本的启发式（无 NUL 字节）归一化到 LF，使摘要在任何检出下
-    与打包内容一致；二进制文件按原字节参与。分块读取避免一次载入整文件。
+    Windows 检出（core.autocrlf）会把文本文件的 LF 转成 CRLF。仅对
+    RES_PACKAGE_DATA 声明的文本资源归一化到 LF；模型、图片及其他文件均按
+    原字节参与，不通过 NUL 字节猜测文件类型。分块读取避免一次载入整文件。
     """
     root = Path(root)
     digest = hashlib.sha256()
@@ -71,18 +71,9 @@ def content_hash(root, rels) -> str:
         digest.update(rel.as_posix().encode("utf-8"))
         digest.update(b"\0")
         with open(root / rel, "rb") as f:
-            normalize = not _contains_nul(f)
-            f.seek(0)
+            normalize = rel.as_posix() in RES_PACKAGE_DATA
             _update_digest(digest, f, normalize)
     return digest.hexdigest()
-
-
-def _contains_nul(stream) -> bool:
-    """Whether the stream contains a NUL byte, matching git's text heuristic."""
-    while chunk := stream.read(1 << 20):
-        if b"\0" in chunk:
-            return True
-    return False
 
 
 def _update_digest(digest, stream, normalize: bool) -> None:

--- a/arknights_mower/utils/resource_pkg.py
+++ b/arknights_mower/utils/resource_pkg.py
@@ -11,7 +11,6 @@ from io import BytesIO
 from pathlib import Path
 from shutil import copytree, rmtree
 from threading import RLock, get_ident
-from uuid import uuid4
 from zipfile import ZipFile
 
 import requests
@@ -39,6 +38,7 @@ from arknights_mower.utils.resource_store import (
     select_resource,
     validate_package,
 )
+from arknights_mower.utils.update_runtime import write_json
 from arknights_mower.utils.zip_safe import is_unsafe_zip_member
 
 RESOURCE_OVERLAY = get_path("@app/resources", space="")
@@ -119,13 +119,7 @@ def _remember_loaded_resource():
 
 
 def _write_index(packages):
-    RESOURCE_OVERLAY.mkdir(parents=True, exist_ok=True)
-    temporary = RESOURCE_OVERLAY / f".index-{uuid4().hex}.json"
-    try:
-        temporary.write_text(json.dumps({"packages": packages}), encoding="utf-8")
-        os.replace(temporary, RESOURCE_OVERLAY / "index.json")
-    finally:
-        temporary.unlink(missing_ok=True)
+    write_json(RESOURCE_OVERLAY / "index.json", {"packages": packages})
 
 
 def _selection():

--- a/arknights_mower/utils/software_update.py
+++ b/arknights_mower/utils/software_update.py
@@ -541,11 +541,18 @@ def info():
         blockers.append(
             "安装位置不可写；请先将程序移至可写目录（macOS 请移出 DMG 后运行）"
         )
-    registered = runtime.instances()
-    if not any(r["pid"] == os.getpid() and r["kind"] == "instance" for r in registered):
-        blockers.append(
-            "请通过 webview_ui.py / Mower 桌面程序启动；直接运行 Flask 或容器请使用原部署工具更新"
-        )
+    try:
+        registered = runtime.instances()
+    except runtime.InstanceScanError as exc:
+        registered = []
+        blockers.append(str(exc))
+    else:
+        if not any(
+            r["pid"] == os.getpid() and r["kind"] == "instance" for r in registered
+        ):
+            blockers.append(
+                "请通过 webview_ui.py / Mower 桌面程序启动；直接运行 Flask 或容器请使用原部署工具更新"
+            )
     settings = get_settings()
     return {
         "ok": True,

--- a/arknights_mower/utils/software_update_worker.py
+++ b/arknights_mower/utils/software_update_worker.py
@@ -25,6 +25,7 @@ from pathlib import Path, PurePosixPath
 if __package__:
     from .github_download import download_url
     from .update_runtime import (
+        InstanceScanError,
         detached_options,
         instances,
         launch_environment,
@@ -32,11 +33,13 @@ if __package__:
         read_json,
         registration_key,
         submission_lock,
+        utf8_output,
         write_json,
     )
 else:
     from github_download import download_url
     from update_runtime import (
+        InstanceScanError,
         detached_options,
         instances,
         launch_environment,
@@ -44,6 +47,7 @@ else:
         read_json,
         registration_key,
         submission_lock,
+        utf8_output,
         write_json,
     )
 
@@ -938,11 +942,14 @@ class Worker:
         }
         deadline = time.monotonic() + 120
         while time.monotonic() < deadline:
-            ready = {
-                registration_key(r)
-                for r in instances(self.state)
-                if r.get("ready") and r.get("restart_job") == self.job["id"]
-            }
+            try:
+                ready = {
+                    registration_key(r)
+                    for r in instances(self.state, timeout=0)
+                    if r.get("ready") and r.get("restart_job") == self.job["id"]
+                }
+            except InstanceScanError:
+                ready = set()  # Retry within the existing readiness deadline.
             if requested <= ready:
                 return
             if any(p.poll() is not None for p in processes):
@@ -1113,18 +1120,7 @@ class Worker:
 
 
 def main(job_path):
-    # Windowed PyInstaller applications may set stdout/stderr to None.
-    if sys.stdout is None or sys.stderr is None:
-        original_streams = sys.stdout, sys.stderr
-        with (Path(job_path).parent / "update.log").open(
-            "a", encoding="utf-8", buffering=1
-        ) as log:
-            try:
-                sys.stdout = sys.stderr = log
-                Worker(job_path).execute()
-            finally:
-                sys.stdout, sys.stderr = original_streams
-    else:
+    with utf8_output(Path(job_path).parent / "update.log"):
         Worker(job_path).execute()
 
 

--- a/arknights_mower/utils/update_runtime.py
+++ b/arknights_mower/utils/update_runtime.py
@@ -168,23 +168,63 @@ def registration_key(record):
     return (record.get("space") or "", record.get("name") or "", record.get("port"))
 
 
-def instances(directory=None):
-    directory = Path(directory or state_dir())
-    result = []
-    for path in (directory / "instances").glob("*.json"):
-        record = read_json(path, {})
-        if record and process_alive(record.get("pid")):
-            result.append(record)
-        else:
-            path.unlink(missing_ok=True)
-    return result
+class InstanceScanError(RuntimeError):
+    """A complete registration snapshot could not be read safely."""
+
+
+def instances(directory=None, *, timeout=5, strict=True):
+    """Read registrations without treating an unreadable file as a dead process.
+
+    The entire scan shares one retry budget. Update admission and shutdown need
+    a complete snapshot; tray rendering can explicitly request a best-effort one.
+    """
+    directory = Path(directory or state_dir()) / "instances"
+    deadline = time.monotonic() + timeout
+    while True:
+        result = []
+        failures = []
+        try:
+            paths = sorted(p for p in directory.iterdir() if p.suffix == ".json")
+        except FileNotFoundError:
+            return []
+        except OSError as exc:
+            paths = []
+            failures.append((directory, exc))
+        for path in paths:
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+                if (
+                    not isinstance(record, dict)
+                    or type(record.get("pid")) is not int
+                    or record["pid"] <= 0
+                ):
+                    raise ValueError("实例登记缺少有效的进程编号")
+                if process_alive(record["pid"]):
+                    result.append(record)
+                else:
+                    path.unlink(missing_ok=True)
+            except FileNotFoundError:
+                pass  # The instance may have removed its registration on exit.
+            except (OSError, ValueError) as exc:
+                failures.append((path, exc))
+        if not failures:
+            return result
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            if not strict:
+                return result
+            path, error = failures[0]
+            raise InstanceScanError(
+                f"无法完整读取实例登记，请稍后重试或检查文件权限：{path}（{error}）"
+            ) from error
+        time.sleep(min(0.05, remaining))
 
 
 def managed_instances(directory=None, data_dir=None):
     data_dir = os.environ.get("MOWER_DATA_DIR", "") if data_dir is None else data_dir
     return [
         record
-        for record in instances(directory)
+        for record in instances(directory, timeout=0, strict=False)
         if record.get("kind") == "instance"
         and record.get("managed")
         and record.get("data_dir", "") == data_dir
@@ -195,7 +235,7 @@ def unified_managers(directory=None, data_dir=None):
     data_dir = os.environ.get("MOWER_DATA_DIR", "") if data_dir is None else data_dir
     return [
         record
-        for record in instances(directory)
+        for record in instances(directory, timeout=0, strict=False)
         if record.get("kind") == "manager"
         and record.get("unified_tray")
         and record.get("data_dir", "") == data_dir
@@ -301,6 +341,10 @@ def launch_environment(record, job_id="", background=False):
     # A frozen child must initialize its own bootloader/runtime, including after
     # replacement of the bundle. System subprocesses must not inherit private libs.
     env["PYINSTALLER_RESET_ENVIRONMENT"] = "1"
+    # Set these before starting source Python children. Frozen workers also
+    # configure their streams explicitly, since bootloaders may ignore them.
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
     for name in ("LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"):
         if name + "_ORIG" in env:
             env[name] = env[name + "_ORIG"]
@@ -310,12 +354,15 @@ def launch_environment(record, job_id="", background=False):
     # copy can change the casing of proxy variables. Normalize them to lowercase
     # so subprocesses and callers see a deterministic environment on every platform.
     for name in ("http_proxy", "https_proxy", "all_proxy", "no_proxy"):
-        matched = next((key for key in env if key.lower() == name), None)
-        if matched is not None:
-            if matched != name:
-                env[name] = env.pop(matched)
-        else:
-            env.pop(name, None)
+        matches = [key for key in env if key.lower() == name]
+        if matches:
+            # requests/urllib prefer the exact lowercase spelling, even when
+            # its value is empty. Never let insertion order overwrite it.
+            key = name if name in env else name.upper()
+            value = env[key] if key in env else env[sorted(matches)[0]]
+            for key in matches:
+                del env[key]
+            env[name] = value
     env.update(
         MOWER_RESTART_JOB=job_id,
         MOWER_BACKGROUND="1" if background else "0",
@@ -328,3 +375,23 @@ def launch_environment(record, job_id="", background=False):
     else:
         env.pop("MOWER_DATA_DIR", None)
     return env
+
+
+@contextmanager
+def utf8_output(log_path):
+    """Use UTF-8 for worker logs, including windowed/frozen standard streams."""
+    original = sys.stdout, sys.stderr
+    log = None
+    try:
+        if any(stream is None for stream in original):
+            log = Path(log_path).open("a", encoding="utf-8", buffering=1)
+        for name, stream in zip(("stdout", "stderr"), original):
+            if stream is None:
+                setattr(sys, name, log)
+            elif hasattr(stream, "reconfigure"):
+                stream.reconfigure(encoding="utf-8", errors="backslashreplace")
+        yield
+    finally:
+        sys.stdout, sys.stderr = original
+        if log is not None:
+            log.close()


### PR DESCRIPTION
alpha 合入 #978 后，实例登记读取失败会被跳过；更新可能在缺少部分运行实例的情况下继续安装。本 PR 基于该版本补齐完整扫描保护、日志编码和三端验证，保留 #968、#978 的有效修复。

### 修改内容

- 实例扫描共用最多 5 秒重试预算，区分文件消失、读取失败、内容无效与进程退出。无法完整读取登记时，在关闭任何实例前结束更新并显示原因；就绪轮询继续等待，托盘读取保留容错。
- 保留 #978 的小写代理优先级及原子替换重试，补齐空值、混合大小写、设置覆盖、SOCKS 和 NO_PROXY 的回归；资源索引复用原子 JSON 写入，失败保留旧索引。
- Python 子进程启用 UTF-8 模式，更新与进程控制 worker 主动设置标准流编码；标准流为空时创建 UTF-8 日志。report.csv 和森空岛 CSV 继续显式使用 GBK，不迁移历史数据。
- 资源换行归一化限定于 RES_PACKAGE_DATA 声明的文本文件，图片、模型及其他文件按原始字节计算；保留流式读取及跨块 CRLF 处理，当前资源哈希和版本不变。
- 新增 Windows、macOS、Linux 定向 CI（Python 3.12、Node.js 20、Git、uv），覆盖共享锁、中文及空格路径、三实例恢复、单实例重启、失败恢复、取消与旧提交切换。
- CI 安装 uv 仅用于覆盖 uv 分支；用户的源码部署仍可使用 pip／ensurepip，不新增 uv 或 venv 目录名限制。

### 验证

- 基础版本为包含 #978 的 alpha：`9018f3cb`；当前提交 `b96e5a21`。
- 本机 macOS 定向回归：124 项，122 项通过，2 项 Windows 原生共享锁测试按平台跳过；Ruff 检查、格式检查和 git diff --check 通过。
- 本机 macOS 完整回归：1244 项，1242 项通过，2 项 Windows 专属测试跳过。
- [当前提交的三端 CI 已通过](https://github.com/ArkMowers/arknights-mower/actions/runs/34045427662)：Windows 124 项（123 通过、1 项 POSIX 专属测试跳过）；macOS、Linux 各 124 项（122 通过、2 项 Windows 专属测试跳过）。Windows 原生共享锁、中文及空格路径下的源码更新与恢复通过。
- 云端完整单元测试：1244 项（18 项平台／可选依赖测试跳过）；脚本测试：87 项（1 项跳过）；识别等价性专项：10 项通过。
- 当前提交全部 11 项检查通过，包括两条既有工作流中的单元测试、Ruff、Prettier，以及 actionlint 和三端更新矩阵。
- 冻结程序标准流分支采用模拟验证；三端完整发行包安装仍未实测，不能以模拟分支通过替代。
- 未修改远端运行环境，未重新生成资源文件或资源版本号。
