### PR TITLE
feat(config): 保存配置时只写入修改过的键

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -3849,7 +3849,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             logger.info(f"现在服务器是{_plan.weekday}")
             use_medicine = False
             if conf.maa_expiring_medicine:
-                if conf.exipring_medicine_on_weekend:
+                if conf.expiring_medicine_on_weekend:
                     use_medicine = server_weekday >= 5
                 else:
                     use_medicine = True

--- a/arknights_mower/solvers/operation.py
+++ b/arknights_mower/solvers/operation.py
@@ -396,7 +396,7 @@ class OperationSolver(SceneGraphSolver):
         elif scene == Scene.OPERATOR_RECOVER_POTION:
             use_medicine = False
             if config.conf.maa_expiring_medicine:
-                if config.conf.exipring_medicine_on_weekend:
+                if config.conf.expiring_medicine_on_weekend:
                     use_medicine = get_server_weekday() >= 5
                 else:
                     use_medicine = True

--- a/arknights_mower/tests/config_tests.py
+++ b/arknights_mower/tests/config_tests.py
@@ -3,12 +3,30 @@ import os
 import tempfile
 import threading
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
 from arknights_mower.utils import config as config_module
 from arknights_mower.utils.config import atomic_write, migrate_app_config_paths
 from arknights_mower.utils.config.conf import Conf
+
+
+@contextmanager
+def _patched_conf(path, conf=None):
+    """临时切到 path 与 conf 下读取/写配置，结束后还原模块级 conf。
+
+    #258 之后 save_conf 只写用户配置过的键，测试须用固定的 path/conf 隔离环境里的
+    @app/config/conf.yml，避免依赖残留内容。
+    """
+    original = config_module.conf
+    try:
+        with patch.object(config_module, "conf_path", path):
+            if conf is not None:
+                config_module.conf = conf
+            yield
+    finally:
+        config_module.conf = original
 
 
 class TestMaaConfig(unittest.TestCase):
@@ -265,7 +283,8 @@ class TestPersistFunctionsWriteThrough(unittest.TestCase):
 
     def test_save_conf_writes_atomic(self):
         target = self.dir / "conf.yml"
-        with patch.object(config_module, "conf_path", target):
+        # 固定一份带 webview 的配置，避免依赖测试环境 @app/config/conf.yml 的遗留内容
+        with _patched_conf(target, Conf(webview={"port": 58000})):
             config_module.save_conf()
         self.assertTrue(target.is_file())
         self.assertIn("webview", target.read_text(encoding="utf-8"))
@@ -303,6 +322,100 @@ class TestPersistFunctionsWriteThrough(unittest.TestCase):
         self.assertTrue(target.is_file())
         leftovers = [p for p in self.dir.rglob(".*.tmp") if p.is_file()]
         self.assertEqual(leftovers, [])
+
+
+class TestConfigPersistence(unittest.TestCase):
+    """#258：save_conf 只写用户配置过的键 + 旧键→新键迁移钩子。"""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+        self.conf_path = self.dir / "conf.yml"
+
+    def _write_conf(self, text):
+        self.conf_path.parent.mkdir(parents=True, exist_ok=True)
+        self.conf_path.write_text(text, encoding="utf-8")
+
+    def test_save_conf_writes_only_user_configured_keys(self):
+        with _patched_conf(self.conf_path, Conf(maa_expiring_medicine=False)):
+            config_module.save_conf()
+        written = self.conf_path.read_text(encoding="utf-8")
+        self.assertIn("maa_expiring_medicine", written)
+        # 未配置的默认字段不落盘
+        self.assertNotIn("expiring_medicine_on_weekend", written)
+        self.assertNotIn("maa_eat_stone", written)
+        self.assertNotIn("ap_fallback", written)
+
+    def test_unconfigured_conf_serializes_without_injected_defaults(self):
+        with _patched_conf(self.conf_path, Conf()):
+            # 未配置任何字段 → 序列化结果为空，不注入任何默认值
+            dumped = config_module.conf.model_dump(exclude_unset=True)
+            config_module.save_conf()
+        self.assertEqual(dumped, {})
+        written = self.conf_path.read_text(encoding="utf-8")
+        self.assertNotIn("maa_eat_stone", written)
+        self.assertNotIn("webview", written)
+
+    def test_legacy_key_migrates_to_new_key_when_configured(self):
+        self._write_conf("exipring_medicine_on_weekend: true\n")
+        with _patched_conf(self.conf_path):
+            config_module.load_conf()
+            self.assertTrue(config_module.conf.expiring_medicine_on_weekend)
+            self.assertIn(
+                "expiring_medicine_on_weekend",
+                config_module.conf.model_fields_set,
+            )
+            config_module.save_conf()
+        written = self.conf_path.read_text(encoding="utf-8")
+        self.assertIn("expiring_medicine_on_weekend", written)
+        self.assertNotIn("exipring_medicine_on_weekend", written)
+
+    def test_legacy_key_not_migrated_when_absent(self):
+        self._write_conf("maa_expiring_medicine: false\n")
+        with _patched_conf(self.conf_path):
+            config_module.load_conf()
+            # 没配过旧键：新键用运行时默认值，且不被标记为已设置（因此不落盘）
+            self.assertFalse(config_module.conf.expiring_medicine_on_weekend)
+            self.assertNotIn(
+                "expiring_medicine_on_weekend",
+                config_module.conf.model_fields_set,
+            )
+
+    def test_new_key_takes_precedence_when_legacy_and_new_both_present(self):
+        self._write_conf(
+            "exipring_medicine_on_weekend: true\nexpiring_medicine_on_weekend: false\n"
+        )
+        with _patched_conf(self.conf_path):
+            config_module.load_conf()
+            # 新旧键同时出现时以新键为准，不覆盖已配置的取反值
+            self.assertFalse(config_module.conf.expiring_medicine_on_weekend)
+
+    def test_migrated_value_survives_round_trip(self):
+        self._write_conf("exipring_medicine_on_weekend: true\n")
+        with _patched_conf(self.conf_path):
+            config_module.load_conf()
+            config_module.save_conf()
+            config_module.load_conf()
+            self.assertTrue(config_module.conf.expiring_medicine_on_weekend)
+
+    def test_conf_post_with_legacy_key_reconciles_at_validation_layer(self):
+        # 兼容：/conf POST 提交旧键名（旧前端整包）时，Conf 校验层统一迁移，不把新键重置成默认。
+        # 旧迁移只在 load_conf（读文件）执行，/conf 提交会绕过——此测锁定那条路径。
+        with _patched_conf(self.conf_path):
+            # 模拟旧前端整包提交：请求体带旧键名、不带新键名
+            config_module.conf = config_module.Conf(
+                **{"exipring_medicine_on_weekend": True}
+            )
+            self.assertTrue(config_module.conf.expiring_medicine_on_weekend)
+            self.assertIn(
+                "expiring_medicine_on_weekend",
+                config_module.conf.model_fields_set,
+            )
+            config_module.save_conf()
+        written = self.conf_path.read_text(encoding="utf-8")
+        self.assertIn("expiring_medicine_on_weekend", written)
+        self.assertNotIn("exipring_medicine_on_weekend", written)
 
 
 if __name__ == "__main__":

--- a/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
+++ b/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
@@ -31,7 +31,7 @@ def _conf(*, enabled=True):
             )
         ],
         maa_expiring_medicine=False,
-        exipring_medicine_on_weekend=False,
+        expiring_medicine_on_weekend=False,
         maa_eat_stone=False,
     )
 

--- a/arknights_mower/utils/config/__init__.py
+++ b/arknights_mower/utils/config/__init__.py
@@ -112,7 +112,7 @@ migrate_app_config_paths()
 def save_conf():
     def dump(f):
         yaml.dump(
-            conf.model_dump(),
+            conf.model_dump(exclude_unset=True),
             f,
             Dumper=CoreDumper,
             encoding="utf-8",
@@ -131,7 +131,9 @@ def load_conf():
         save_conf()
         return
     with conf_path.open("r", encoding="utf-8") as f:
-        conf = Conf(**yaml.load(f, Loader=CoreLoader))
+        # 旧键 → 新键的兼容（exipring_medicine_on_weekend）由 Conf 校验层统一处理，
+        # 读文件与 /conf POST 等所有构造路径都走同一套迁移。
+        conf = Conf(**(yaml.load(f, Loader=CoreLoader) or {}))
 
 
 conf: Conf

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -3,8 +3,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from pydantic import BaseModel, Field, model_validator
-from pydantic_core import PydanticUndefined
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from arknights_mower import __rootdir__
 from arknights_mower.utils.path import get_path
@@ -31,18 +30,11 @@ def default_adb_path():
 
 
 class ConfModel(BaseModel):
-    @model_validator(mode="before")
-    @classmethod
-    def nested_defaults(cls, data):
-        for name, field in cls.model_fields.items():
-            if name not in data:
-                if field.default_factory is not None:
-                    data[name] = field.default_factory()
-                elif field.default is PydanticUndefined:
-                    data[name] = field.annotation()
-                else:
-                    data[name] = field.default
-        return data
+    # 用户没配置的字段由 pydantic 用默认值在运行时补齐，不写回配置文件。
+    # validate_default=True 让带默认值的字段（如 maa_weekly_plan 的 dict 默认值）也经历一次
+    # 校验、转成模型实例；配合 save_conf 的 model_dump(exclude_unset=True)，落盘的只有
+    # 用户显式配置过的键，未配置的字段不写入磁盘（新字段默认值由运行时补齐）。
+    model_config = ConfigDict(validate_default=True)
 
 
 class CluePart(ConfModel):
@@ -60,7 +52,7 @@ class CluePart(ConfModel):
 
     maa_credit_fight: bool = True
     "信用作战开关"
-    credit_fight: CreditFightConf
+    credit_fight: CreditFightConf = Field(default_factory=CreditFightConf)
     "信用作战设置"
     enable_party: int = 1
     "线索收集"
@@ -93,7 +85,9 @@ class EmailPart(ConfModel):
     "邮箱密码"
     recipient: list[str] = []
     "收件人"
-    custom_smtp_server: CustomSMTPServerConf
+    custom_smtp_server: CustomSMTPServerConf = Field(
+        default_factory=CustomSMTPServerConf
+    )
     "自定义邮箱"
     mail_subject: str = "[Mower通知]"
     "标题前缀"
@@ -124,7 +118,7 @@ class ExtraPart(ConfModel):
 
     start_automatically: bool = False
     "启动后自动开始任务"
-    webview: WebViewConf
+    webview: WebViewConf = Field(default_factory=WebViewConf)
     "GUI相关设置"
     theme: str = "light"
     "界面主题"
@@ -132,7 +126,7 @@ class ExtraPart(ConfModel):
     "截图最短间隔（毫秒）"
     screenshot: float = 1
     "截图保留时长（小时），0 不写盘，实时预览仍可用"
-    waiting_scene: WaitingSceneConf
+    waiting_scene: WaitingSceneConf = Field(default_factory=WaitingSceneConf)
     "等待时间"
 
 
@@ -200,17 +194,19 @@ class LongTaskPart(ConfModel):
     "肉鸽主题"
     maa_rcl_theme: str = "Tales"
     "生息演算主题（Tales/Fire/RelaunchAnchor）"
-    rcl: RclConf
+    rcl: RclConf = Field(default_factory=RclConf)
     "生息演算设置"
-    rogue: RogueConf
+    rogue: RogueConf = Field(default_factory=RogueConf)
     "肉鸽设置"
-    sss: SSSConf
+    sss: SSSConf = Field(default_factory=SSSConf)
     "保全设置"
-    reclamation_algorithm: ReclamationAlgorithmConf
+    reclamation_algorithm: ReclamationAlgorithmConf = Field(
+        default_factory=ReclamationAlgorithmConf
+    )
     "生息演算"
-    secret_front: SecretFrontConf
+    secret_front: SecretFrontConf = Field(default_factory=SecretFrontConf)
     "隐秘战线结局"
-    sign_in: SignInConf
+    sign_in: SignInConf = Field(default_factory=SignInConf)
     "签到活动"
 
     class HotUpdateConf(ConfModel):
@@ -225,7 +221,7 @@ class LongTaskPart(ConfModel):
                 self.enable = True
             return self
 
-    hot_update: HotUpdateConf
+    hot_update: HotUpdateConf = Field(default_factory=HotUpdateConf)
     "热更新"
 
 
@@ -299,7 +295,7 @@ class RegularTaskPart(ConfModel):
     "日常任务间隔"
     maa_expiring_medicine: bool = True
     "自动使用将要过期（约3天）的理智药"
-    exipring_medicine_on_weekend: bool = False
+    expiring_medicine_on_weekend: bool = False
     "仅在周末使用将要过期的理智药"
     ap_fallback: int = 0
     "关卡体力消耗默认值（数据中找不到关卡时的兜底，0 表示不启用）"
@@ -369,7 +365,9 @@ class RIICPart(ConfModel):
     "跑单前置延时"
     resting_threshold: float = 0.65
     "心情阈值"
-    run_order_grandet_mode: RunOrderGrandetModeConf
+    run_order_grandet_mode: RunOrderGrandetModeConf = Field(
+        default_factory=RunOrderGrandetModeConf
+    )
     "葛朗台跑单"
     free_room: bool = False
     "宿舍不养闲人模式"
@@ -450,7 +448,7 @@ class SimulatorPart(ConfModel):
 
     adb: str = "127.0.0.1:16384"
     "ADB连接地址"
-    simulator: SimulatorConf
+    simulator: SimulatorConf = Field(default_factory=SimulatorConf)
     "模拟器"
     maa_adb_path: str = Field(default_factory=default_adb_path)
     "ADB路径"
@@ -458,9 +456,11 @@ class SimulatorPart(ConfModel):
     "任务结束后关闭游戏"
     package_type: int = 1
     "游戏服务器"
-    custom_screenshot: CustomScreenshotConf
+    custom_screenshot: CustomScreenshotConf = Field(
+        default_factory=CustomScreenshotConf
+    )
     "自定义截图"
-    tap_to_launch_game: TapToLaunchGameConf
+    tap_to_launch_game: TapToLaunchGameConf = Field(default_factory=TapToLaunchGameConf)
     "点击屏幕启动游戏"
     exit_game_when_idle: bool = False
     "任务结束后退出游戏"
@@ -472,7 +472,7 @@ class SimulatorPart(ConfModel):
     "关闭MuMu模拟器12时结束adb进程"
     touch_method: str = "scrcpy"
     "触控模式"
-    droidcast: DroidCastConf
+    droidcast: DroidCastConf = Field(default_factory=DroidCastConf)
     "DroidCast截图设置"
     mumu12IPC: bool = False
     "MuMu12IPC截图设置"
@@ -534,6 +534,14 @@ class MaaRewardPart(ConfModel):
     "领取五周年赠送月卡奖励"
 
 
+# 已退役的旧字段名 → 现在的字段名。旧键名拼写有误（exipring），已换名；旧配置文件或旧前端
+# 提交时仍会用旧键名，须在构造 Conf 时统一把它搬到新键名下——只在旧键名确实出现时搬运
+# （没配过就不写新键、不注入默认值），新旧并存时以新键为准（不覆盖）。
+_LEGACY_KEY_MIGRATIONS = {
+    "exipring_medicine_on_weekend": "expiring_medicine_on_weekend",
+}
+
+
 class Conf(
     CluePart,
     EmailPart,
@@ -548,6 +556,21 @@ class Conf(
     MaaRewardPart,
     AIAgentPart,
 ):
+    # 迁移放在校验层而不是 load_conf：/conf POST 等所有构造路径都能统一兼容旧字段，
+    # 否则旧前端整包提交旧键名会被当未知键忽略、新键落成默认值。
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_legacy_keys(cls, data):
+        if not isinstance(data, dict):
+            return data
+        for old, new in _LEGACY_KEY_MIGRATIONS.items():
+            if old not in data:
+                continue
+            if new not in data:
+                data[new] = data[old]
+            data.pop(old, None)
+        return data
+
     @property
     def APPNAME(self):
         return (

--- a/ui/src/components/MaaWeekly.vue
+++ b/ui/src/components/MaaWeekly.vue
@@ -20,7 +20,7 @@ const {
   maa_weekly_plan,
   maa_enable,
   maa_expiring_medicine,
-  exipring_medicine_on_weekend,
+  expiring_medicine_on_weekend,
   ap_fallback
 } = storeToRefs(store)
 
@@ -263,7 +263,7 @@ function cancelCopyDialogLongPress() {
           <n-flex class="weekly-plan-toolbar" align="center">
             <n-checkbox v-model:checked="maa_expiring_medicine">使用将要过期的理智药</n-checkbox>
             <n-checkbox
-              v-model:checked="exipring_medicine_on_weekend"
+              v-model:checked="expiring_medicine_on_weekend"
               :disabled="!maa_expiring_medicine"
             >
               周末使用

--- a/ui/src/stores/config.js
+++ b/ui/src/stores/config.js
@@ -120,7 +120,7 @@ export const useConfigStore = defineStore('config', () => {
   const hot_update_auto_update = ref(false)
   const notification_level = ref('INFO')
   const waiting_scene = ref({})
-  const exipring_medicine_on_weekend = ref(false)
+  const expiring_medicine_on_weekend = ref(false)
   const maa_mail = ref(false)
   const maa_recruit = ref(false)
   const maa_orundum = ref(false)
@@ -454,7 +454,7 @@ export const useConfigStore = defineStore('config', () => {
     hot_update_auto_update.value = response.data.hot_update?.auto_update ?? false
     notification_level.value = response.data.notification_level
     waiting_scene.value = response.data.waiting_scene
-    exipring_medicine_on_weekend.value = response.data.exipring_medicine_on_weekend
+    expiring_medicine_on_weekend.value = response.data.expiring_medicine_on_weekend
     maa_mail.value = response.data.maa_mail
     maa_recruit.value = response.data.maa_recruit
     maa_orundum.value = response.data.maa_orundum
@@ -576,7 +576,7 @@ export const useConfigStore = defineStore('config', () => {
       },
       notification_level: notification_level.value,
       waiting_scene: waiting_scene.value,
-      exipring_medicine_on_weekend: exipring_medicine_on_weekend.value,
+      expiring_medicine_on_weekend: expiring_medicine_on_weekend.value,
       maa_mail: maa_mail.value,
       maa_recruit: maa_recruit.value,
       maa_orundum: maa_orundum.value,
@@ -736,7 +736,7 @@ export const useConfigStore = defineStore('config', () => {
     hot_update_auto_update,
     notification_level,
     waiting_scene,
-    exipring_medicine_on_weekend,
+    expiring_medicine_on_weekend,
     maa_mail,
     maa_recruit,
     maa_orundum,


### PR DESCRIPTION
## 变更

- save_conf 改用 model_dump(exclude_unset=True)，配置文件只保留用户配置过的键，未配置字段不再落盘。
- 就位旧键→新键迁移钩子：exipring_medicine_on_weekend 只在用户配置过时搬运到 expiring_medicine_on_weekend，没配过就不写新键、不注入默认值；新旧并存时以新键为准。迁移放在 Conf 的 before-validator 里统一处理，旧配置文件与旧前端提交（/conf POST 带旧键名）都走同一套兼容，不会因旧键名被当未知键忽略而把新键重置成默认。旧键名拼写有误，消费方（operation / base_schedule / 前端两块 / 对应测试）一并改到新键名。
- 根因说明：ConfModel.nested_defaults 这个 before-validator 把每个默认值都注入输入数据，使 pydantic 认为所有字段都被设置——只把 save_conf 改成 exclude_unset=True 不会生效。改为让 pydantic 用默认值原生补齐：16 个原本必填的嵌套模型字段加 default_factory，并用 validate_default=True 兜住 maa_weekly_plan 这类默认值是 dict 列表的字段（否则不会转成模型实例、weekly_plan_loader 会解析失败），删除注入默认值的逻辑。

## 限制

- 通过 /conf（POST）保存时前端会把整个配置对象一并提交；新前端带新键名可正常保存，旧前端提交里若仍带旧键名则由 Conf 校验层迁移过来。旧前端若因读不到新键名而在提交里完全省略该字段，后端全量替换 conf 时该字段会落默认值——这属于前端版本落后，无法在不破坏 exclude_unset 的前提下由后端兜回。本次改动覆盖「旧键名仍出现在提交里」的情况。

## 验证

- 新增 config_tests：exclude_unset 保存行为 + 旧键迁移（含「没配过旧键不写新键」「新旧并存以新键为准」「/conf POST 带旧键名在校验层兼容」）。
- 全量 1166 通过、6 skip、1 既有环境失败（socksio 未安装，与本改动无关）；ruff lint + format 全过。