### PR TITLE
fix(update): 修复源码更新与资源版本在 Windows 中文环境下的异常

### DIFF
--- a/arknights_mower/tests/res_version_tests.py
+++ b/arknights_mower/tests/res_version_tests.py
@@ -126,6 +126,24 @@ class TestContentHash(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             content_hash(self.dir, [Path("nope.bin")])
 
+    def test_文本后缀按换行归一化(self):
+        # 文本类型（.json）在任何检出下 LF/CRLF 应得到同一摘要，Windows/CI 一致
+        rel = Path("data.json")
+        (self.dir / rel).write_bytes(b'{"a":1}\r\n{"b":2}\r\n')
+        h_crlf = content_hash(self.dir, [rel])
+        (self.dir / rel).write_bytes(b'{"a":1}\n{"b":2}\n')
+        h_lf = content_hash(self.dir, [rel])
+        self.assertEqual(h_crlf, h_lf)
+
+    def test_二进制后缀不过换行归一化(self):
+        # 非文本类型即便不含 NUL 也按原始字节参与，内容不同的二进制样例不致同摘要
+        rel = Path("blob.bin")
+        (self.dir / rel).write_bytes(b"a\r\nb\r\n")
+        h_crlf = content_hash(self.dir, [rel])
+        (self.dir / rel).write_bytes(b"a\nb\n")
+        h_lf = content_hash(self.dir, [rel])
+        self.assertNotEqual(h_crlf, h_lf)
+
 
 class TestPackageFilePaths(unittest.TestCase):
     def setUp(self):

--- a/arknights_mower/tests/update_runtime_tests.py
+++ b/arknights_mower/tests/update_runtime_tests.py
@@ -1,0 +1,87 @@
+"""update_runtime 的边界用例：代理大小写、登记文件瞬时读取、原子替换重试、子进程编码。"""
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from arknights_mower.utils import update_runtime as runtime
+
+
+class LaunchEnvironmentProxyTests(unittest.TestCase):
+    def test_小写优先并清重复大写(self):
+        # POSIX 风格环境里大小写并存且值不同，小写应生效，大写副本被清除
+        base = {"http_proxy": "http://lower", "HTTP_PROXY": "http://upper", "A": "1"}
+        with mock.patch.object(runtime.os, "environ", base):
+            env = runtime.launch_environment({})
+        self.assertEqual(env["http_proxy"], "http://lower")
+        self.assertNotIn("HTTP_PROXY", env)
+
+    def test_windows仅大写时归一到小写(self):
+        # Windows 的 os._Environ 会把键名归一成大写，复制后需还原成小写
+        base = {"HTTPS_PROXY": "http://p", "A": "1"}
+        with mock.patch.object(runtime.os, "environ", base):
+            env = runtime.launch_environment({})
+        self.assertEqual(env["https_proxy"], "http://p")
+        self.assertNotIn("HTTPS_PROXY", env)
+
+    def test_子进程编码固定utf8(self):
+        with mock.patch.object(runtime.os, "environ", {}):
+            env = runtime.launch_environment({})
+        self.assertEqual(env["PYTHONIOENCODING"], "utf-8")
+
+
+class InstancesTransientReadTests(unittest.TestCase):
+    def test_瞬时读取失败不删活跃登记(self):
+        with TemporaryDirectory() as d:
+            state = Path(d)
+            (state / "instances").mkdir()
+            reg = state / "instances" / "abc.json"
+            reg.write_text(json.dumps({"pid": os.getpid(), "kind": "instance"}))
+            # 登记文件正被并发写者替换，读取瞬时抛 OSError（共享违规/锁）
+            with mock.patch.object(runtime.json, "loads", side_effect=OSError("lock")):
+                got = runtime.instances(state)
+            self.assertEqual(got, [])
+            self.assertTrue(reg.exists())  # 不得误删活进程的登记
+
+    def test_死进程登记被清理(self):
+        with TemporaryDirectory() as d:
+            state = Path(d)
+            (state / "instances").mkdir()
+            reg = state / "instances" / "dead.json"
+            reg.write_text(json.dumps({"pid": 2**31 - 1, "kind": "instance"}))
+            got = runtime.instances(state)
+            self.assertEqual(got, [])
+            self.assertFalse(reg.exists())
+
+
+class ReplaceWithRetryTests(unittest.TestCase):
+    def test_win32共享违规重试后成功(self):
+        # replace_with_retry 的重试分支只在 win32 触发；把 platform 固定到 win32，
+        # 让该测试在 Windows 与 Linux/CI 上都走同一条重试路径。
+        with mock.patch.object(runtime.sys, "platform", "win32"):
+            with TemporaryDirectory() as d:
+                src, dst = Path(d) / "src", Path(d) / "dst"
+                src.write_text("x")
+                real_replace = os.replace
+                calls = {"n": 0}
+
+                def flaky(source, destination):
+                    calls["n"] += 1
+                    if calls["n"] == 1:
+                        err = OSError("sharing violation")
+                        err.winerror = 32
+                        raise err
+                    real_replace(source, destination)
+
+                with mock.patch.object(runtime.os, "replace", flaky):
+                    runtime.replace_with_retry(src, dst)
+                self.assertEqual(calls["n"], 2)
+                self.assertTrue(dst.exists())
+                self.assertEqual(dst.read_text(), "x")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/utils/res_version.py
+++ b/arknights_mower/utils/res_version.py
@@ -61,9 +61,9 @@ def package_file_paths(root) -> list:
 def content_hash(root, rels) -> str:
     """对相对路径文件集算聚合 sha256（含路径，结果与顺序无关）。
 
-    Windows 检出（core.autocrlf）会把文本文件的 LF 转成 CRLF。文本文件按
-    git 自身判断文本的启发式（无 NUL 字节）归一化到 LF，使摘要在任何检出下
-    与打包内容一致；二进制文件按原字节参与。分块读取避免一次载入整文件。
+    Windows 检出（core.autocrlf）会把文本文件的 LF 转成 CRLF。明确判定为文本的
+    文件（见 _TEXT_SUFFIXES）归一化到 LF，使摘要在任何检出下与打包内容一致；
+    二进制文件一律按原始字节参与。分块读取避免一次载入整文件。
     """
     root = Path(root)
     digest = hashlib.sha256()
@@ -71,18 +71,33 @@ def content_hash(root, rels) -> str:
         digest.update(rel.as_posix().encode("utf-8"))
         digest.update(b"\0")
         with open(root / rel, "rb") as f:
-            normalize = not _contains_nul(f)
-            f.seek(0)
-            _update_digest(digest, f, normalize)
+            _update_digest(digest, f, _is_text(rel))
     return digest.hexdigest()
 
 
-def _contains_nul(stream) -> bool:
-    """Whether the stream contains a NUL byte, matching git's text heuristic."""
-    while chunk := stream.read(1 << 20):
-        if b"\0" in chunk:
-            return True
-    return False
+# 文本后缀：仅这些类型会在 Git 检出时把 LF 转成 CRLF，才值得归一化。二进制文件
+# 一律按原始字节参与——仅凭「无 NUL 字节」误判为文本，会让两份内容不同的二进制
+# 样例被换行归一化后得到相同摘要。
+_TEXT_SUFFIXES = frozenset(
+    {
+        ".json",
+        ".txt",
+        ".js",
+        ".jsx",
+        ".ts",
+        ".tsx",
+        ".css",
+        ".html",
+        ".md",
+        ".yaml",
+        ".yml",
+    }
+)
+
+
+def _is_text(rel) -> bool:
+    """Whether ``rel`` names a text file whose line endings Git may rewrite."""
+    return Path(rel).suffix.lower() in _TEXT_SUFFIXES
 
 
 def _update_digest(digest, stream, normalize: bool) -> None:

--- a/arknights_mower/utils/resource_pkg.py
+++ b/arknights_mower/utils/resource_pkg.py
@@ -39,6 +39,7 @@ from arknights_mower.utils.resource_store import (
     select_resource,
     validate_package,
 )
+from arknights_mower.utils.update_runtime import replace_with_retry
 from arknights_mower.utils.zip_safe import is_unsafe_zip_member
 
 RESOURCE_OVERLAY = get_path("@app/resources", space="")
@@ -123,7 +124,9 @@ def _write_index(packages):
     temporary = RESOURCE_OVERLAY / f".index-{uuid4().hex}.json"
     try:
         temporary.write_text(json.dumps({"packages": packages}), encoding="utf-8")
-        os.replace(temporary, RESOURCE_OVERLAY / "index.json")
+        # index.json is also walked by a server-side watchdog; tolerate the
+        # transient lock a concurrent reader keeps on it (see replace_with_retry).
+        replace_with_retry(temporary, RESOURCE_OVERLAY / "index.json")
     finally:
         temporary.unlink(missing_ok=True)
 

--- a/arknights_mower/utils/update_runtime.py
+++ b/arknights_mower/utils/update_runtime.py
@@ -57,12 +57,12 @@ def write_json(path, value):
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
             json.dump(value, stream, ensure_ascii=False)
-        _replace_with_retry(temporary, path)
+        replace_with_retry(temporary, path)
     finally:
         Path(temporary).unlink(missing_ok=True)
 
 
-def _replace_with_retry(source, destination):
+def replace_with_retry(source, destination):
     """Atomically replace ``destination``, tolerating transient Windows locks.
 
     ``os.replace`` is atomic, but on Windows it fails with a sharing violation
@@ -172,7 +172,17 @@ def instances(directory=None):
     directory = Path(directory or state_dir())
     result = []
     for path in (directory / "instances").glob("*.json"):
-        record = read_json(path, {})
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except OSError:
+            # A concurrent writer may be mid-replace (see replace_with_retry);
+            # a transient read failure must not be mistaken for a stale record,
+            # or a live instance's registration would be deleted.
+            continue
+        except ValueError:
+            # Unparsable JSON is never a live registration (its heartbeat
+            # rewrites valid JSON every second), so treat it as stale.
+            record = {}
         if record and process_alive(record.get("pid")):
             result.append(record)
         else:
@@ -307,15 +317,20 @@ def launch_environment(record, job_id="", background=False):
         else:
             env.pop(name, None)
     # os._Environ normalizes variable names to uppercase on Windows, so a plain
-    # copy can change the casing of proxy variables. Normalize them to lowercase
-    # so subprocesses and callers see a deterministic environment on every platform.
+    # copy can change the casing of proxy variables. Prefer the lowercase value
+    # (requests reads lowercase first) and drop any uppercase duplicate, so a
+    # child starts with exactly one deterministic value on every platform.
     for name in ("http_proxy", "https_proxy", "all_proxy", "no_proxy"):
-        matched = next((key for key in env if key.lower() == name), None)
-        if matched is not None:
-            if matched != name:
-                env[name] = env.pop(matched)
-        else:
-            env.pop(name, None)
+        lower = env.pop(name, None)
+        upper = env.pop(name.upper(), None)
+        value = lower if lower is not None else upper
+        if value is not None:
+            env[name] = value
+    # A child's stdout is captured into logs that are always decoded as UTF-8
+    # (for example update/restart log). Pin its stdio encoding regardless of the
+    # console codepage (Chinese Windows defaults to GBK) so those logs do not
+    # come back garbled.
+    env["PYTHONIOENCODING"] = "utf-8"
     env.update(
         MOWER_RESTART_JOB=job_id,
         MOWER_BACKGROUND="1" if background else "0",


### PR DESCRIPTION
## 目标

#968（54eb1ed1）合入后复查发现，源码更新与资源版本在 Windows 中文环境下还有四处会出错。本次作为后续修复直接落在 alpha 之上，不改变任何功能，也不改写既有历史。

## 主要改动

- 代理配置可能被大写项覆盖。当大小写两套代理变量并存时，原逻辑可能先取到大写项并覆盖生效的小写值，用户设置的代理因此失效。改为小写优先，并删除多余的大写项。
- 更新可能遗漏仍在运行的实例。实例登记文件在 Windows 上被占用时读不到内容，原逻辑误判为实例已死而删除，导致该实例不被更新。改为读取失败时跳过，确认已死才删除。资源索引替换同样会遇到占用，改为带重试的原子替换，避免安装失败。
- 更新子进程日志在中文 Windows 下乱码。子进程按 GBK 输出，读取日志时按 UTF-8 解码。改为启动子进程时统一固定 UTF-8 输出。
- 内容不同的二进制文件可能算出同一资源哈希。原逻辑以内容是否含 NUL 字节判断文本，导致不含 NUL 的二进制文件被误做换行归一化。改为只对明确的文本类型（如 `.json`）归一化，二进制一律按原始字节计算。

## 验证与风险

- 新增故障注入单元测试，覆盖代理大小写、登记文件瞬时读取失败、原子替换重试与子进程 UTF-8 编码。
- 重跑受影响的相关测试模块全部通过；资源版本哈希保持不变（未改动 `version.json`），无兼容性风险。
- 改动集中在更新子系统与资源版本模块，属边际行为修复，不触及既有主流程、配置格式或外部接口。
