### PR TITLE
feat(window-shell): 将 Windows 端窗口改为无边框自绘标题栏并保留原生缩放

### DIFF
--- a/arknights_mower/tests/webview_ui_tests.py
+++ b/arknights_mower/tests/webview_ui_tests.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from arknights_mower import __version__
 from arknights_mower.utils.config import gui
+from arknights_mower.utils.window_shell import WindowRatio
 from webview_ui import (
     _LINUX_WEBVIEW_INSTALL_HINT,
     DEFAULT_WINDOW_SIZE,
@@ -95,27 +96,27 @@ class TestResolveWindowSize(unittest.TestCase):
         self.assertEqual(resolve_window_size(float("inf"), 850), DEFAULT_WINDOW_SIZE)
 
 
-class TestGuiWindowSize(unittest.TestCase):
+class TestGuiWindowRatio(unittest.TestCase):
     def test_missing_file_returns_none(self):
-        # gui.yml 还不存在（首次运行）→ 返回 None，由调用方兜底默认尺寸。
+        # gui.yml 还不存在（首次运行）→ 返回 None，由调用方兜底默认比例。
         with tempfile.TemporaryDirectory() as d:
             with mock.patch.object(gui, "gui_path", Path(d) / "gui.yml"):
-                self.assertIsNone(gui.load_window_size())
+                self.assertIsNone(gui.load_window_ratio())
 
     def test_save_then_load_roundtrip(self):
-        # 存进去的尺寸能原样读回，验证读写都落在 gui.yml 上。
+        # 存进去的比例能原样读回，验证读写都落在 gui.yml 上。
         with tempfile.TemporaryDirectory() as d:
             with mock.patch.object(gui, "gui_path", Path(d) / "gui.yml"):
-                gui.save_window_size((1600, 900))
-                self.assertEqual(gui.load_window_size(), (1600, 900))
+                gui.save_window_ratio(WindowRatio(0.6, 0.5))
+                self.assertEqual(gui.load_window_ratio(), WindowRatio(0.6, 0.5))
 
     def test_corrupt_content_returns_none(self):
         # 内容非法（宽为非数字）→ 返回 None，不把坏值传出去。
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / "gui.yml"
-            p.write_text("width: abc\nheight: 900\n", encoding="utf-8")
+            p.write_text("ratio:\n  width: abc\n  height: 900\n", encoding="utf-8")
             with mock.patch.object(gui, "gui_path", p):
-                self.assertIsNone(gui.load_window_size())
+                self.assertIsNone(gui.load_window_ratio())
 
 
 class TestWindowTitle(unittest.TestCase):

--- a/arknights_mower/utils/config/gui.py
+++ b/arknights_mower/utils/config/gui.py
@@ -12,27 +12,37 @@ import yaml
 from yamlcore import CoreDumper, CoreLoader
 
 from arknights_mower.utils.config import atomic_write, gui_path
+from arknights_mower.utils.window_shell import WindowRatio
 
 
-def load_window_size():
-    """读取窗口尺寸；文件缺失或内容非法时返回 None，由调用方兜底默认值。"""
+def load_window_ratio() -> WindowRatio | None:
+    """读取窗口尺寸占屏幕工作区的比例（width/height 各一个 0~3 之间的数）。
+
+    存比例而不是绝对像素：窗口大小是设备相关的配置，换电脑/换分辨率时绝对像素
+    会不匹配；比例则始终按当前屏幕换算。文件缺失或内容非法返回 None。
+    """
     if not gui_path.is_file():
         return None
     try:
         with gui_path.open("r", encoding="utf-8") as f:
             data = yaml.load(f, Loader=CoreLoader) or {}
-        return (int(data["width"]), int(data["height"]))
+        ratio = data["ratio"]
+        width = float(ratio["width"])
+        height = float(ratio["height"])
+        if not (0 < width <= 3 and 0 < height <= 3):
+            return None
+        return WindowRatio(width, height)
     except (OSError, TypeError, KeyError, ValueError):
         return None
 
 
-def save_window_size(size):
-    """写入窗口尺寸（调用方已消毒，保证非法尺寸不进盘）。"""
-    width, height = size
+def save_window_ratio(ratio: WindowRatio) -> None:
+    """写入窗口尺寸比例（调用方已消毒，非法值不进盘），走原子写。"""
+    width, height = ratio.width, ratio.height
 
     def dump(f):
         yaml.dump(
-            {"width": width, "height": height},
+            {"ratio": {"width": width, "height": height}},
             f,
             Dumper=CoreDumper,
             encoding="utf-8",

--- a/arknights_mower/utils/window_shell.py
+++ b/arknights_mower/utils/window_shell.py
@@ -1,0 +1,300 @@
+import json
+import logging
+import platform
+from threading import Lock
+from typing import Any, NamedTuple
+
+WINDOW_SHELL_PROTOCOL = "mower-window-shell-v1"
+WINDOW_SHELL_EVENT = "mower-window-state"
+
+
+class WindowSize(NamedTuple):
+    """A desktop window footprint in logical pixels."""
+
+    width: int
+    height: int
+
+
+class WindowRatio(NamedTuple):
+    """A desktop window footprint as a fraction of the screen work area."""
+
+    width: float
+    height: float
+
+
+DESKTOP_WINDOW_WIDTH = 1450
+DESKTOP_WINDOW_HEIGHT = 850
+DESKTOP_WINDOW_MIN_SIZE = WindowSize(1024, 640)
+DESKTOP_WINDOW_TITLEBAR_HEIGHT = 36
+DESKTOP_WINDOW_CONTROLS_WIDTH = 46 * 3
+DESKTOP_WINDOW_SIDEBAR_CONTROL_WIDTH = 44
+
+_SPI_GETWORKAREA = 0x0030
+
+_BACKGROUND_COLORS = {
+    "light": "#FAF9F7",
+    "dark": "#18181C",
+}
+
+logger = logging.getLogger(__name__)
+
+# Cached after the first successful probe: it is read before the window exists
+# (the process is not yet DPI-aware, so Windows returns *logical* pixels), and
+# every later open/save sizing reuses that same logical area instead of
+# re-probing under a has-changed DPI-awareness and mixing logical with physical.
+_WORK_AREA_CACHE: WindowSize | None = None
+
+
+def window_background_color(theme: str) -> str:
+    return _BACKGROUND_COLORS.get(theme, _BACKGROUND_COLORS["light"])
+
+
+def is_windows(system: str | None = None) -> bool:
+    """True when the running (or supplied) platform resolves to Windows."""
+    return normalize_platform(system) == "windows"
+
+
+def window_dpi_scale(hwnd: int) -> float:
+    """Return the display scale factor (1.0, 1.25, 1.5, ...) for a native window handle.
+
+    ``GetDpiForWindow`` only exists on Windows 10 1607+, and the process reports a
+    meaningful DPI only once it is DPI-aware, so callers read this after the window
+    exists. A missing API or a failed probe resolves to a neutral scale of 1.0.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        get_dpi = getattr(ctypes.windll.user32, "GetDpiForWindow", None)
+        if get_dpi is None:
+            return 1.0
+        get_dpi.argtypes = [wintypes.HWND]
+        get_dpi.restype = wintypes.UINT
+        raw = int(get_dpi(hwnd))
+        return max(raw / 96.0, 1.0) if raw else 1.0
+    except Exception:
+        return 1.0
+
+
+def _screen_work_area() -> WindowSize | None:
+    """Primary display work area; None when it cannot be detected."""
+    global _WORK_AREA_CACHE
+    if _WORK_AREA_CACHE is not None:
+        return _WORK_AREA_CACHE
+    try:
+        if is_windows():
+            import ctypes
+            from ctypes import wintypes
+
+            rect = wintypes.RECT()
+            if ctypes.windll.user32.SystemParametersInfoW(
+                _SPI_GETWORKAREA, 0, ctypes.byref(rect), 0
+            ):
+                width = rect.right - rect.left
+                height = rect.bottom - rect.top
+                if width > 0 and height > 0:
+                    _WORK_AREA_CACHE = WindowSize(width, height)
+                    return _WORK_AREA_CACHE
+        else:
+            import tkinter as tk
+
+            root = tk.Tk()
+            try:
+                root.withdraw()
+                width = root.winfo_screenwidth()
+                height = root.winfo_screenheight()
+            finally:
+                root.destroy()
+            if width > 0 and height > 0:
+                _WORK_AREA_CACHE = WindowSize(width, height)
+                return _WORK_AREA_CACHE
+    except Exception:
+        pass
+    return None
+
+
+def configured_desktop_window_size(size: WindowSize) -> WindowSize:
+    """Return the configured startup size within the shell minimum and the display."""
+    min_size = DESKTOP_WINDOW_MIN_SIZE
+    work_area = _screen_work_area()
+    if work_area:
+        max_width, max_height = work_area.width, work_area.height
+    else:
+        max_width = max_height = float("inf")
+    return WindowSize(
+        min(max(int(size.width), min_size.width), max_width),
+        min(max(int(size.height), min_size.height), max_height),
+    )
+
+
+def default_desktop_window_size() -> WindowSize:
+    """Return the default startup footprint for the shell within the display."""
+    return configured_desktop_window_size(
+        WindowSize(DESKTOP_WINDOW_WIDTH, DESKTOP_WINDOW_HEIGHT)
+    )
+
+
+def window_size_from_ratio(ratio: WindowRatio) -> WindowSize:
+    """Derive a logical window size from a fraction of the screen work area, then
+    clamp it to the shell minimum and the current display. A user-stored ratio is
+    kept proportional, so a window enlarged on a large display round-trips on the
+    next launch instead of snapping back to the fixed default footprint."""
+    work_area = _screen_work_area()
+    if work_area:
+        width = round(work_area.width * ratio.width)
+        height = round(work_area.height * ratio.height)
+    else:
+        width, height = DESKTOP_WINDOW_WIDTH, DESKTOP_WINDOW_HEIGHT
+    return configured_desktop_window_size(WindowSize(width, height))
+
+
+def ratio_from_window_size(size: WindowSize) -> WindowRatio | None:
+    """Fraction of the screen work area the window currently occupies; None when
+    the work area cannot be detected (caller then keeps the previous value)."""
+    work_area = _screen_work_area()
+    if not work_area or work_area.width <= 0 or work_area.height <= 0:
+        return None
+    return WindowRatio(size.width / work_area.width, size.height / work_area.height)
+
+
+def normalize_platform(system: str | None = None) -> str:
+    current = (system or platform.system()).lower()
+    return {
+        "windows": "windows",
+        "darwin": "macos",
+        "macos": "macos",
+        "linux": "linux",
+    }.get(current, "unsupported")
+
+
+class WindowShellBridge:
+    """The complete and intentionally small API exposed to the desktop WebUI."""
+
+    def __init__(
+        self,
+        window: Any,
+        system: str | None = None,
+        initial_size: WindowSize = WindowSize(
+            DESKTOP_WINDOW_WIDTH, DESKTOP_WINDOW_HEIGHT
+        ),
+    ):
+        self._window = window
+        self._platform = normalize_platform(system)
+        self._lock = Lock()
+        self._state = {
+            "state": "normal",
+            "maximized": False,
+            "minimized": False,
+            "width": initial_size.width,
+            "height": initial_size.height,
+        }
+
+    def minimize(self) -> bool:
+        return self._call_window("minimize")
+
+    def maximize(self) -> bool:
+        return self._call_window("maximize")
+
+    def restore(self) -> bool:
+        return self._call_window("restore")
+
+    def close(self) -> bool:
+        # The custom titlebar follows direct-close behavior for this iteration;
+        # the existing tray lifecycle remains owned by webview_ui.
+        self._window.confirm_close = False
+        return self._call_window("destroy")
+
+    def start_resize(self, edge: str) -> bool:
+        if self._platform != "windows":
+            return False
+        try:
+            from arknights_mower.utils.windows_frameless import (
+                begin_windows_resize,
+            )
+
+            return begin_windows_resize(self._window, edge)
+        except Exception:
+            logger.exception("Desktop window resize could not start: %s", edge)
+            return False
+
+    def get_window_state(self) -> dict[str, Any]:
+        with self._lock:
+            return {"protocol": WINDOW_SHELL_PROTOCOL, **self._state}
+
+    def get_platform(self) -> dict[str, str]:
+        return {
+            "protocol": WINDOW_SHELL_PROTOCOL,
+            "event": WINDOW_SHELL_EVENT,
+            "platform": self._platform,
+        }
+
+    def _call_window(self, method_name: str) -> bool:
+        try:
+            getattr(self._window, method_name)()
+            return True
+        except Exception:
+            logger.exception("Desktop window command failed: %s", method_name)
+            return False
+
+    def _set_native_state(self, state: str) -> None:
+        with self._lock:
+            self._state.update(
+                state=state,
+                maximized=state == "maximized",
+                minimized=state == "minimized",
+            )
+        self._publish_state()
+
+    def _on_maximized(self) -> None:
+        self._set_native_state("maximized")
+
+    def _on_minimized(self) -> None:
+        self._set_native_state("minimized")
+
+    def _on_restored(self) -> None:
+        self._set_native_state("normal")
+
+    def _on_resized(self, width: int, height: int) -> None:
+        with self._lock:
+            self._state.update(width=int(width), height=int(height))
+        self._publish_state()
+
+    def _publish_state(self) -> None:
+        payload = json.dumps(self.get_window_state(), ensure_ascii=False)
+        event_name = json.dumps(WINDOW_SHELL_EVENT)
+        script = (
+            f"window.dispatchEvent(new CustomEvent({event_name}, "
+            f"{{ detail: {payload} }}));"
+        )
+        try:
+            self._window.evaluate_js(script)
+        except Exception:
+            # Native state remains authoritative even if the page is still
+            # loading or has already gone away.
+            logger.debug("Window state event could not be delivered", exc_info=True)
+
+
+def attach_window_shell(
+    window: Any,
+    system: str | None = None,
+    initial_size: WindowSize = WindowSize(DESKTOP_WINDOW_WIDTH, DESKTOP_WINDOW_HEIGHT),
+) -> WindowShellBridge:
+    bridge = WindowShellBridge(window, system, initial_size)
+
+    # pywebview 5.1 Window.expose only serializes the functions passed here.
+    # Never pass the bridge or Window object itself to js_api.
+    window.expose(
+        bridge.minimize,
+        bridge.maximize,
+        bridge.restore,
+        bridge.close,
+        bridge.start_resize,
+        bridge.get_window_state,
+        bridge.get_platform,
+    )
+
+    window.events.maximized += bridge._on_maximized
+    window.events.minimized += bridge._on_minimized
+    window.events.restored += bridge._on_restored
+    window.events.resized += bridge._on_resized
+    return bridge

--- a/arknights_mower/utils/windows_frameless.py
+++ b/arknights_mower/utils/windows_frameless.py
@@ -1,0 +1,543 @@
+"""Small WinForms adaptation that restores OS-owned frameless resizing.
+
+pywebview 5.1 sets ``FormBorderStyle.None`` for frameless windows, which removes
+the native resize frame. This module keeps the window border visually absent,
+but restores the standard sizing styles and returns native non-client hit-test
+codes at the window edges. Windows still owns the resize loop, DPI handling,
+cursor feedback, snapping, and multi-monitor interaction.
+"""
+
+import ctypes
+import logging
+from ctypes import wintypes
+from typing import Any
+
+from arknights_mower.utils.window_shell import (
+    DESKTOP_WINDOW_CONTROLS_WIDTH,
+    DESKTOP_WINDOW_SIDEBAR_CONTROL_WIDTH,
+    DESKTOP_WINDOW_TITLEBAR_HEIGHT,
+    WindowSize,
+    is_windows,
+    window_dpi_scale,
+)
+
+logger = logging.getLogger(__name__)
+
+_hooks: dict[str, tuple[Any, ...]] = {}
+
+_WS_THICKFRAME = 0x00040000
+_WS_MINIMIZEBOX = 0x00020000
+_WS_MAXIMIZEBOX = 0x00010000
+_WS_SYSMENU = 0x00080000
+_WS_CAPTION = 0x00C00000
+
+_WM_NCLBUTTONDOWN = 0x00A1
+
+_SWP_NOMOVE = 0x0002
+_SWP_NOZORDER = 0x0004
+_SWP_NOACTIVATE = 0x0010
+_SWP_FRAMECHANGED = 0x0020
+
+_MONITOR_DEFAULTTONEAREST = 2
+
+_WINDOWS_FRAMELESS_ERROR = "pywebview WinForms window is not available"
+
+
+def _winforms_window(window: Any):
+    """Return the pywebview WinForms BrowserView that backs *window*."""
+    from webview.platforms import winforms
+
+    form = winforms.BrowserView.instances.get(window.uid)
+    if form is None:
+        raise RuntimeError(_WINDOWS_FRAMELESS_ERROR)
+    return form
+
+
+def _winforms_hwnd(window: Any) -> int:
+    """Return the native Win32 handle for *window*'s WinForms form."""
+    return int(_winforms_window(window).Handle.ToInt64())
+
+
+def _user32() -> ctypes.WinDLL:
+    return ctypes.WinDLL("user32", use_last_error=True)
+
+
+_RESIZE_EDGE_HIT_TEST = {
+    "left": 10,
+    "right": 11,
+    "top": 12,
+    "top-left": 13,
+    "top-right": 14,
+    "bottom": 15,
+    "bottom-left": 16,
+    "bottom-right": 17,
+}
+
+
+def frameless_window_style(style: int) -> int:
+    """Keep native window operations without restoring the painted caption shell."""
+    return (style & ~_WS_CAPTION) | (
+        _WS_THICKFRAME | _WS_MINIMIZEBOX | _WS_MAXIMIZEBOX | _WS_SYSMENU
+    )
+
+
+def begin_windows_resize(window: Any, edge: str) -> bool:
+    """Start the native sizing loop from an in-window HTML edge grip."""
+    hit_test = _RESIZE_EDGE_HIT_TEST.get(edge)
+    if not is_windows() or hit_test is None:
+        return False
+
+    form = _winforms_window(window)
+    hwnd = int(form.Handle.ToInt64())
+    user32 = _user32()
+    user32.ReleaseCapture.argtypes = []
+    user32.ReleaseCapture.restype = wintypes.BOOL
+    user32.GetCursorPos.argtypes = [ctypes.POINTER(_POINT)]
+    user32.GetCursorPos.restype = wintypes.BOOL
+    user32.SendMessageW.argtypes = [
+        wintypes.HWND,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+    ]
+    user32.SendMessageW.restype = ctypes.c_ssize_t
+
+    def start_native_resize() -> bool:
+        point = _POINT()
+        if not user32.GetCursorPos(ctypes.byref(point)):
+            raise ctypes.WinError(ctypes.get_last_error())
+        user32.ReleaseCapture()
+        position = ((point.y & 0xFFFF) << 16) | (point.x & 0xFFFF)
+        user32.SendMessageW(hwnd, _WM_NCLBUTTONDOWN, hit_test, position)
+        return True
+
+    if form.InvokeRequired:
+        from System import Boolean, Func
+
+        return bool(form.Invoke(Func[Boolean](start_native_resize)))
+    return start_native_resize()
+
+
+class _POINT(ctypes.Structure):
+    _fields_ = [("x", wintypes.LONG), ("y", wintypes.LONG)]
+
+
+class _RECT(ctypes.Structure):
+    _fields_ = [
+        ("left", wintypes.LONG),
+        ("top", wintypes.LONG),
+        ("right", wintypes.LONG),
+        ("bottom", wintypes.LONG),
+    ]
+
+
+class _MINMAXINFO(ctypes.Structure):
+    _fields_ = [
+        ("ptReserved", _POINT),
+        ("ptMaxSize", _POINT),
+        ("ptMaxPosition", _POINT),
+        ("ptMinTrackSize", _POINT),
+        ("ptMaxTrackSize", _POINT),
+    ]
+
+
+class _MONITORINFO(ctypes.Structure):
+    _fields_ = [
+        ("cbSize", wintypes.DWORD),
+        ("rcMonitor", _RECT),
+        ("rcWork", _RECT),
+        ("dwFlags", wintypes.DWORD),
+    ]
+
+
+def install_windows_frameless_resize(
+    window: Any,
+    initial_size: WindowSize,
+    min_size: WindowSize,
+) -> bool:
+    if not is_windows():
+        return False
+    layout_refreshed = False
+
+    def install_after_show() -> None:
+        try:
+            _install_hook(window, initial_size, min_size)
+        except Exception:
+            logger.exception("Failed to install Windows frameless resize support")
+
+    def refresh_after_load() -> None:
+        nonlocal layout_refreshed
+        if layout_refreshed:
+            return
+        try:
+            _refresh_webview_layout(window)
+            layout_refreshed = True
+        except Exception:
+            logger.exception(
+                "Failed to refresh the WebView layout after startup sizing"
+            )
+
+    window.events.shown += install_after_show
+    window.events.loaded += refresh_after_load
+    return True
+
+
+def _refresh_webview_layout(window: Any) -> None:
+    """Make WebView2 consume the DPI-corrected outer size after navigation.
+
+    pywebview 5.1 creates the WebView2 controller before the frameless form is
+    calibrated to its requested logical size. On a scaled display the control
+    can retain its smaller pre-calibration surface until the next user resize.
+    A one-physical-pixel native resize, immediately restored, lets WinForms
+    perform its normal DockStyle.Fill layout after WebView2 is ready.
+    """
+    hwnd = _winforms_hwnd(window)
+    user32 = _user32()
+    user32.GetWindowRect.argtypes = [wintypes.HWND, ctypes.POINTER(_RECT)]
+    user32.GetWindowRect.restype = wintypes.BOOL
+    user32.SetWindowPos.argtypes = [
+        wintypes.HWND,
+        wintypes.HWND,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        wintypes.UINT,
+    ]
+    user32.SetWindowPos.restype = wintypes.BOOL
+    rect = _RECT()
+    if not user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    width = rect.right - rect.left
+    height = rect.bottom - rect.top
+    swp_flags = _SWP_NOMOVE | _SWP_NOZORDER | _SWP_NOACTIVATE
+    if not user32.SetWindowPos(hwnd, None, 0, 0, width + 1, height, swp_flags):
+        raise ctypes.WinError(ctypes.get_last_error())
+    if not user32.SetWindowPos(hwnd, None, 0, 0, width, height, swp_flags):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _install_hook(
+    window: Any,
+    initial_size: WindowSize,
+    min_size: WindowSize,
+) -> None:
+    hwnd = _winforms_hwnd(window)
+    user32 = _user32()
+    long_ptr = ctypes.c_ssize_t
+    wnd_proc_type = ctypes.WINFUNCTYPE(
+        long_ptr,
+        wintypes.HWND,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+    )
+
+    get_window_long = user32.GetWindowLongPtrW
+    get_window_long.argtypes = [wintypes.HWND, ctypes.c_int]
+    get_window_long.restype = long_ptr
+
+    set_window_long = user32.SetWindowLongPtrW
+    set_window_long.argtypes = [wintypes.HWND, ctypes.c_int, long_ptr]
+    set_window_long.restype = long_ptr
+
+    call_window_proc = user32.CallWindowProcW
+    call_window_proc.argtypes = [
+        long_ptr,
+        wintypes.HWND,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+    ]
+    call_window_proc.restype = long_ptr
+
+    user32.GetWindowRect.argtypes = [wintypes.HWND, ctypes.POINTER(_RECT)]
+    user32.GetWindowRect.restype = wintypes.BOOL
+    user32.IsZoomed.argtypes = [wintypes.HWND]
+    user32.IsZoomed.restype = wintypes.BOOL
+    user32.IsIconic.argtypes = [wintypes.HWND]
+    user32.IsIconic.restype = wintypes.BOOL
+    user32.MonitorFromWindow.argtypes = [wintypes.HWND, wintypes.DWORD]
+    user32.MonitorFromWindow.restype = wintypes.HMONITOR
+    user32.GetMonitorInfoW.argtypes = [wintypes.HMONITOR, ctypes.POINTER(_MONITORINFO)]
+    user32.GetMonitorInfoW.restype = wintypes.BOOL
+    user32.GetSystemMetrics.argtypes = [ctypes.c_int]
+    user32.GetSystemMetrics.restype = ctypes.c_int
+    user32.SetWindowPos.argtypes = [
+        wintypes.HWND,
+        wintypes.HWND,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        wintypes.UINT,
+    ]
+    user32.SetWindowPos.restype = wintypes.BOOL
+    user32.PostMessageW.argtypes = [
+        wintypes.HWND,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+    ]
+    user32.PostMessageW.restype = wintypes.BOOL
+    get_dpi_for_window = getattr(user32, "GetDpiForWindow", None)
+    if get_dpi_for_window is not None:
+        get_dpi_for_window.argtypes = [wintypes.HWND]
+        get_dpi_for_window.restype = wintypes.UINT
+
+    gwlp_wndproc = -4
+    gwl_style = -16
+    wm_nccalcsize = 0x0083
+    wm_nchittest = 0x0084
+    wm_getminmaxinfo = 0x0024
+    wm_ncdestroy = 0x0082
+    wm_size = 0x0005
+    wm_windowposchanged = 0x0047
+    wm_restore_normal_rect = 0x8001  # WM_APP + 1
+
+    size_restored = 0
+    size_maximized = 2
+
+    htclient = 1
+    htcaption = 2
+
+    sm_cxsizeframe = 32
+    sm_cysizeframe = 33
+    sm_cxpaddedborder = 92
+
+    def window_scale() -> float:
+        return window_dpi_scale(hwnd)
+
+    def system_metric(metric: int) -> int:
+        metric_for_dpi = getattr(user32, "GetSystemMetricsForDpi", None)
+        if get_dpi_for_window is not None and metric_for_dpi is not None:
+            metric_for_dpi.argtypes = [ctypes.c_int, wintypes.UINT]
+            metric_for_dpi.restype = ctypes.c_int
+            return int(metric_for_dpi(metric, get_dpi_for_window(hwnd)))
+        return int(user32.GetSystemMetrics(metric))
+
+    def hit_test(l_param: int) -> int:
+        rect = _RECT()
+        if not user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+            return htclient
+
+        x = ctypes.c_short(l_param & 0xFFFF).value
+        y = ctypes.c_short((l_param >> 16) & 0xFFFF).value
+        border_x = system_metric(sm_cxsizeframe) + system_metric(sm_cxpaddedborder)
+        border_y = system_metric(sm_cysizeframe) + system_metric(sm_cxpaddedborder)
+
+        maximized = bool(user32.IsZoomed(hwnd))
+        left = not maximized and rect.left <= x < rect.left + border_x
+        right = not maximized and rect.right - border_x <= x < rect.right
+        top = not maximized and rect.top <= y < rect.top + border_y
+        bottom = not maximized and rect.bottom - border_y <= y < rect.bottom
+
+        if top and left:
+            return _RESIZE_EDGE_HIT_TEST["top-left"]
+        if top and right:
+            return _RESIZE_EDGE_HIT_TEST["top-right"]
+        if bottom and left:
+            return _RESIZE_EDGE_HIT_TEST["bottom-left"]
+        if bottom and right:
+            return _RESIZE_EDGE_HIT_TEST["bottom-right"]
+        if left:
+            return _RESIZE_EDGE_HIT_TEST["left"]
+        if right:
+            return _RESIZE_EDGE_HIT_TEST["right"]
+        if top:
+            return _RESIZE_EDGE_HIT_TEST["top"]
+        if bottom:
+            return _RESIZE_EDGE_HIT_TEST["bottom"]
+        scale = window_scale()
+        in_titlebar = y < rect.top + round(DESKTOP_WINDOW_TITLEBAR_HEIGHT * scale)
+        after_sidebar_control = x >= rect.left + round(
+            DESKTOP_WINDOW_SIDEBAR_CONTROL_WIDTH * scale
+        )
+        before_controls = x < rect.right - round(DESKTOP_WINDOW_CONTROLS_WIDTH * scale)
+        if in_titlebar and after_sidebar_control and before_controls:
+            return htcaption
+        return htclient
+
+    def constrain_maximized_bounds(l_param: int) -> None:
+        minmax = ctypes.cast(l_param, ctypes.POINTER(_MINMAXINFO)).contents
+        scale = window_scale()
+        minmax.ptMinTrackSize.x = round(min_size.width * scale)
+        minmax.ptMinTrackSize.y = round(min_size.height * scale)
+
+        monitor = user32.MonitorFromWindow(hwnd, _MONITOR_DEFAULTTONEAREST)
+        if not monitor:
+            return
+        info = _MONITORINFO(cbSize=ctypes.sizeof(_MONITORINFO))
+        if not user32.GetMonitorInfoW(monitor, ctypes.byref(info)):
+            return
+
+        minmax.ptMaxPosition.x = info.rcWork.left - info.rcMonitor.left
+        minmax.ptMaxPosition.y = info.rcWork.top - info.rcMonitor.top
+        minmax.ptMaxSize.x = info.rcWork.right - info.rcWork.left
+        minmax.ptMaxSize.y = info.rcWork.bottom - info.rcWork.top
+
+    original_proc = get_window_long(hwnd, gwlp_wndproc)
+    normal_rect: _RECT | None = None
+    was_maximized = False
+    restore_pending = False
+
+    @wnd_proc_type
+    def window_proc(
+        message_hwnd: int,
+        message: int,
+        w_param: int,
+        l_param: int,
+    ) -> int:
+        nonlocal normal_rect, restore_pending, was_maximized
+        try:
+            if message == wm_restore_normal_rect:
+                if normal_rect is not None:
+                    width = normal_rect.right - normal_rect.left
+                    height = normal_rect.bottom - normal_rect.top
+                    user32.SetWindowPos(
+                        hwnd,
+                        None,
+                        normal_rect.left,
+                        normal_rect.top,
+                        width,
+                        height,
+                        _SWP_NOZORDER | _SWP_NOACTIVATE,
+                    )
+                restore_pending = False
+                return 0
+            # Keep the WebView client flush with the real outer window. DWM
+            # still owns clipping, shadow and the single outer corner.
+            if message == wm_nccalcsize:
+                return 0
+            if message == wm_nchittest:
+                result = hit_test(l_param)
+                if result != htclient:
+                    return result
+            if message == wm_getminmaxinfo:
+                call_window_proc(original_proc, message_hwnd, message, w_param, l_param)
+                constrain_maximized_bounds(l_param)
+                return 0
+            if message == wm_size:
+                result = call_window_proc(
+                    original_proc, message_hwnd, message, w_param, l_param
+                )
+                if w_param == size_maximized:
+                    was_maximized = True
+                elif w_param == size_restored and was_maximized:
+                    restore_pending = True
+                    was_maximized = False
+                    user32.PostMessageW(hwnd, wm_restore_normal_rect, 0, 0)
+                return result
+            if message == wm_windowposchanged:
+                result = call_window_proc(
+                    original_proc, message_hwnd, message, w_param, l_param
+                )
+                if (
+                    not user32.IsZoomed(hwnd)
+                    and not user32.IsIconic(hwnd)
+                    and not was_maximized
+                    and not restore_pending
+                ):
+                    rect = _RECT()
+                    if user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+                        normal_rect = rect
+                return result
+            if message == wm_ncdestroy:
+                result = call_window_proc(
+                    original_proc, message_hwnd, message, w_param, l_param
+                )
+                _hooks.pop(window.uid, None)
+                return result
+        except Exception:
+            logger.exception("Windows frameless message handling failed")
+        return call_window_proc(original_proc, message_hwnd, message, w_param, l_param)
+
+    ctypes.set_last_error(0)
+    previous_proc = set_window_long(
+        hwnd,
+        gwlp_wndproc,
+        ctypes.cast(window_proc, ctypes.c_void_p).value,
+    )
+    if not previous_proc and ctypes.get_last_error():
+        raise ctypes.WinError(ctypes.get_last_error())
+    # Keep the delegate alive as soon as Win32 owns its function pointer. If a
+    # later sizing call fails, garbage-collecting it would leave a dangling
+    # WNDPROC on a still-live window.
+    _hooks[window.uid] = (window_proc, original_proc)
+
+    original_rect = _RECT()
+    if not user32.GetWindowRect(hwnd, ctypes.byref(original_rect)):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    style = get_window_long(hwnd, gwl_style)
+    ctypes.set_last_error(0)
+    previous_style = set_window_long(
+        hwnd,
+        gwl_style,
+        frameless_window_style(style),
+    )
+    if not previous_style and ctypes.get_last_error():
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    scale = window_scale()
+    target_width = round(initial_size.width * scale)
+    target_height = round(initial_size.height * scale)
+    target_left = (
+        original_rect.left
+        + (original_rect.right - original_rect.left - target_width) // 2
+    )
+    target_top = (
+        original_rect.top
+        + (original_rect.bottom - original_rect.top - target_height) // 2
+    )
+    swp_flags = _SWP_NOZORDER | _SWP_NOACTIVATE | _SWP_FRAMECHANGED
+    if not user32.SetWindowPos(
+        hwnd,
+        None,
+        target_left,
+        target_top,
+        target_width,
+        target_height,
+        swp_flags,
+    ):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    # SWP_FRAMECHANGED rebuilds the non-client frame. Apply the final DWM
+    # policy afterwards: one system-owned outer corner and no painted border.
+    _apply_dwm_window_chrome(hwnd)
+
+
+def _apply_dwm_window_chrome(hwnd: int) -> None:
+    """Let DWM clip one real outer corner without painting another frame."""
+    try:
+        dwmapi = ctypes.WinDLL("dwmapi", use_last_error=True)
+        set_attribute = dwmapi.DwmSetWindowAttribute
+        set_attribute.argtypes = [
+            wintypes.HWND,
+            wintypes.DWORD,
+            ctypes.c_void_p,
+            wintypes.DWORD,
+        ]
+        set_attribute.restype = ctypes.c_long
+        attributes = (
+            (33, wintypes.DWORD(2)),  # DWMWA_WINDOW_CORNER_PREFERENCE: ROUND
+            (34, wintypes.DWORD(0xFFFFFFFE)),  # DWMWA_BORDER_COLOR: COLOR_NONE
+        )
+        for attribute, value in attributes:
+            result = set_attribute(
+                hwnd,
+                attribute,
+                ctypes.byref(value),
+                ctypes.sizeof(value),
+            )
+            if result:
+                logger.debug(
+                    "DWM frame color attribute %s is not supported (HRESULT %#x)",
+                    attribute,
+                    result & 0xFFFFFFFF,
+                )
+    except (AttributeError, OSError):
+        # These attributes are available on Windows 11. Older supported
+        # systems keep their normal compositor-owned rendering.
+        logger.debug("DWM window chrome policy is not supported", exc_info=True)

--- a/server.py
+++ b/server.py
@@ -913,6 +913,11 @@ def _request_title_refresh():
         conn.send(("title", current))
     except Exception:
         logger.exception("通知 WebView 刷新窗口标题失败")
+    for ws in list(ws_connections):
+        try:
+            ws.send(json.dumps({"type": "resource_updated"}))
+        except Exception:
+            logger.exception("广播资源版本变更给前端失败")
 
 
 def conn_send(text):

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -4,10 +4,36 @@
     :date-locale="dateZhCN"
     class="provider"
     :theme="theme == 'dark' ? darkTheme : undefined"
+    :theme-overrides="theme == 'dark' ? mowerDarkThemeOverrides : mowerLightThemeOverrides"
     :hljs="hljs"
-    style="user-select: none"
+    :style="{
+      userSelect: 'none',
+      ...(theme === 'dark' ? mowerDarkCssVariables : mowerLightCssVariables)
+    }"
+    :class="{
+      'provider--dark': theme === 'dark',
+      'provider--window-shell': windowShellActive
+    }"
   >
     <n-global-style />
+    <WindowTitlebar
+      :active="windowShellActive"
+      :title="windowShellTitle"
+      :version="windowTitleVersion"
+      :instance-name="windowShell.metadata.instanceName || '默认实例'"
+      :theme="theme"
+      :control-side="windowShellControlSide"
+      :maximized="windowShellState.maximized"
+      :controls="windowShellControls"
+      :busy="windowShellBusy"
+      :mower-port="mowerPort"
+      :emulator-name="emulatorName"
+      :adb-port="adbPort"
+      :on-control="windowShell.runControl"
+      :on-toggle-maximize="windowShell.toggleMaximize"
+      :resizable="windowShellPlatform === 'windows' && !windowShellState.maximized"
+      :on-resize="windowShell.startResize"
+    />
     <n-dialog-provider>
       <n-message-provider>
         <n-loading-bar-provider>
@@ -23,14 +49,19 @@
             :y-offset="60"
             :rotate="-15"
           />
-          <n-layout :has-sider="!mobile" class="outer-layout">
+          <n-layout
+            :has-sider="!mobile"
+            class="outer-layout"
+            :class="{ 'outer-layout--collapsed': sidebarCollapsed }"
+          >
             <n-layout-sider
               v-if="!mobile"
-              bordered
+              :bordered="!windowShellActive"
               collapse-mode="width"
               :collapsed-width="64"
               :width="210"
-              show-trigger
+              v-model:collapsed="sidebarCollapsed"
+              :show-trigger="!windowShellActive"
             >
               <n-menu
                 :indent="24"
@@ -73,6 +104,22 @@
                 </div>
               </n-modal>
             </n-layout-content>
+            <template v-if="windowShellActive && !mobile">
+              <div class="sider-fade-zone" @mousedown.stop @click="toggleSidebar">
+                <div
+                  class="sider-fade-btn"
+                  :class="{ 'sider-fade-btn--collapsed': sidebarCollapsed }"
+                  aria-hidden="true"
+                >
+                  <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M5.64645 3.14645C5.45118 3.34171 5.45118 3.65829 5.64645 3.85355L9.79289 8L5.64645 12.1464C5.45118 12.3417 5.45118 12.6583 5.64645 12.8536C5.84171 13.0488 6.15829 13.0488 6.35355 12.8536L10.8536 8.35355C11.0488 8.15829 11.0488 7.84171 10.8536 7.64645L6.35355 3.14645C6.15829 2.95118 5.84171 2.95118 5.64645 3.14645Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </template>
             <n-layout-footer v-if="mobile">
               <n-tabs type="line" justify-content="space-evenly" size="small">
                 <n-tab name="日志" @click="$router.push('/')">
@@ -211,16 +258,53 @@ import RoseOutline from '@vicons/ionicons5/RoseOutline'
 import Coffee from '@vicons/tabler/Coffee'
 import { NIcon } from 'naive-ui'
 import { storeToRefs } from 'pinia'
-import { computed, defineAsyncComponent, h, inject, onMounted, provide, ref, watch } from 'vue'
+import {
+  computed,
+  defineAsyncComponent,
+  h,
+  inject,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  provide,
+  ref,
+  watch
+} from 'vue'
 import Feedback from '@/components/Feedback.vue'
 import GlobalUpdateDrop from '@/components/GlobalUpdateDrop.vue'
+import WindowTitlebar from '@/components/WindowTitlebar.vue'
+import {
+  mowerDarkCssVariables,
+  mowerDarkThemeOverrides,
+  mowerLightCssVariables,
+  mowerLightThemeOverrides
+} from '@/theme/mower'
+import '@/theme/mower.css'
+import { createWindowShellAdapter, formatWindowTitle } from '@/window-shell/adapter.js'
+import { installModalDragging } from '@/utils/modal-drag.js'
 
 const ChatBot = defineAsyncComponent(() => import('@/components/ChatBot.vue'))
+const windowShell = createWindowShellAdapter()
+const {
+  active: windowShellActive,
+  busy: windowShellBusy,
+  controls: windowShellControls,
+  controlSide: windowShellControlSide,
+  platform: windowShellPlatform,
+  state: windowShellState
+} = windowShell
+
+let disposeModalDrag = null
 
 const showModal = ref(false)
 const showModal2 = ref(false)
 const showFeedback = ref(false)
+const sidebarCollapsed = ref(false)
 provide('show_feedback', showFeedback)
+provide('sidebar_collapsed', sidebarCollapsed)
+function toggleSidebar() {
+  sidebarCollapsed.value = !sidebarCollapsed.value
+}
 function renderIcon(icon) {
   return () => h(NIcon, null, { default: () => h(icon) })
 }
@@ -386,8 +470,77 @@ const {
   simulator,
   start_automatically,
   theme,
-  webview
+  webview,
+  adb
 } = storeToRefs(config_store)
+let activeThemeTransition = null
+
+async function setThemeWithTransition(nextTheme) {
+  if (nextTheme === theme.value) return
+
+  const root = document.documentElement
+  const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+  root.classList.add('mower-theme-changing')
+
+  if (!reduceMotion && typeof document.startViewTransition === 'function') {
+    activeThemeTransition?.skipTransition?.()
+    const transition = document.startViewTransition(async () => {
+      theme.value = nextTheme
+      await nextTick()
+    })
+    activeThemeTransition = transition
+    try {
+      await transition.ready.catch(() => {})
+    } finally {
+      if (activeThemeTransition === transition) {
+        root.classList.remove('mower-theme-changing')
+      }
+    }
+    void transition.finished
+      .catch(() => {})
+      .finally(() => {
+        if (activeThemeTransition === transition) activeThemeTransition = null
+      })
+    return
+  }
+
+  const provider = document.querySelector('.provider')
+  if (!reduceMotion && provider?.animate) {
+    const fadeOut = provider.animate([{ opacity: 1 }, { opacity: 0.84 }], {
+      duration: 90,
+      easing: 'ease-out',
+      fill: 'forwards'
+    })
+    await fadeOut.finished.catch(() => {})
+    fadeOut.cancel()
+  }
+  theme.value = nextTheme
+  await nextTick()
+  root.classList.remove('mower-theme-changing')
+  provider?.animate?.([{ opacity: 0.84 }, { opacity: 1 }], {
+    duration: 130,
+    easing: 'ease-out'
+  })
+}
+
+provide('set_theme_with_transition', setThemeWithTransition)
+const windowShellTitle = computed(() =>
+  formatWindowTitle({
+    version: windowTitleVersion.value,
+    instanceName: windowShell.metadata.instanceName
+  })
+)
+
+// 标题栏副信息：实例@端口 与 模拟器@adb端口。实例名已写进系统窗口标题（formatWindowTitle），
+// 这里标题栏内再补两个 @端口：mower 端口 = 前端服务所在端口（webview 与后端同源），
+// adb 端口 = ADB 连接地址（形如 127.0.0.1:62001）的端口段。
+const mowerPort = computed(() => window.location.port || '')
+const emulatorName = computed(() => simulator.value?.name || '')
+const adbPort = computed(() => {
+  const addr = adb.value || ''
+  const idx = addr.lastIndexOf(':')
+  return idx === -1 ? '' : addr.slice(idx + 1)
+})
 
 const plan_store = usePlanStore()
 const { operators } = storeToRefs(plan_store)
@@ -404,6 +557,15 @@ const showUpdateNoticeModal = ref(false)
 
 const resource_version_store = useResourceVersionStore()
 const { installResource, loadResourceVersion, loadResourceJob } = resource_version_store
+// 标题栏版本：软件版固定（取启动快照的前半段），资源版实时取当前生效的资源包展示版本；
+// 资源包在别处更新时后端广播 resource_updated → loadResourceVersionLocal 刷新这里。
+const windowTitleVersion = computed(() => {
+  const snapshot = windowShell.metadata.version
+  const sep = snapshot.lastIndexOf(' - ')
+  const softVer = sep === -1 ? snapshot : snapshot.slice(0, sep)
+  const liveRes = resource_version_store.info.current_display
+  return liveRes ? `${softVer} - ${liveRes}` : softVer
+})
 
 const axios = inject('axios')
 
@@ -467,6 +629,8 @@ const operators_with_free_current = computed(() => {
 })
 
 onMounted(async () => {
+  void windowShell.initialize()
+  disposeModalDrag = installModalDragging()
   actions_on_resize()
   window.addEventListener('resize', () => {
     actions_on_resize()
@@ -588,6 +752,25 @@ onMounted(async () => {
   }
 })
 
+onBeforeUnmount(() => {
+  disposeModalDrag?.()
+  windowShell.dispose()
+  delete document.documentElement.dataset.windowShellTheme
+  delete document.documentElement.dataset.mowerTheme
+})
+
+watch(
+  [theme, loaded, windowShellActive],
+  ([currentTheme, appLoaded, shellActive]) => {
+    document.documentElement.dataset.mowerTheme = currentTheme === 'dark' ? 'dark' : 'light'
+    if (appLoaded && shellActive) {
+      document.documentElement.dataset.windowShellTheme = currentTheme === 'dark' ? 'dark' : 'light'
+      window.scrollTo(0, 0)
+    }
+  },
+  { immediate: true }
+)
+
 watch(
   () => webview.value.scale,
   () => {
@@ -629,6 +812,218 @@ watch(
   transform-origin: 0 0;
 }
 
+.provider--window-shell {
+  --window-shell-frame-surface: #faf9f7;
+  --window-shell-content-surface: #fff;
+  --window-shell-content-shadow-left: rgba(63, 55, 47, 0.13);
+  --window-shell-content-shadow-top: rgba(63, 55, 47, 0.07);
+  --window-shell-content-shadow-corner: rgba(63, 55, 47, 0.09);
+  --window-shell-scrollbar-thumb: rgba(46, 43, 40, 0.2);
+  --window-shell-scrollbar-thumb-hover: rgba(46, 43, 40, 0.34);
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  overflow: hidden;
+  background: var(--window-shell-frame-surface);
+}
+
+html[data-window-shell-theme='dark'] .provider--window-shell {
+  --window-shell-frame-surface: #18181c;
+  --window-shell-content-surface: #101014;
+  --window-shell-content-shadow-left: rgba(0, 0, 0, 0.34);
+  --window-shell-content-shadow-top: rgba(0, 0, 0, 0.2);
+  --window-shell-content-shadow-corner: rgba(0, 0, 0, 0.26);
+  --window-shell-scrollbar-thumb: rgba(255, 255, 255, 0.18);
+  --window-shell-scrollbar-thumb-hover: rgba(255, 255, 255, 0.3);
+  background: var(--window-shell-frame-surface);
+}
+
+.provider--window-shell .outer-layout {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto;
+  background: var(--window-shell-frame-surface);
+}
+
+.provider--window-shell .n-layout-sider {
+  background: var(--window-shell-frame-surface);
+}
+
+.provider--window-shell .n-layout-sider__border {
+  background: transparent;
+}
+
+.provider--window-shell .layout-content-container {
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  background: var(--window-shell-content-surface);
+  border-radius: 10px 0 0 0;
+  box-shadow:
+    -7px 0 18px -14px var(--window-shell-content-shadow-left),
+    0 -6px 16px -14px var(--window-shell-content-shadow-top),
+    -5px -5px 20px -16px var(--window-shell-content-shadow-corner);
+}
+
+/* shadcn 输入框（n-input / n-input-number）——按 shadcn Input 源码规格：
+   h-9(36px) / rounded-md(6px) / 1px border-input / bg-background / px-3 / text-sm
+   / placeholder:muted-foreground / focus-visible:ring-2 + ring-offset-2 */
+.n-input {
+  --n-height: 36px !important;
+  --n-border-radius: 6px !important;
+  --n-border: 1px solid #e4e4e7 !important;
+  --n-border-hover: 1px solid #d4d4d8 !important;
+  --n-border-focus: 1px solid #e4e4e7 !important;
+  --n-color: #ffffff !important;
+  --n-color-hover: #ffffff !important;
+  --n-color-focus: #ffffff !important;
+  --n-padding-left: 12px !important;
+  --n-padding-right: 12px !important;
+  --n-padding-vertical: 0 !important;
+  --n-text-color: #09090b !important;
+  --n-placeholder-color: #71717a !important;
+  --n-box-shadow-focus: 0 0 0 2px #ffffff, 0 0 0 4px rgba(24, 160, 88, 0.4) !important;
+}
+html[data-window-shell-theme='dark'] .n-input {
+  --n-border: 1px solid #27272a !important;
+  --n-border-hover: 1px solid #3f3f46 !important;
+  --n-border-focus: 1px solid #27272a !important;
+  --n-color: #101014 !important;
+  --n-color-hover: #101014 !important;
+  --n-color-focus: #101014 !important;
+  --n-text-color: #fafafa !important;
+  --n-placeholder-color: #71717a !important;
+  --n-box-shadow-focus: 0 0 0 2px #101014, 0 0 0 4px rgba(99, 226, 183, 0.4) !important;
+}
+
+/* shadcn 下拉选择框（n-select）：触发器 = 同款输入框盒子 + 菜单 = 圆角浮层/option 高亮 */
+.n-base-selection {
+  --n-height: 36px !important;
+  --n-border-radius: 6px !important;
+  --n-border: 1px solid #e4e4e7 !important;
+  --n-border-hover: 1px solid #d4d4d8 !important;
+  --n-border-focus: 1px solid #e4e4e7 !important;
+  --n-color: #ffffff !important;
+  --n-color-active: #ffffff !important;
+  --n-box-shadow-focus: 0 0 0 2px #ffffff, 0 0 0 4px rgba(24, 160, 88, 0.4) !important;
+  --n-text-color: #09090b !important;
+  --n-placeholder-color: #71717a !important;
+  --n-padding-single: 0 12px !important;
+  --n-font-size: 14px !important;
+}
+.n-base-select-menu {
+  --n-color: #ffffff !important;
+  --n-border-radius: 6px !important;
+  --n-option-font-size: 14px !important;
+  --n-option-color-pending: rgba(24, 160, 88, 0.08) !important;
+  --n-option-color-active: rgba(24, 160, 88, 0.1) !important;
+  --n-option-color-active-pending: rgba(24, 160, 88, 0.14) !important;
+}
+html[data-window-shell-theme='dark'] .n-base-selection {
+  --n-border: 1px solid #27272a !important;
+  --n-border-hover: 1px solid #3f3f46 !important;
+  --n-border-focus: 1px solid #27272a !important;
+  --n-color: #101014 !important;
+  --n-color-active: #101014 !important;
+  --n-text-color: #fafafa !important;
+  --n-placeholder-color: #71717a !important;
+  --n-box-shadow-focus: 0 0 0 2px #101014, 0 0 0 4px rgba(99, 226, 183, 0.4) !important;
+}
+html[data-window-shell-theme='dark'] .n-base-select-menu {
+  --n-color: #101014 !important;
+  --n-option-color-pending: rgba(99, 226, 183, 0.12) !important;
+  --n-option-color-active: rgba(99, 226, 183, 0.16) !important;
+  --n-option-color-active-pending: rgba(99, 226, 183, 0.2) !important;
+}
+
+html.mower-theme-changing *,
+html.mower-theme-changing *::before,
+html.mower-theme-changing *::after {
+  transition: none !important;
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 220ms;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  mix-blend-mode: normal;
+}
+
+::view-transition-old(root) {
+  animation-name: mower-theme-fade-out;
+}
+
+::view-transition-new(root) {
+  animation-name: mower-theme-fade-in;
+}
+
+@keyframes mower-theme-fade-out {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes mower-theme-fade-in {
+  from {
+    opacity: 0;
+  }
+}
+
+/* naive-ui 弹窗 teleport 到 <body>，不在 .provider--window-shell 内，
+   所以上面的滚动条样式和 --window-shell-scrollbar-thumb 变量都够不到它。
+   mower.css 已让 .n-modal 的卡片/对话框内容节点滚动（.n-card-content / .n-dialog__content），
+   这里把同名滚动条样式应用到这些 body 级浮层，并把变量提到 :root 兜底。 */
+:root {
+  --window-shell-scrollbar-thumb: rgba(46, 43, 40, 0.2);
+  --window-shell-scrollbar-thumb-hover: rgba(46, 43, 40, 0.34);
+}
+html[data-window-shell-theme='dark'] {
+  --window-shell-scrollbar-thumb: rgba(255, 255, 255, 0.18);
+  --window-shell-scrollbar-thumb-hover: rgba(255, 255, 255, 0.3);
+}
+
+.provider--window-shell *,
+.n-modal,
+.n-modal * {
+  scrollbar-color: var(--window-shell-scrollbar-thumb) transparent;
+  scrollbar-width: thin;
+}
+
+.provider--window-shell *::-webkit-scrollbar,
+.n-modal *::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.provider--window-shell *::-webkit-scrollbar-track,
+.provider--window-shell *::-webkit-scrollbar-corner,
+.n-modal *::-webkit-scrollbar-track,
+.n-modal *::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.provider--window-shell *::-webkit-scrollbar-thumb,
+.n-modal *::-webkit-scrollbar-thumb {
+  min-height: 36px;
+  background: var(--window-shell-scrollbar-thumb);
+  background-clip: content-box;
+  border: 3px solid transparent;
+  border-radius: 999px;
+}
+
+.provider--window-shell *::-webkit-scrollbar-thumb:hover,
+.n-modal *::-webkit-scrollbar-thumb:hover {
+  background: var(--window-shell-scrollbar-thumb-hover);
+  background-clip: content-box;
+}
+
+.provider--window-shell *::-webkit-scrollbar-button,
+.n-modal *::-webkit-scrollbar-button {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 .n-tab-pane {
   flex-grow: 1;
   display: flex;
@@ -668,7 +1063,9 @@ td {
 }
 
 .dialog-btn {
-  margin-left: 4px;
+  /* 与旁边的路径输入框（36px）对齐：高度拉到 36px；间距 8px 给输入框聚焦 ring(外扩4px) 留空档 */
+  margin-left: 8px;
+  --n-height: 36px !important;
 }
 
 .report-card {
@@ -683,7 +1080,6 @@ td {
   height: 200px;
   padding: 20px 20px 80px 20px;
   border: 1px solid #ccc;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .n-checkbox .n-checkbox__label {
@@ -694,7 +1090,67 @@ td {
 }
 
 .outer-layout {
+  position: relative;
   height: 100%;
+}
+
+/* 无边框窗口：侧栏折叠触发器，悬挂在侧栏/内容交界线上，鼠标滑到才浮现。图标为 naive 原生
+   ChevronRight（arrow-circle 触发器同款）；展开时朝左(旋转180°)、折叠时朝右。 */
+.provider--window-shell .sider-fade-zone {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 210px;
+  width: 22px;
+  transform: translateX(-50%);
+  cursor: pointer;
+  z-index: 2;
+}
+.outer-layout--collapsed .sider-fade-zone {
+  left: 64px;
+}
+.sider-fade-btn {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.07);
+  background: #fff;
+  color: #808080;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+  display: grid;
+  place-items: center;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    color 0.15s ease;
+}
+.sider-fade-zone:hover .sider-fade-btn,
+.sider-fade-btn:focus-visible {
+  opacity: 1;
+  color: #18a058;
+}
+.sider-fade-btn svg {
+  display: block;
+  width: 15px;
+  height: 15px;
+  fill: currentcolor;
+  transform: rotate(180deg);
+  transition: transform 0.2s ease;
+}
+.sider-fade-btn--collapsed svg {
+  transform: rotate(0deg);
+}
+html[data-mower-theme='dark'] .sider-fade-btn {
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgb(44, 44, 50);
+  color: rgba(255, 255, 255, 0.68);
+}
+html[data-mower-theme='dark'] .sider-fade-zone:hover .sider-fade-btn {
+  color: #63e2b7;
 }
 
 .outer-layout > .n-layout-scroll-container {

--- a/ui/src/components/WindowTitlebar.vue
+++ b/ui/src/components/WindowTitlebar.vue
@@ -1,0 +1,335 @@
+<template>
+  <header
+    v-show="active"
+    class="window-titlebar"
+    :class="[
+      `window-titlebar--controls-${controlSide}`,
+      {
+        'window-titlebar--dark': theme === 'dark',
+        'window-titlebar--maximized': maximized
+      }
+    ]"
+    data-window-shell
+  >
+    <div
+      class="window-titlebar__brand pywebview-drag-region"
+      data-window-drag-region
+      aria-hidden="true"
+      @dblclick.stop="onToggleMaximize"
+    >
+      <img class="window-titlebar__brand-mark" :src="'/favicon.ico'" alt="" />
+    </div>
+
+    <div
+      class="window-titlebar__drag-region pywebview-drag-region"
+      data-window-drag-region
+      @dblclick.stop="onToggleMaximize"
+    >
+      <span class="window-titlebar__identity" :title="title">
+        <span class="window-titlebar__product">Mower</span>
+        <span v-if="version" class="window-titlebar__version">{{ version }}</span>
+        <span class="window-titlebar__separator" aria-hidden="true">·</span>
+        <span class="window-titlebar__instance"
+          >{{ instanceName }}{{ mowerPort ? `@${mowerPort}` : '' }}</span
+        >
+        <span v-if="emulatorName" class="window-titlebar__separator" aria-hidden="true">·</span>
+        <span v-if="emulatorName" class="window-titlebar__instance"
+          >{{ emulatorName }}{{ adbPort ? `@${adbPort}` : '' }}</span
+        >
+      </span>
+    </div>
+
+    <div class="window-titlebar__controls" data-window-controls>
+      <button
+        v-for="control in controls"
+        :key="control.id"
+        class="window-titlebar__control"
+        :class="{ 'window-titlebar__control--close': control.id === 'close' }"
+        type="button"
+        :aria-label="control.label"
+        :title="control.label"
+        :data-window-control="control.id"
+        :disabled="busy[control.action || control.id]"
+        @mousedown.stop
+        @click="onControl(control.action || control.id)"
+      >
+        <svg v-if="control.icon === 'minimize'" aria-hidden="true" viewBox="0 0 16 16">
+          <path d="M3 8.5h10" />
+        </svg>
+        <svg v-else-if="control.icon === 'restore'" aria-hidden="true" viewBox="0 0 16 16">
+          <path d="M5.5 5.5h7v7h-7z" />
+          <path d="M3.5 10.5h-1v-7h7v1" />
+        </svg>
+        <svg v-else-if="control.icon === 'maximize'" aria-hidden="true" viewBox="0 0 16 16">
+          <rect x="3" y="3" width="10" height="10" rx="0.5" />
+        </svg>
+        <svg v-else aria-hidden="true" viewBox="0 0 16 16">
+          <path d="m4 4 8 8M12 4l-8 8" />
+        </svg>
+      </button>
+    </div>
+
+    <template v-if="resizable">
+      <div
+        v-for="edge in resizeEdges"
+        :key="edge"
+        class="window-titlebar__resize-grip"
+        :data-window-resize-edge="edge"
+        aria-hidden="true"
+        @mousedown.left.prevent.stop="onResize(edge)"
+      ></div>
+    </template>
+  </header>
+</template>
+
+<script setup>
+import { WINDOW_RESIZE_EDGES } from '@/window-shell/adapter.js'
+
+const resizeEdges = WINDOW_RESIZE_EDGES
+
+defineProps({
+  active: { type: Boolean, required: true },
+  title: { type: String, required: true },
+  version: { type: String, required: true },
+  instanceName: { type: String, required: true },
+  theme: { type: String, required: true },
+  controlSide: { type: String, required: true },
+  maximized: { type: Boolean, required: true },
+  controls: { type: Array, required: true },
+  busy: { type: Object, required: true },
+  mowerPort: { type: String, default: '' },
+  emulatorName: { type: String, default: '' },
+  adbPort: { type: String, default: '' },
+  onControl: { type: Function, required: true },
+  onToggleMaximize: { type: Function, required: true },
+  resizable: { type: Boolean, required: true },
+  onResize: { type: Function, required: true }
+})
+</script>
+
+<style scoped>
+.window-titlebar {
+  --window-titlebar-text: #302e2c;
+  --window-titlebar-muted: #817d78;
+  --window-titlebar-control: #242220;
+  --window-titlebar-hover: rgba(40, 37, 35, 0.07);
+  --window-titlebar-pressed: rgba(40, 37, 35, 0.12);
+  --window-titlebar-focus: #18a058;
+  display: flex;
+  flex: 0 0 36px;
+  align-items: stretch;
+  width: 100%;
+  height: 36px;
+  min-width: 0;
+  color: var(--window-titlebar-text);
+  background: transparent;
+  border: 0;
+  box-sizing: border-box;
+  user-select: none;
+}
+
+.window-titlebar--dark {
+  --window-titlebar-text: rgba(255, 255, 255, 0.88);
+  --window-titlebar-muted: rgba(255, 255, 255, 0.52);
+  --window-titlebar-control: rgba(255, 255, 255, 0.9);
+  --window-titlebar-hover: rgba(255, 255, 255, 0.08);
+  --window-titlebar-pressed: rgba(255, 255, 255, 0.13);
+  --window-titlebar-focus: #63c38a;
+}
+
+.window-titlebar__drag-region {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  min-width: 0;
+  height: 100%;
+  padding: 0 18px 0 4px;
+  box-sizing: border-box;
+}
+
+.window-titlebar__identity {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  gap: 7px;
+  line-height: 1;
+}
+
+.window-titlebar__product {
+  flex: 0 0 auto;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--window-titlebar-text);
+}
+
+.window-titlebar__version {
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--window-titlebar-muted);
+}
+
+.window-titlebar__separator {
+  flex: 0 0 auto;
+  color: var(--window-titlebar-muted);
+}
+
+.window-titlebar__instance {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--window-titlebar-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.window-titlebar__controls {
+  display: flex;
+  flex: 0 0 auto;
+  height: 100%;
+}
+
+.window-titlebar--controls-start .window-titlebar__controls {
+  order: -1;
+}
+
+.window-titlebar__brand,
+.window-titlebar__control {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: 46px;
+  height: 100%;
+  padding: 0;
+  color: var(--window-titlebar-control);
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  appearance: none;
+}
+
+.window-titlebar__brand {
+  flex: 0 0 44px;
+  width: 44px;
+  display: inline-grid;
+  place-items: center;
+}
+
+.window-titlebar__control:hover:not(:disabled) {
+  background: var(--window-titlebar-hover);
+}
+
+.window-titlebar__control:active:not(:disabled) {
+  background: var(--window-titlebar-pressed);
+}
+
+.window-titlebar__control:focus-visible {
+  outline: 2px solid var(--window-titlebar-focus);
+  outline-offset: -3px;
+}
+
+.window-titlebar__control:disabled {
+  cursor: default;
+  opacity: 0.42;
+}
+
+.window-titlebar__control--close:hover:not(:disabled),
+.window-titlebar__control--close:focus-visible {
+  color: #fff;
+  background: #c94b52;
+}
+
+.window-titlebar__control--close:active:not(:disabled) {
+  color: #fff;
+  background: #b33e45;
+}
+
+.window-titlebar__control svg {
+  width: 13px;
+  height: 13px;
+  overflow: visible;
+  fill: none;
+  stroke: currentcolor;
+  stroke-linecap: square;
+  stroke-linejoin: miter;
+  stroke-width: 1.25;
+  vector-effect: non-scaling-stroke;
+}
+
+.window-titlebar__brand-mark {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+  pointer-events: none;
+}
+
+.window-titlebar__resize-grip {
+  position: fixed;
+  z-index: 10000;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge='top'],
+.window-titlebar__resize-grip[data-window-resize-edge='bottom'] {
+  right: 10px;
+  left: 10px;
+  height: 6px;
+  cursor: ns-resize;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge='top'] {
+  top: 0;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge='bottom'] {
+  bottom: 0;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge='left'],
+.window-titlebar__resize-grip[data-window-resize-edge='right'] {
+  top: 10px;
+  bottom: 10px;
+  width: 6px;
+  cursor: ew-resize;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge='left'] {
+  left: 0;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge='right'] {
+  right: 0;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge^='top-'],
+.window-titlebar__resize-grip[data-window-resize-edge^='bottom-'] {
+  width: 10px;
+  height: 10px;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge^='top-'] {
+  top: 0;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge^='bottom-'] {
+  bottom: 0;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge$='-left'] {
+  left: 0;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge$='-right'] {
+  right: 0;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge='top-left'],
+.window-titlebar__resize-grip[data-window-resize-edge='bottom-right'] {
+  cursor: nwse-resize;
+}
+
+.window-titlebar__resize-grip[data-window-resize-edge='top-right'],
+.window-titlebar__resize-grip[data-window-resize-edge='bottom-left'] {
+  cursor: nesw-resize;
+}
+</style>

--- a/ui/src/stores/mower.js
+++ b/ui/src/stores/mower.js
@@ -48,6 +48,16 @@ export const useMowerStore = defineStore('mower', () => {
       const data = JSON.parse(event.data)
       if (data.type === 'log') {
         log_lines.value = log_lines.value.concat(data.data.split('\n')).slice(-100) // 追加日志
+        if (data.screenshot) {
+          sc_uri.value = data.screenshot
+        }
+      } else if (data.type === 'resource_updated') {
+        // 资源包在别处被更新（安装/共享资源/手动上传）时，让标题栏的资源版本实时刷新
+        import('@/stores/resourceVersion')
+          .then(({ useResourceVersionStore }) =>
+            useResourceVersionStore().loadResourceVersionLocal()
+          )
+          .catch(() => {})
       }
     }
   }

--- a/ui/src/theme/mower.css
+++ b/ui/src/theme/mower.css
@@ -1,0 +1,157 @@
+.provider,
+:root {
+  --mower-segment-rail: #efefed;
+  --mower-segment-active: #ffffff;
+  --mower-segment-muted: rgba(31, 30, 28, 0.5);
+  --mower-segment-border: rgba(55, 49, 43, 0.09);
+  --mower-segment-rail-shadow: inset 0 1px 3px rgba(55, 49, 43, 0.11),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.72);
+  --mower-segment-capsule-shadow: inset 0 0 0 1px rgba(55, 49, 43, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.88), 0 1px 3px rgba(55, 49, 43, 0.13),
+    0 4px 10px -7px rgba(55, 49, 43, 0.32);
+}
+
+html[data-mower-theme='dark'],
+html[data-mower-theme='dark'] .provider {
+  --mower-segment-rail: rgb(24, 24, 28);
+  --mower-segment-active: rgb(49, 49, 55);
+  --mower-segment-muted: rgba(255, 255, 255, 0.48);
+  --mower-segment-border: rgba(255, 255, 255, 0.08);
+  --mower-segment-rail-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.68),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.06);
+  --mower-segment-capsule-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.07),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 3px rgba(0, 0, 0, 0.52),
+    0 4px 12px -7px rgba(0, 0, 0, 0.78);
+}
+
+.provider .n-card:not(.n-card--embedded),
+.provider .n-checkbox-box,
+.provider .mower-surface-panel {
+  box-shadow: none;
+}
+
+/* 实色按钮（非 text/ghost）加一档 shadcn `shadow-xs` 轻阴影；text/ghost 按钮不加。
+   默认按钮的可见边框由主题 Button.border 给出（1px solid border），这里只管阴影。 */
+.provider .n-button:not(.n-button--text):not(.n-button--ghost) {
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+}
+html[data-mower-theme='dark'] .provider .n-button:not(.n-button--text):not(.n-button--ghost) {
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.25);
+}
+
+/* shadcn `focus-visible:ring-[3px]` 绿色聚焦环（与输入框聚焦一致），叠加在轻阴影之上 */
+.provider .n-button:not(.n-button--text):not(.n-button--ghost):focus-visible {
+  outline: none;
+  box-shadow:
+    0 1px 2px 0 rgba(0, 0, 0, 0.08),
+    0 0 0 3px rgba(24, 160, 88, 0.2);
+}
+html[data-mower-theme='dark']
+  .provider
+  .n-button:not(.n-button--text):not(.n-button--ghost):focus-visible {
+  box-shadow:
+    0 1px 2px 0 rgba(0, 0, 0, 0.4),
+    0 0 0 3px rgba(99, 226, 183, 0.2);
+}
+
+.provider .n-data-table,
+.provider .n-table,
+.provider .n-list,
+.provider .n-upload-dragger {
+  border-radius: 10px;
+}
+
+.provider .n-collapse-item {
+  padding: 0 12px;
+  border-radius: 8px;
+  background: var(--mower-control-surface);
+}
+
+.provider .n-collapse-item + .n-collapse-item {
+  margin-top: 8px;
+}
+
+.provider .mower-surface-panel {
+  border-radius: 12px;
+  background: var(--mower-surface);
+}
+
+#app .n-tabs.n-tabs--segment-type .n-tabs-capsule {
+  border: 1px solid var(--mower-segment-border);
+  background: var(--mower-segment-active);
+  box-shadow: var(--mower-segment-capsule-shadow);
+}
+
+#app .n-tabs.n-tabs--segment-type .n-tabs-rail {
+  padding: 3px;
+  border-radius: 10px;
+  background: var(--mower-segment-rail);
+  box-shadow: var(--mower-segment-rail-shadow);
+}
+
+#app .n-tabs.n-tabs--segment-type .n-tabs-tab:not(.n-tabs-tab--active) {
+  color: var(--mower-segment-muted);
+}
+
+/* Cap the modal panel to the app viewport. We deliberately do NOT set
+   `overflow: hidden` on the panel itself: naive-ui teleports inner popovers
+   (select menus, tooltips, …) into the panel root, so an `overflow` there would
+   clip them — the "dropdown hidden behind the modal wall" symptom. The panel
+   keeps its height cap; content scrolls inside `.n-card-content`/`.n-dialog__content`
+   below, which is a separate node, so popovers still fly above it. */
+.n-modal {
+  max-width: calc(var(--app-width, 100vw) - 48px);
+  max-height: calc(var(--app-height, 100dvh) - 48px);
+}
+
+.n-modal.n-card,
+.n-modal.n-dialog {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.n-modal.n-card > .n-card-header,
+.n-modal.n-card > .n-card__footer,
+.n-modal.n-card > .n-card__action,
+.n-modal.n-dialog > .n-dialog__title,
+.n-modal.n-dialog > .n-dialog__action {
+  flex: 0 0 auto;
+}
+
+.n-modal.n-card > .n-card-content,
+.n-modal.n-dialog > .n-dialog__content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+.provider .n-divider:not(.n-divider--vertical) {
+  width: calc(100% - 32px);
+  margin-right: 16px;
+  margin-left: 16px;
+}
+
+.provider .n-divider:not(.n-divider--vertical) .n-divider__line {
+  height: 1px;
+}
+
+.provider .n-input.mower-input--underline {
+  overflow: hidden;
+  border-radius: var(--n-border-radius);
+  background-color: transparent;
+  border-bottom: 1px solid color-mix(in srgb, currentcolor 18%, transparent);
+  box-shadow: none;
+}
+
+.provider .n-input.mower-input--underline .n-input__border,
+.provider .n-input.mower-input--underline .n-input__state-border {
+  display: none;
+}
+
+.provider .n-input.mower-input--underline.n-input--focus {
+  border-bottom-color: var(--n-caret-color);
+}

--- a/ui/src/theme/mower.js
+++ b/ui/src/theme/mower.js
@@ -1,0 +1,503 @@
+const transparentBorder = '1px solid transparent'
+
+const sharedCommon = {
+  borderRadius: '6px',
+  borderRadiusSmall: '4px',
+  fontWeightStrong: '600'
+}
+
+function createMowerTheme(palette) {
+  // shadcn `outline` 变体的默认按钮：给普通（无 type）按钮 1px 可见边框，
+  // 让它不再是无边框的浅灰平铺块。primary 系列保留透明边框（实心绿不要边）。
+  const defaultBorder = `1px solid ${palette.border}`
+  return {
+    common: {
+      ...sharedCommon,
+      primaryColor: palette.primary,
+      primaryColorHover: palette.primaryHover,
+      primaryColorPressed: palette.primaryPressed,
+      primaryColorSuppl: palette.primarySuppl,
+      successColor: palette.success,
+      successColorHover: palette.successHover,
+      successColorPressed: palette.successPressed,
+      successColorSuppl: palette.successSuppl,
+      warningColor: palette.warning,
+      warningColorHover: palette.warningHover,
+      warningColorPressed: palette.warningPressed,
+      warningColorSuppl: palette.warningSuppl,
+      errorColor: palette.error,
+      errorColorHover: palette.errorHover,
+      errorColorPressed: palette.errorPressed,
+      errorColorSuppl: palette.errorSuppl,
+      infoColor: palette.info,
+      infoColorHover: palette.infoHover,
+      infoColorPressed: palette.infoPressed,
+      infoColorSuppl: palette.infoSuppl,
+      bodyColor: palette.page,
+      cardColor: palette.surface,
+      modalColor: palette.surfaceRaised,
+      popoverColor: palette.popover,
+      inputColor: palette.input,
+      actionColor: palette.control,
+      hoverColor: palette.controlHover,
+      pressedColor: palette.controlPressed,
+      borderColor: palette.border,
+      dividerColor: palette.divider,
+      tableColor: palette.surface,
+      tableHeaderColor: palette.tableHeader,
+      tableColorStriped: palette.tableStriped,
+      tabColor: palette.tab,
+      boxShadow1: palette.shadowSmall,
+      boxShadow2: palette.shadowMedium,
+      boxShadow3: palette.shadowLarge
+    },
+    Layout: {
+      color: palette.page,
+      colorEmbedded: palette.control,
+      headerColor: palette.surface,
+      siderColor: palette.sider,
+      footerColor: palette.surface,
+      headerBorderColor: 'transparent',
+      siderBorderColor: 'transparent',
+      footerBorderColor: 'transparent'
+    },
+    Button: {
+      borderRadiusTiny: '3px',
+      borderRadiusSmall: '4px',
+      borderRadiusMedium: '6px',
+      borderRadiusLarge: '8px',
+      border: defaultBorder,
+      borderFocus: defaultBorder,
+      borderHover: defaultBorder,
+      borderPressed: defaultBorder,
+      borderDisabled: defaultBorder,
+      color: palette.control,
+      colorFocus: palette.controlHover,
+      colorHover: palette.controlHover,
+      colorPressed: palette.controlPressed,
+      borderPrimary: transparentBorder,
+      borderFocusPrimary: transparentBorder,
+      borderHoverPrimary: transparentBorder,
+      borderPressedPrimary: transparentBorder,
+      colorPrimary: palette.accent,
+      colorFocusPrimary: palette.accentHover,
+      colorHoverPrimary: palette.accentHover,
+      colorPressedPrimary: palette.accentPressed,
+      rippleColorPrimary: palette.accentPressed,
+      textColorPrimary: palette.accentText,
+      textColorFocusPrimary: palette.accentText,
+      textColorHoverPrimary: palette.accentText,
+      textColorPressedPrimary: palette.accentText
+    },
+    Card: {
+      color: palette.cardBlock,
+      colorEmbedded: palette.control,
+      actionColor: palette.control,
+      borderColor: 'transparent',
+      borderRadius: '12px',
+      closeBorderRadius: '6px',
+      boxShadow: 'none'
+    },
+    Dialog: {
+      border: transparentBorder,
+      borderRadius: '12px',
+      closeBorderRadius: '6px',
+      color: palette.surfaceRaised
+    },
+    Modal: {
+      boxShadow: palette.shadowLarge
+    },
+    Drawer: {
+      borderRadius: '12px',
+      closeBorderRadius: '6px',
+      boxShadow: palette.shadowLarge
+    },
+    Input: {
+      border: transparentBorder,
+      borderDisabled: transparentBorder,
+      borderFocus: transparentBorder,
+      borderHover: transparentBorder,
+      borderRadius: '6px',
+      boxShadowFocus: palette.focusShadow,
+      color: palette.control,
+      colorDisabled: palette.controlDisabled,
+      colorFocus: palette.controlFocus,
+      caretColor: palette.primary
+    },
+    Checkbox: {
+      border: transparentBorder,
+      borderChecked: transparentBorder,
+      borderDisabled: transparentBorder,
+      borderDisabledChecked: transparentBorder,
+      borderFocus: transparentBorder,
+      boxShadowFocus: palette.focusShadow,
+      borderRadius: '3px',
+      color: palette.control,
+      colorChecked: palette.accent,
+      colorDisabled: palette.controlDisabled,
+      colorDisabledChecked: palette.controlDisabled,
+      checkMarkColor: palette.accentText
+    },
+    Radio: {
+      buttonBorderRadius: '6px',
+      color: palette.control,
+      colorActive: palette.accent,
+      dotColorActive: palette.accentText,
+      boxShadow: `inset 0 0 0 1px ${palette.border}`,
+      boxShadowHover: `inset 0 0 0 1px ${palette.primary}`,
+      boxShadowActive: 'none',
+      boxShadowFocus: palette.focusShadow
+    },
+    Switch: {
+      railBorderRadiusSmall: '9px',
+      railBorderRadiusMedium: '11px',
+      railBorderRadiusLarge: '13px',
+      buttonBorderRadiusSmall: '7px',
+      buttonBorderRadiusMedium: '9px',
+      buttonBorderRadiusLarge: '11px',
+      railColor: palette.controlPressed,
+      railColorActive: palette.accent,
+      buttonColor: palette.surfaceRaised,
+      buttonBoxShadow: 'none',
+      boxShadowFocus: palette.focusShadow,
+      textColor: palette.accentText
+    },
+    Select: {
+      menuBoxShadow: palette.shadowMedium
+    },
+    AutoComplete: {
+      menuBoxShadow: palette.shadowMedium
+    },
+    Tag: {
+      border: transparentBorder,
+      borderPrimary: transparentBorder,
+      borderSuccess: transparentBorder,
+      borderWarning: transparentBorder,
+      borderError: transparentBorder,
+      borderInfo: transparentBorder,
+      borderRadius: '3px',
+      closeBorderRadius: '3px',
+      color: palette.control,
+      colorBordered: palette.control,
+      colorPrimary: palette.primaryBlock,
+      colorBorderedPrimary: palette.primaryBlock,
+      colorSuccess: palette.successBlock,
+      colorBorderedSuccess: palette.successBlock,
+      colorWarning: palette.warningBlock,
+      colorBorderedWarning: palette.warningBlock,
+      colorError: palette.errorBlock,
+      colorBorderedError: palette.errorBlock,
+      colorInfo: palette.infoBlock,
+      colorBorderedInfo: palette.infoBlock,
+      textColorPrimary: palette.primaryText,
+      textColorSuccess: palette.successText,
+      textColorWarning: palette.warningText,
+      textColorError: palette.errorText,
+      textColorInfo: palette.infoText
+    },
+    Menu: {
+      borderRadius: '6px',
+      itemColorActive: palette.primaryBlock,
+      itemColorActiveCollapsed: palette.primaryBlock,
+      itemColorActiveHover: palette.primaryBlock
+    },
+    Popover: {
+      color: palette.popover,
+      borderRadius: '10px',
+      boxShadow: palette.shadowMedium
+    },
+    Dropdown: {
+      borderRadius: '8px',
+      color: palette.popover,
+      dividerColor: palette.divider
+    },
+    Tooltip: {
+      borderRadius: '6px',
+      boxShadow: palette.shadowSmall,
+      color: palette.tooltip,
+      textColor: palette.tooltipText,
+      peers: {
+        Popover: {
+          borderRadius: '6px',
+          boxShadow: palette.shadowSmall,
+          color: palette.tooltip,
+          textColor: palette.tooltipText
+        }
+      }
+    },
+    Message: {
+      borderRadius: '8px',
+      closeBorderRadius: '5px',
+      boxShadow: palette.shadowMedium,
+      boxShadowInfo: palette.shadowMedium,
+      boxShadowSuccess: palette.shadowMedium,
+      boxShadowWarning: palette.shadowMedium,
+      boxShadowError: palette.shadowMedium,
+      boxShadowLoading: palette.shadowMedium
+    },
+    Notification: {
+      borderRadius: '10px',
+      closeBorderRadius: '5px',
+      boxShadow: palette.shadowMedium
+    },
+    Alert: {
+      border: transparentBorder,
+      borderInfo: transparentBorder,
+      borderSuccess: transparentBorder,
+      borderWarning: transparentBorder,
+      borderError: transparentBorder,
+      borderRadius: '8px',
+      closeBorderRadius: '5px',
+      color: palette.control,
+      colorInfo: palette.alertInfoBlock,
+      colorSuccess: palette.alertSuccessBlock,
+      colorWarning: palette.alertWarningBlock,
+      colorError: palette.alertErrorBlock,
+      iconColorInfo: palette.alertInfoIcon,
+      iconColorSuccess: palette.alertSuccessIcon,
+      iconColorWarning: palette.alertWarningIcon,
+      iconColorError: palette.alertErrorIcon
+    },
+    Divider: {
+      color: palette.divider
+    },
+    Collapse: {
+      dividerColor: 'transparent',
+      titleFontWeight: '600'
+    },
+    DataTable: {
+      borderRadius: '10px',
+      borderColor: palette.divider,
+      thColor: palette.tableHeader,
+      tdColor: palette.surface,
+      tdColorStriped: palette.tableStriped
+    },
+    DatePicker: {
+      itemBorderRadius: '4px',
+      scrollItemBorderRadius: '4px',
+      panelBorderRadius: '10px',
+      panelBoxShadow: palette.shadowMedium,
+      panelColor: palette.surfaceRaised,
+      panelHeaderDividerColor: palette.divider,
+      calendarDaysDividerColor: palette.divider,
+      calendarDividerColor: palette.divider,
+      panelActionDividerColor: palette.divider
+    },
+    List: {
+      borderRadius: '10px',
+      borderColor: palette.divider,
+      color: palette.surface,
+      colorHover: palette.controlHover
+    },
+    Slider: {
+      /* 亮色下白色 thumb 会融进白色轨道/背景，给一圈极淡描边+柔和投影分离轮廓（不改颜色） */
+      handleBoxShadow: '0 0 0 1px rgba(0, 0, 0, 0.12), 0 1px 3px rgba(0, 0, 0, 0.14)',
+      handleBoxShadowFocus: palette.focusShadow,
+      indicatorBorderRadius: '6px',
+      indicatorBoxShadow: palette.shadowSmall
+    },
+    Table: {
+      borderRadius: '10px',
+      borderColor: palette.divider,
+      thColor: palette.tableHeader,
+      tdColor: palette.surface,
+      tdColorStriped: palette.tableStriped
+    },
+    Tabs: {
+      tabBorderRadius: '6px',
+      closeBorderRadius: '4px',
+      tabColor: palette.control,
+      tabColorSegment: palette.surfaceRaised,
+      colorSegment: palette.controlPressed
+    },
+    TimePicker: {
+      itemBorderRadius: '4px',
+      borderRadius: '10px',
+      panelBoxShadow: palette.shadowMedium,
+      panelColor: palette.surfaceRaised,
+      panelDividerColor: palette.divider
+    },
+    Upload: {
+      borderRadius: '8px',
+      draggerColor: palette.control,
+      draggerBorder: transparentBorder,
+      draggerBorderHover: transparentBorder,
+      itemColorHover: palette.controlHover
+    }
+  }
+}
+
+export const mowerLightThemeOverrides = createMowerTheme({
+  primary: '#18a058',
+  primaryHover: '#36ad6a',
+  primaryPressed: '#0c7a43',
+  primarySuppl: '#36ad6a',
+  accent: '#18a058',
+  accentHover: '#36ad6a',
+  accentPressed: '#0c7a43',
+  accentText: '#ffffff',
+  success: '#18a058',
+  successHover: '#36ad6a',
+  successPressed: '#0c7a43',
+  successSuppl: '#36ad6a',
+  warning: '#f0a020',
+  warningHover: '#fcb040',
+  warningPressed: '#c97c10',
+  warningSuppl: '#fcb040',
+  error: '#d03050',
+  errorHover: '#de576d',
+  errorPressed: '#ab1f3f',
+  errorSuppl: '#de576d',
+  info: '#2080f0',
+  infoHover: '#4098fc',
+  infoPressed: '#1060c9',
+  infoSuppl: '#4098fc',
+  page: '#fff',
+  surface: '#fff',
+  surfaceRaised: '#fff',
+  popover: '#fff',
+  tooltip: 'rgba(0, 0, 0, 0.85)',
+  tooltipText: '#ffffff',
+  input: 'rgba(255, 255, 255, 1)',
+  sider: 'rgb(250, 250, 252)',
+  cardBlock: '#ffffff',
+  control: 'rgb(250, 250, 252)',
+  controlHover: 'rgb(243, 243, 245)',
+  controlPressed: 'rgb(237, 237, 239)',
+  controlFocus: '#ffffff',
+  controlDisabled: 'rgb(250, 250, 252)',
+  border: 'rgb(224, 224, 230)',
+  divider: 'rgb(239, 239, 245)',
+  tableHeader: 'rgb(250, 250, 252)',
+  tableStriped: 'rgba(0, 0, 100, 0.02)',
+  tab: 'rgb(247, 247, 250)',
+  primaryBlock: 'rgba(24, 160, 88, 0.12)',
+  primaryText: '#18a058',
+  successBlock: 'rgba(24, 160, 88, 0.12)',
+  successText: '#18a058',
+  warningBlock: 'rgba(240, 160, 32, 0.15)',
+  warningText: '#f0a020',
+  errorBlock: 'rgba(208, 48, 80, 0.1)',
+  errorText: '#d03050',
+  infoBlock: 'rgba(32, 128, 240, 0.12)',
+  infoText: '#2080f0',
+  alertInfoBlock: 'rgba(237, 245, 254, 1)',
+  alertSuccessBlock: 'rgba(237, 247, 242, 1)',
+  alertWarningBlock: 'rgba(254, 247, 237, 1)',
+  alertErrorBlock: 'rgba(251, 238, 241, 1)',
+  alertInfoIcon: '#2080f0',
+  alertSuccessIcon: '#18a058',
+  alertWarningIcon: '#f0a020',
+  alertErrorIcon: '#d03050',
+  focusShadow: '0 0 0 2px rgba(24, 160, 88, 0.2)',
+  switchShadow: '0 1px 3px rgba(0, 0, 0, 0.12)',
+  shadowSmall:
+    '0 1px 2px -2px rgba(0, 0, 0, .08), 0 3px 6px 0 rgba(0, 0, 0, .06), 0 5px 12px 4px rgba(0, 0, 0, .04)',
+  shadowMedium:
+    '0 3px 6px -4px rgba(0, 0, 0, .12), 0 6px 16px 0 rgba(0, 0, 0, .08), 0 9px 28px 8px rgba(0, 0, 0, .05)',
+  shadowLarge:
+    '0 6px 16px -9px rgba(0, 0, 0, .08), 0 9px 28px 0 rgba(0, 0, 0, .05), 0 12px 48px 16px rgba(0, 0, 0, .03)'
+})
+
+export const mowerDarkThemeOverrides = createMowerTheme({
+  primary: '#63e2b7',
+  primaryHover: '#7fe7c4',
+  primaryPressed: '#5acea7',
+  primarySuppl: 'rgb(42, 148, 125)',
+  accent: '#63e2b7',
+  accentHover: '#7fe7c4',
+  accentPressed: '#5acea7',
+  accentText: '#000000',
+  success: '#63e2b7',
+  successHover: '#7fe7c4',
+  successPressed: '#5acea7',
+  successSuppl: 'rgb(42, 148, 125)',
+  warning: '#f2c97d',
+  warningHover: '#f5d599',
+  warningPressed: '#e6c260',
+  warningSuppl: 'rgb(240, 138, 0)',
+  error: '#e88080',
+  errorHover: '#e98b8b',
+  errorPressed: '#e57272',
+  errorSuppl: 'rgb(208, 58, 82)',
+  info: '#70c0e8',
+  infoHover: '#8acbec',
+  infoPressed: '#66afd3',
+  infoSuppl: 'rgb(56, 137, 197)',
+  page: 'rgb(16, 16, 20)',
+  surface: 'rgb(24, 24, 28)',
+  surfaceRaised: 'rgb(44, 44, 50)',
+  popover: 'rgb(72, 72, 78)',
+  tooltip: 'rgb(72, 72, 78)',
+  tooltipText: 'rgba(255, 255, 255, 0.9)',
+  input: 'rgba(255, 255, 255, 0.1)',
+  sider: 'rgb(24, 24, 28)',
+  cardBlock: 'rgb(24, 24, 28)',
+  control: 'rgba(255, 255, 255, 0.06)',
+  controlHover: 'rgba(255, 255, 255, 0.09)',
+  controlPressed: 'rgba(255, 255, 255, 0.05)',
+  controlFocus: 'rgba(255, 255, 255, 0.1)',
+  controlDisabled: 'rgba(255, 255, 255, 0.06)',
+  border: 'rgba(255, 255, 255, 0.24)',
+  divider: 'rgba(255, 255, 255, 0.09)',
+  tableHeader: 'rgba(255, 255, 255, 0.06)',
+  tableStriped: 'rgba(255, 255, 255, 0.05)',
+  tab: 'rgba(255, 255, 255, 0.04)',
+  primaryBlock: 'rgba(99, 226, 183, 0.16)',
+  primaryText: '#63e2b7',
+  successBlock: 'rgba(99, 226, 183, 0.16)',
+  successText: '#63e2b7',
+  warningBlock: 'rgba(242, 201, 125, 0.16)',
+  warningText: '#f2c97d',
+  errorBlock: 'rgba(232, 128, 128, 0.16)',
+  errorText: '#e88080',
+  infoBlock: 'rgba(112, 192, 232, 0.16)',
+  infoText: '#70c0e8',
+  alertInfoBlock: 'rgba(56, 137, 197, 0.25)',
+  alertSuccessBlock: 'rgba(42, 148, 125, 0.25)',
+  alertWarningBlock: 'rgba(240, 138, 0, 0.25)',
+  alertErrorBlock: 'rgba(208, 58, 82, 0.25)',
+  alertInfoIcon: 'rgb(56, 137, 197)',
+  alertSuccessIcon: 'rgb(42, 148, 125)',
+  alertWarningIcon: 'rgb(240, 138, 0)',
+  alertErrorIcon: 'rgb(208, 58, 82)',
+  focusShadow: '0 0 0 2px rgba(99, 226, 183, 0.2)',
+  switchShadow: '0 1px 3px rgba(0, 0, 0, 0.24)',
+  shadowSmall:
+    '0 1px 2px -2px rgba(0, 0, 0, .24), 0 3px 6px 0 rgba(0, 0, 0, .18), 0 5px 12px 4px rgba(0, 0, 0, .12)',
+  shadowMedium:
+    '0 3px 6px -4px rgba(0, 0, 0, .24), 0 6px 12px 0 rgba(0, 0, 0, .16), 0 9px 18px 8px rgba(0, 0, 0, .10)',
+  shadowLarge:
+    '0 6px 16px -9px rgba(0, 0, 0, .08), 0 9px 28px 0 rgba(0, 0, 0, .05), 0 12px 48px 16px rgba(0, 0, 0, .03)'
+})
+
+function createMowerCssVariables(theme) {
+  return {
+    '--mower-surface': theme.common.cardColor,
+    '--mower-shadow-surface': 'none',
+    '--mower-shadow-control': 'none',
+    '--mower-control-surface': theme.common.actionColor,
+    '--mower-control-hover': theme.common.hoverColor,
+    '--mower-divider': theme.common.dividerColor,
+    '--mower-primary': theme.common.primaryColor,
+    '--mower-primary-hover': theme.common.primaryColorHover,
+    '--mower-primary-contrast': theme.Button.textColorPrimary,
+    '--mower-primary-block': theme.Tag.colorPrimary,
+    '--mower-primary-text': theme.Tag.textColorPrimary,
+    '--mower-success': theme.common.successColor,
+    '--mower-success-block': theme.Tag.colorSuccess,
+    '--mower-success-text': theme.Tag.textColorSuccess,
+    '--mower-warning': theme.common.warningColor,
+    '--mower-warning-block': theme.Tag.colorWarning,
+    '--mower-warning-text': theme.Tag.textColorWarning,
+    '--mower-error': theme.common.errorColor,
+    '--mower-error-block': theme.Tag.colorError,
+    '--mower-error-text': theme.Tag.textColorError,
+    '--mower-info': theme.common.infoColor,
+    '--mower-info-block': theme.Tag.colorInfo,
+    '--mower-info-text': theme.Tag.textColorInfo
+  }
+}
+
+export const mowerLightCssVariables = createMowerCssVariables(mowerLightThemeOverrides)
+export const mowerDarkCssVariables = createMowerCssVariables(mowerDarkThemeOverrides)

--- a/ui/src/theme/mower.test.js
+++ b/ui/src/theme/mower.test.js
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+import { darkTheme, lightTheme } from 'naive-ui'
+
+import {
+  mowerDarkCssVariables,
+  mowerDarkThemeOverrides,
+  mowerLightCssVariables,
+  mowerLightThemeOverrides
+} from './mower'
+
+const nativeCommonTokens = [
+  'primaryColor',
+  'primaryColorHover',
+  'primaryColorPressed',
+  'primaryColorSuppl',
+  'successColor',
+  'successColorHover',
+  'successColorPressed',
+  'successColorSuppl',
+  'warningColor',
+  'warningColorHover',
+  'warningColorPressed',
+  'warningColorSuppl',
+  'errorColor',
+  'errorColorHover',
+  'errorColorPressed',
+  'errorColorSuppl',
+  'infoColor',
+  'infoColorHover',
+  'infoColorPressed',
+  'infoColorSuppl',
+  'bodyColor',
+  'cardColor',
+  'modalColor',
+  'popoverColor',
+  'inputColor',
+  'actionColor',
+  'hoverColor',
+  'pressedColor',
+  'borderColor',
+  'dividerColor',
+  'tableColor',
+  'tableHeaderColor',
+  'tableColorStriped',
+  'tabColor',
+  'boxShadow1',
+  'boxShadow2',
+  'boxShadow3'
+]
+
+const requiredThemeSections = [
+  'Layout',
+  'Button',
+  'Card',
+  'Dialog',
+  'Modal',
+  'Drawer',
+  'Input',
+  'Checkbox',
+  'Radio',
+  'Switch',
+  'Select',
+  'AutoComplete',
+  'Tag',
+  'Menu',
+  'Popover',
+  'Dropdown',
+  'Tooltip',
+  'Message',
+  'Notification',
+  'Alert',
+  'Divider',
+  'Collapse',
+  'DataTable',
+  'DatePicker',
+  'List',
+  'Slider',
+  'Table',
+  'Tabs',
+  'TimePicker',
+  'Upload'
+]
+
+const themes = [
+  [
+    'light',
+    lightTheme,
+    mowerLightThemeOverrides,
+    mowerLightCssVariables,
+    { color: 'rgba(0, 0, 0, 0.85)', textColor: '#ffffff' }
+  ],
+  [
+    'dark',
+    darkTheme,
+    mowerDarkThemeOverrides,
+    mowerDarkCssVariables,
+    { color: 'rgb(72, 72, 78)', textColor: 'rgba(255, 255, 255, 0.9)' }
+  ]
+]
+
+describe.each(themes)('Mower %s theme', (_mode, naiveTheme, mowerTheme, cssVariables, tooltip) => {
+  it('keeps the Naive UI palette and font defaults', () => {
+    for (const token of nativeCommonTokens) {
+      expect(mowerTheme.common[token]).toBe(naiveTheme.common[token])
+    }
+    expect(mowerTheme.common).not.toHaveProperty('fontFamily')
+    expect(mowerTheme.common).not.toHaveProperty('fontFamilyMono')
+  })
+
+  it('covers every visual component used by the frontend', () => {
+    expect(Object.keys(mowerTheme)).toEqual(expect.arrayContaining(requiredThemeSections))
+  })
+
+  it('only overrides supported Naive UI theme keys', () => {
+    for (const [section, values] of Object.entries(mowerTheme)) {
+      const validValues =
+        section === 'common' ? naiveTheme.common : naiveTheme[section]?.self?.(naiveTheme.common)
+      expect(validValues, `missing Naive UI theme section ${section}`).toBeTruthy()
+
+      const { peers = {}, ...selfValues } = values
+      for (const [key, value] of Object.entries(selfValues)) {
+        expect(validValues, `${section}.${key}`).toHaveProperty(key)
+        expect(value, `${section}.${key}`).not.toBeUndefined()
+      }
+
+      for (const [peer, peerValues] of Object.entries(peers)) {
+        const validPeerValues = naiveTheme[section]?.peers?.[peer]?.self?.(naiveTheme.common)
+        expect(validPeerValues, `missing Naive UI peer ${section}.peers.${peer}`).toBeTruthy()
+        for (const [key, value] of Object.entries(peerValues)) {
+          expect(validPeerValues, `${section}.peers.${peer}.${key}`).toHaveProperty(key)
+          expect(value, `${section}.peers.${peer}.${key}`).not.toBeUndefined()
+        }
+      }
+    }
+  })
+
+  it('uses progressively larger radii for larger components', () => {
+    expect(mowerTheme.Checkbox.borderRadius).toBe('3px')
+    expect(mowerTheme.Button.borderRadiusSmall).toBe('4px')
+    expect(mowerTheme.Input.borderRadius).toBe('6px')
+    expect(mowerTheme.Alert.borderRadius).toBe('8px')
+    expect(mowerTheme.Popover.borderRadius).toBe('10px')
+    expect(mowerTheme.Card.borderRadius).toBe('12px')
+  })
+
+  it('keeps tooltip text legible against its floating surface', () => {
+    expect(mowerTheme.Tooltip.color).toBe(tooltip.color)
+    expect(mowerTheme.Tooltip.textColor).toBe(tooltip.textColor)
+    expect(mowerTheme.Tooltip.peers.Popover).toMatchObject(tooltip)
+  })
+
+  it('keeps shadows for floating layers while in-page cards stay flat', () => {
+    expect(mowerTheme.Card.boxShadow).toBe('none')
+    expect(mowerTheme.Modal.boxShadow).not.toBe('none')
+    expect(mowerTheme.Drawer.boxShadow).not.toBe('none')
+    expect(mowerTheme.Select.menuBoxShadow).not.toBe('none')
+    expect(mowerTheme.Popover.boxShadow).not.toBe('none')
+  })
+
+  it('derives custom-page semantic colors from the same theme source', () => {
+    expect(cssVariables).toMatchObject({
+      '--mower-surface': mowerTheme.common.cardColor,
+      '--mower-shadow-surface': 'none',
+      '--mower-shadow-control': 'none',
+      '--mower-divider': mowerTheme.common.dividerColor,
+      '--mower-primary': mowerTheme.common.primaryColor,
+      '--mower-primary-block': mowerTheme.Tag.colorPrimary,
+      '--mower-success-text': mowerTheme.Tag.textColorSuccess,
+      '--mower-warning-text': mowerTheme.Tag.textColorWarning,
+      '--mower-error-text': mowerTheme.Tag.textColorError,
+      '--mower-info-text': mowerTheme.Tag.textColorInfo
+    })
+  })
+
+  it('uses a recessed rail and a contrasting raised capsule for segmented tabs', () => {
+    expect(mowerTheme.Tabs.colorSegment).not.toBe(mowerTheme.Tabs.tabColorSegment)
+    expect(mowerTheme.Tabs.tabColorSegment).toBe(mowerTheme.common.modalColor)
+  })
+})

--- a/ui/src/utils/modal-drag.js
+++ b/ui/src/utils/modal-drag.js
@@ -1,0 +1,80 @@
+// Makes naive-ui modals draggable by their header so the panel can be moved
+// freely inside the desktop shell instead of staying pinned to the window centre.
+//
+// The panel is centred by its container in normal flow, so on the first drag we
+// convert it to fixed screen coordinates (matching its current on-screen rect)
+// and then track the pointer to reposition it. This keeps the modal's own CSS
+// intact — we only take over once the user actually starts a drag.
+//
+// Install with `installModalDragging()`; returns a disposable.
+
+const DRAG_HANDLE_SELECTOR = '.n-card-header, .n-dialog__title'
+// Elements the user may need to click rather than drag on.
+const INTERACTIVE =
+  'button, a, input, textarea, select, [contenteditable], [role="button"], .n-card-header__close'
+
+let active = null
+
+function onHandlePointerDown(event) {
+  if (event.button !== 0) return
+  if (active) return // one drag at a time
+  if (event.target.closest(INTERACTIVE)) return
+
+  const handle = event.target.closest(DRAG_HANDLE_SELECTOR)
+  if (!handle) return
+
+  // Only drag the main modal panel, never something nested inside it.
+  const panel = handle.closest('.n-modal')
+  if (!panel) return
+
+  const rect = panel.getBoundingClientRect()
+  const startX = event.clientX
+  const startY = event.clientY
+
+  const pointerId = event.pointerId
+  const onPointerMove = (moveEvent) => {
+    if (!active || moveEvent.pointerId !== pointerId) return
+    const dx = moveEvent.clientX - startX
+    const dy = moveEvent.clientY - startY
+    if (!active.moved && Math.hypot(dx, dy) < 3) return
+    active.moved = true
+    panel.style.left = `${active.left + dx}px`
+    panel.style.top = `${active.top + dy}px`
+  }
+
+  const onPointerUp = () => {
+    window.removeEventListener('pointermove', onPointerMove)
+    window.removeEventListener('pointerup', onPointerUp)
+    window.removeEventListener('pointercancel', onPointerUp)
+    active = null
+  }
+
+  window.addEventListener('pointermove', onPointerMove)
+  window.addEventListener('pointerup', onPointerUp)
+  window.addEventListener('pointercancel', onPointerUp)
+
+  active = {
+    panel,
+    left: rect.left,
+    top: rect.top,
+    moved: false
+  }
+
+  // Take the panel out of the container's centering flow and pin it to the
+  // position it currently occupies, then the pointer handler moves it.
+  panel.style.position = 'fixed'
+  panel.style.left = `${rect.left}px`
+  panel.style.top = `${rect.top}px`
+  panel.style.right = 'auto'
+  panel.style.bottom = 'auto'
+  panel.style.margin = '0'
+  panel.style.transform = 'none'
+}
+
+export function installModalDragging() {
+  document.addEventListener('pointerdown', onHandlePointerDown, true)
+  return function dispose() {
+    document.removeEventListener('pointerdown', onHandlePointerDown, true)
+    active = null
+  }
+}

--- a/ui/src/window-shell/adapter.js
+++ b/ui/src/window-shell/adapter.js
@@ -1,0 +1,253 @@
+import { computed, ref } from 'vue'
+
+export const WINDOW_RESIZE_EDGES = Object.freeze([
+  'left',
+  'right',
+  'top',
+  'bottom',
+  'top-left',
+  'top-right',
+  'bottom-left',
+  'bottom-right'
+])
+
+const VALID_PLATFORMS = new Set(['windows', 'macos', 'linux'])
+const REQUIRED_METHODS = [
+  'minimize',
+  'maximize',
+  'restore',
+  'close',
+  'start_resize',
+  'get_window_state',
+  'get_platform'
+]
+const CONTROL_METHODS = new Set(['minimize', 'maximize', 'restore', 'close'])
+const RESIZE_EDGES = new Set(WINDOW_RESIZE_EDGES)
+
+const NORMAL_STATE = Object.freeze({
+  state: 'normal',
+  maximized: false,
+  minimized: false,
+  width: 0,
+  height: 0
+})
+
+function hasBridgeContract(api) {
+  return Boolean(api && REQUIRED_METHODS.every((method) => typeof api[method] === 'function'))
+}
+
+function validState(state, protocol) {
+  return Boolean(
+    state &&
+    state.protocol === protocol &&
+    ['normal', 'maximized', 'minimized'].includes(state.state) &&
+    typeof state.maximized === 'boolean' &&
+    typeof state.minimized === 'boolean' &&
+    Number.isFinite(state.width) &&
+    Number.isFinite(state.height)
+  )
+}
+
+function withTimeout(promise, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('window shell bridge timed out')), timeoutMs)
+    Promise.resolve(promise).then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
+}
+
+function readBridge(windowObject) {
+  return windowObject?.pywebview?.api
+}
+
+function waitForBridge(windowObject, timeoutMs) {
+  const existing = readBridge(windowObject)
+  if (hasBridgeContract(existing)) return Promise.resolve(existing)
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (api) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      windowObject?.removeEventListener?.('pywebviewready', onReady)
+      resolve(api)
+    }
+    const onReady = () => {
+      const api = readBridge(windowObject)
+      finish(hasBridgeContract(api) ? api : null)
+    }
+    const timer = setTimeout(() => finish(null), timeoutMs)
+    windowObject?.addEventListener?.('pywebviewready', onReady, { once: true })
+  })
+}
+
+export function readWindowShellMetadata(locationObject) {
+  const params = new URLSearchParams(locationObject?.search || '')
+  const bootstrapTheme = params.get('window_theme')
+  return Object.freeze({
+    requested: params.get('window_shell') === '1',
+    version: params.get('mower_version') || '',
+    instanceName: params.get('instance_name') || '',
+    bootstrapTheme: ['light', 'dark'].includes(bootstrapTheme) ? bootstrapTheme : 'light'
+  })
+}
+
+export function formatWindowTitle({ version = '', instanceName = '' } = {}) {
+  const parts = [version ? `Mower ${version}` : 'Mower']
+  parts.push(instanceName || '默认实例')
+  return parts.join(' · ')
+}
+
+export function createWindowShellAdapter({
+  windowObject = window,
+  readyTimeoutMs = 1200,
+  callTimeoutMs = 1000
+} = {}) {
+  const active = ref(false)
+  const platform = ref(null)
+  const state = ref({ ...NORMAL_STATE })
+  const busy = ref({
+    minimize: false,
+    maximize: false,
+    restore: false,
+    close: false
+  })
+  const metadata = readWindowShellMetadata(windowObject?.location)
+  let bridge = null
+  let initializePromise = null
+  let activeProtocol = null
+  let listeningEvent = null
+
+  const controlSide = computed(() => (platform.value === 'macos' ? 'start' : 'end'))
+  const controls = computed(() => {
+    if (!active.value) return []
+    const maximizeControl = state.value.maximized
+      ? { id: 'maximize', action: 'restore', label: '还原', icon: 'restore' }
+      : { id: 'maximize', action: 'maximize', label: '最大化', icon: 'maximize' }
+    const standard = [
+      { id: 'minimize', action: 'minimize', label: '最小化', icon: 'minimize' },
+      maximizeControl,
+      { id: 'close', action: 'close', label: '关闭', icon: 'close' }
+    ]
+    return platform.value === 'macos' ? [standard[2], standard[0], standard[1]] : standard
+  })
+
+  const onNativeState = (event) => {
+    if (validState(event?.detail, activeProtocol)) state.value = { ...event.detail }
+  }
+
+  async function initializeOnce() {
+    try {
+      if (!metadata.requested) return false
+      const candidate = await waitForBridge(windowObject, readyTimeoutMs)
+      if (!candidate) return false
+
+      const [platformResult, stateResult] = await Promise.all([
+        withTimeout(candidate.get_platform(), callTimeoutMs),
+        withTimeout(candidate.get_window_state(), callTimeoutMs)
+      ])
+      const protocol = platformResult?.protocol
+      const event = platformResult?.event
+      if (
+        !protocol ||
+        !event ||
+        !VALID_PLATFORMS.has(platformResult.platform) ||
+        protocol !== stateResult?.protocol ||
+        !validState(stateResult, protocol)
+      ) {
+        disposeListener()
+        return false
+      }
+
+      // Subscribe to the event name the Python side actually dispatches. This is
+      // the single source of truth for the bridge contract, so renaming it on the
+      // backend cannot silently leave the client listening for a stale name.
+      activeProtocol = protocol
+      bridge = candidate
+      platform.value = platformResult.platform
+      state.value = { ...stateResult }
+      active.value = true
+      windowObject?.addEventListener?.(event, onNativeState)
+      listeningEvent = event
+      return true
+    } catch {
+      disposeListener()
+      return false
+    }
+  }
+
+  function initialize() {
+    if (!initializePromise) initializePromise = initializeOnce()
+    return initializePromise
+  }
+
+  async function runControl(action) {
+    if (!active.value || !bridge || !CONTROL_METHODS.has(action)) return false
+    busy.value = { ...busy.value, [action]: true }
+    try {
+      return (await withTimeout(bridge[action](), callTimeoutMs)) === true
+    } catch {
+      return false
+    } finally {
+      busy.value = { ...busy.value, [action]: false }
+    }
+  }
+
+  const minimize = () => runControl('minimize')
+  const maximize = () => runControl('maximize')
+  const restore = () => runControl('restore')
+  const close = () => runControl('close')
+  const toggleMaximize = () => (state.value.maximized ? restore() : maximize())
+
+  async function startResize(edge) {
+    if (!active.value || !bridge || !RESIZE_EDGES.has(edge) || state.value.maximized) {
+      return false
+    }
+    try {
+      return (await withTimeout(bridge.start_resize(edge), callTimeoutMs)) === true
+    } catch {
+      return false
+    }
+  }
+
+  function disposeListener() {
+    if (!listeningEvent) return
+    windowObject?.removeEventListener?.(listeningEvent, onNativeState)
+    listeningEvent = null
+  }
+
+  function dispose() {
+    disposeListener()
+    active.value = false
+    activeProtocol = null
+    bridge = null
+  }
+
+  return {
+    active,
+    platform,
+    state,
+    busy,
+    metadata,
+    controlSide,
+    controls,
+    initialize,
+    runControl,
+    minimize,
+    maximize,
+    restore,
+    close,
+    toggleMaximize,
+    startResize,
+    dispose
+  }
+}

--- a/ui/src/window-shell/adapter.test.js
+++ b/ui/src/window-shell/adapter.test.js
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createWindowShellAdapter } from './adapter.js'
+
+// These mirror the bridge contract the Python side serves via get_platform();
+// the adapter must agree with whatever the backend reports, not with these.
+const PROTOCOL = 'mower-window-shell-v1'
+const EVENT = 'mower-window-state'
+
+function makeBridge(platform = 'windows') {
+  return {
+    minimize: vi.fn(async () => true),
+    maximize: vi.fn(async () => true),
+    restore: vi.fn(async () => true),
+    close: vi.fn(async () => true),
+    start_resize: vi.fn(async () => true),
+    get_platform: vi.fn(async () => ({ protocol: PROTOCOL, event: EVENT, platform })),
+    get_window_state: vi.fn(async () => ({
+      protocol: PROTOCOL,
+      state: 'normal',
+      maximized: false,
+      minimized: false,
+      width: 1450,
+      height: 850
+    }))
+  }
+}
+
+function makeWindow() {
+  const windowObject = new EventTarget()
+  windowObject.location = { search: '?window_shell=1' }
+  return windowObject
+}
+
+describe('window shell adapter', () => {
+  it('leaves a normal browser inactive with no user-agent guessing', async () => {
+    const browserWindow = makeWindow()
+    browserWindow.location.search = ''
+    const adapter = createWindowShellAdapter({ windowObject: browserWindow, readyTimeoutMs: 5 })
+
+    await expect(adapter.initialize()).resolves.toBe(false)
+    expect(adapter.active.value).toBe(false)
+    expect(adapter.controls.value).toEqual([])
+  })
+
+  it('rejects a matching-looking bridge without the Python desktop marker', async () => {
+    const browserWindow = makeWindow()
+    browserWindow.location.search = ''
+    browserWindow.pywebview = { api: makeBridge() }
+    const adapter = createWindowShellAdapter({ windowObject: browserWindow })
+
+    await expect(adapter.initialize()).resolves.toBe(false)
+    expect(adapter.active.value).toBe(false)
+  })
+
+  it('waits for pywebviewready and activates only after validating the bridge contract', async () => {
+    const desktopWindow = makeWindow()
+    const bridge = makeBridge('windows')
+    const adapter = createWindowShellAdapter({ windowObject: desktopWindow, readyTimeoutMs: 50 })
+    const initializing = adapter.initialize()
+
+    desktopWindow.pywebview = { api: bridge }
+    desktopWindow.dispatchEvent(new Event('pywebviewready'))
+
+    await expect(initializing).resolves.toBe(true)
+    expect(adapter.active.value).toBe(true)
+    expect(adapter.controlSide.value).toBe('end')
+    expect(adapter.controls.value.map((control) => control.id)).toEqual([
+      'minimize',
+      'maximize',
+      'close'
+    ])
+  })
+
+  it('centralizes macOS control placement and ordering', async () => {
+    const desktopWindow = makeWindow()
+    desktopWindow.pywebview = { api: makeBridge('macos') }
+    const adapter = createWindowShellAdapter({ windowObject: desktopWindow })
+
+    await adapter.initialize()
+
+    expect(adapter.controlSide.value).toBe('start')
+    expect(adapter.controls.value.map((control) => control.id)).toEqual([
+      'close',
+      'minimize',
+      'maximize'
+    ])
+  })
+
+  it('uses native events rather than command success to change the maximize control', async () => {
+    const desktopWindow = makeWindow()
+    const bridge = makeBridge()
+    desktopWindow.pywebview = { api: bridge }
+    const adapter = createWindowShellAdapter({ windowObject: desktopWindow })
+    await adapter.initialize()
+
+    await adapter.maximize()
+    expect(adapter.state.value.maximized).toBe(false)
+    expect(adapter.controls.value[1].icon).toBe('maximize')
+
+    desktopWindow.dispatchEvent(
+      new CustomEvent(EVENT, {
+        detail: {
+          protocol: PROTOCOL,
+          state: 'maximized',
+          maximized: true,
+          minimized: false,
+          width: 1920,
+          height: 1040
+        }
+      })
+    )
+
+    expect(adapter.state.value.maximized).toBe(true)
+    expect(adapter.controls.value[1].icon).toBe('restore')
+    await adapter.toggleMaximize()
+    expect(bridge.restore).toHaveBeenCalledOnce()
+  })
+
+  it('degrades safely when bridge validation or a control call fails', async () => {
+    const invalidWindow = makeWindow()
+    invalidWindow.pywebview = { api: makeBridge('unknown') }
+    const invalidAdapter = createWindowShellAdapter({ windowObject: invalidWindow })
+    await expect(invalidAdapter.initialize()).resolves.toBe(false)
+    expect(invalidAdapter.active.value).toBe(false)
+
+    const desktopWindow = makeWindow()
+    const bridge = makeBridge()
+    bridge.close.mockRejectedValue(new Error('bridge unavailable'))
+    desktopWindow.pywebview = { api: bridge }
+    const adapter = createWindowShellAdapter({ windowObject: desktopWindow })
+    await adapter.initialize()
+
+    await expect(adapter.close()).resolves.toBe(false)
+    expect(adapter.busy.value.close).toBe(false)
+    expect(adapter.active.value).toBe(true)
+  })
+
+  it('delegates valid resize edges to the native window frame', async () => {
+    const desktopWindow = makeWindow()
+    const bridge = makeBridge()
+    desktopWindow.pywebview = { api: bridge }
+    const adapter = createWindowShellAdapter({ windowObject: desktopWindow })
+    await adapter.initialize()
+
+    await expect(adapter.startResize('bottom-right')).resolves.toBe(true)
+    await expect(adapter.startResize('unexpected')).resolves.toBe(false)
+    expect(bridge.start_resize).toHaveBeenCalledOnce()
+    expect(bridge.start_resize).toHaveBeenCalledWith('bottom-right')
+  })
+})

--- a/webview_ui.py
+++ b/webview_ui.py
@@ -280,20 +280,60 @@ def webview_window(
 
         mower_log.bind_mp_queue(log_queue)
 
-    from arknights_mower.utils.config.gui import load_window_size, save_window_size
+    from arknights_mower.utils import config
+    from arknights_mower.utils.config.gui import load_window_ratio, save_window_ratio
+    from arknights_mower.utils.window_shell import (
+        DESKTOP_WINDOW_MIN_SIZE,
+        WindowSize,
+        attach_window_shell,
+        default_desktop_window_size,
+        is_windows,
+        ratio_from_window_size,
+        window_background_color,
+        window_dpi_scale,
+        window_size_from_ratio,
+    )
 
     global width
     global height
 
-    size = load_window_size()
-    width, height = resolve_window_size(*size) if size else DEFAULT_WINDOW_SIZE
+    config.load_conf()
+    theme = config.conf.theme
+    ratio = load_window_ratio()
+    if ratio:
+        width, height = window_size_from_ratio(ratio)
+    else:
+        width, height = default_desktop_window_size()
+    # 无边框自绘标题栏是 Windows 专属：原生非客户区缩放/DPI 都依赖下面的 Win32
+    # hook，其余平台沿用原生窗口。否则会得到一个既不能拖拽也不能缩放的裸窗口。
+    shell_enabled = is_windows()
+    url = append_query_param(url, "window_shell", "1") if shell_enabled else url
+    url = append_query_param(url, "window_theme", theme)
+    url = append_query_param(url, "mower_version", title_version())
+
+    def current_dpi_scale() -> float:
+        # 窗口所在显示器 DPI 缩放（1.0 / 1.25 / 1.5 ...）。resized 回调给的是物理
+        # 像素，存盘前要还原成逻辑值，否则物理值会被 create_window 当作逻辑再放大
+        # 一次，越开越大。每次缩放时重新探测，窗口拖到不同 DPI 的显示器也能对上。
+        if not shell_enabled:
+            return 1.0
+        try:
+            from webview.platforms import winforms
+
+            form = winforms.BrowserView.instances.get(window.uid)
+            if form is not None:
+                return window_dpi_scale(int(form.Handle.ToInt64()))
+        except Exception:
+            pass
+        return 1.0
 
     def window_size(w, h):
         global width
         global height
-        size = sanitize_window_size(w, h)
-        if size is not None:
-            width, height = size
+        scale = current_dpi_scale()
+        logical = sanitize_window_size(round(w / scale), round(h / scale))
+        if logical is not None:
+            width, height = logical
 
     window = webview.create_window(
         window_title(instance_name, port),
@@ -302,8 +342,25 @@ def webview_window(
         confirm_close=not tray,
         width=width,
         height=height,
+        min_size=DESKTOP_WINDOW_MIN_SIZE,
+        resizable=True,
+        frameless=shell_enabled,
+        easy_drag=False,
+        shadow=True,
+        background_color=window_background_color(theme),
     )
     window.events.resized += window_size
+    bridge = attach_window_shell(window, initial_size=WindowSize(width, height))
+    if bridge.get_platform()["platform"] == "windows":
+        from arknights_mower.utils.windows_frameless import (
+            install_windows_frameless_resize,
+        )
+
+        install_windows_frameless_resize(
+            window,
+            WindowSize(width, height),
+            DESKTOP_WINDOW_MIN_SIZE,
+        )
 
     def recv_msg():
         while True:
@@ -345,7 +402,9 @@ def webview_window(
 
         size = sanitize_window_size(width, height)
         if size is not None:
-            save_window_size(size)
+            ratio = ratio_from_window_size(WindowSize(*size))
+            if ratio is not None:
+                save_window_ratio(ratio)
         sys.exit()
     except Exception:
         from arknights_mower.utils.log import logger


### PR DESCRIPTION
## 变更

把 Windows 端桌面窗口改为无边框并自绘标题栏：

- 标题栏进入应用内随主题切换，窗口控制走后端桥接
- 保留 Windows 原生非客户区缩放、对齐与 DPI 处理，避免无边框化带来易用性回退
- 窗口尺寸改为按屏幕工作区比例写入 gui.yml；默认 1450×850，用户调大的窗口以比例存储并一比一回
- resized 回调给物理像素，存盘前按显示器 DPI 还原成逻辑值，否则尺寸越开越大
- 窗口几何收敛为 WindowSize/WindowRatio 值对象，bridge 协议由后端单一来源下发
- 标题栏软件版本取启动快照，资源包版本经 resource_updated 广播实时刷新

## 限制

仅 Windows 生效：拖拽/缩放/DPI 归一依赖 Windows 原生非客户区机制（WM_NCHITTEST、SetWindowPos、GetDpiForWindow）；macOS/Linux 沿用系统原生窗口与原始标题栏。

## 验证

ruff 全过；webview_ui_tests + config_tests 共 44 通过；prettier 全过。