### PR TITLE
feat(maa): 改用 medicine_expire_days 支持按剩余天数使用理智药

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -3853,12 +3853,14 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             server_weekday = get_server_weekday()
             _plan = conf.maa_weekly_plan[server_weekday]
             logger.info(f"现在服务器是{_plan.weekday}")
-            use_medicine = False
-            if conf.maa_expiring_medicine:
+            medicine_expire_days = 0
+            if conf.medicine_expire_days > 0:
                 if conf.expiring_medicine_on_weekend:
-                    use_medicine = server_weekday >= 5
+                    medicine_expire_days = (
+                        conf.medicine_expire_days if server_weekday >= 5 else 0
+                    )
                 else:
-                    use_medicine = True
+                    medicine_expire_days = conf.medicine_expire_days
             stages = self.apply_maa_stage_inventory_rules(_plan.stage)
             for stage in stages:
                 logger.info(f"添加关卡:{stage}")
@@ -3877,7 +3879,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         "penguin_id": "",
                         "DrGrandet": False,
                         "server": "CN",
-                        "expiring_medicine": 999 if use_medicine else 0,
+                        "medicine_expire_days": medicine_expire_days,
                     },
                 )
                 self.stages.append(stage)

--- a/arknights_mower/solvers/operation.py
+++ b/arknights_mower/solvers/operation.py
@@ -395,7 +395,7 @@ class OperationSolver(SceneGraphSolver):
             return True
         elif scene == Scene.OPERATOR_RECOVER_POTION:
             use_medicine = False
-            if config.conf.maa_expiring_medicine:
+            if config.conf.medicine_expire_days > 0:
                 if config.conf.expiring_medicine_on_weekend:
                     use_medicine = get_server_weekday() >= 5
                 else:

--- a/arknights_mower/tests/config_tests.py
+++ b/arknights_mower/tests/config_tests.py
@@ -338,10 +338,10 @@ class TestConfigPersistence(unittest.TestCase):
         self.conf_path.write_text(text, encoding="utf-8")
 
     def test_save_conf_writes_only_user_configured_keys(self):
-        with _patched_conf(self.conf_path, Conf(maa_expiring_medicine=False)):
+        with _patched_conf(self.conf_path, Conf(medicine_expire_days=3)):
             config_module.save_conf()
         written = self.conf_path.read_text(encoding="utf-8")
-        self.assertIn("maa_expiring_medicine", written)
+        self.assertIn("medicine_expire_days", written)
         # 未配置的默认字段不落盘
         self.assertNotIn("expiring_medicine_on_weekend", written)
         self.assertNotIn("maa_eat_stone", written)
@@ -356,6 +356,22 @@ class TestConfigPersistence(unittest.TestCase):
         written = self.conf_path.read_text(encoding="utf-8")
         self.assertNotIn("maa_eat_stone", written)
         self.assertNotIn("webview", written)
+
+    def test_medicine_expire_days_defaults_to_zero_when_unset(self):
+        with _patched_conf(self.conf_path, Conf()):
+            # 未配置 → 运行时默认 0（不使用过期理智药），且不被标记为已设置
+            self.assertEqual(config_module.conf.medicine_expire_days, 0)
+            self.assertNotIn(
+                "medicine_expire_days", config_module.conf.model_fields_set
+            )
+
+    def test_medicine_expire_days_round_trips_when_configured(self):
+        with _patched_conf(self.conf_path, Conf(medicine_expire_days=3)):
+            self.assertEqual(config_module.conf.medicine_expire_days, 3)
+            self.assertIn("medicine_expire_days", config_module.conf.model_fields_set)
+            config_module.save_conf()
+        written = self.conf_path.read_text(encoding="utf-8")
+        self.assertIn("medicine_expire_days", written)
 
     def test_legacy_key_migrates_to_new_key_when_configured(self):
         self._write_conf("exipring_medicine_on_weekend: true\n")
@@ -372,7 +388,7 @@ class TestConfigPersistence(unittest.TestCase):
         self.assertNotIn("exipring_medicine_on_weekend", written)
 
     def test_legacy_key_not_migrated_when_absent(self):
-        self._write_conf("maa_expiring_medicine: false\n")
+        self._write_conf("maa_eat_stone: false\n")
         with _patched_conf(self.conf_path):
             config_module.load_conf()
             # 没配过旧键：新键用运行时默认值，且不被标记为已设置（因此不落盘）

--- a/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
+++ b/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
@@ -10,7 +10,12 @@ import arknights_mower.solvers.base_schedule as base_schedule  # noqa: E402
 from arknights_mower.solvers.base_schedule import BaseSchedulerSolver  # noqa: E402
 
 
-def _conf(*, enabled=True):
+def _conf(
+    *,
+    enabled=True,
+    medicine_expire_days=0,
+    expiring_medicine_on_weekend=False,
+):
     return SimpleNamespace(
         maa_stage_inventory_enable=enabled,
         maa_stage_limit_rules=[
@@ -24,16 +29,71 @@ def _conf(*, enabled=True):
         maa_stage_ratio_rules=[],
         maa_weekly_plan=[
             SimpleNamespace(
-                weekday="周一",
-                stage=["1-7", "CE-6"],
-                medicine=0,
-                sanity_threshold=0,
+                weekday=name, stage=["1-7", "CE-6"], medicine=0, sanity_threshold=0
             )
+            for name in ("周一", "周二", "周三", "周四", "周五", "周六", "周日")
         ],
-        maa_expiring_medicine=False,
-        expiring_medicine_on_weekend=False,
+        medicine_expire_days=medicine_expire_days,
+        expiring_medicine_on_weekend=expiring_medicine_on_weekend,
         maa_eat_stone=False,
     )
+
+
+class MaaFightMedicineExpireDaysTests(unittest.TestCase):
+    """#263：Fight 下发 medicine_expire_days，替换已弃用的 expiring_medicine。"""
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda self: None)
+    def _append_fight(self, **overrides):
+        solver = BaseSchedulerSolver()
+        solver.MAA = MagicMock()
+        solver.stages = []
+        weekday = overrides.pop("weekday", 0)
+        with (
+            patch.object(solver, "maybe_switch_expired_activity_plan"),
+            # 本类只测 medicine_expire_days 取值，绕过库存选关（不注入快照、不依赖 depot）
+            patch.object(
+                base_schedule.config, "conf", _conf(enabled=False, **overrides)
+            ),
+            patch.object(
+                base_schedule,
+                "get_server_weekday",
+                return_value=weekday,
+            ),
+            patch.object(base_schedule, "cultivateDepotSolver"),
+        ):
+            solver.append_maa_task("Fight")
+        return solver.MAA.append_task.call_args
+
+    def test_disabled_medicine_sends_zero_and_no_legacy_key(self):
+        # 默认不使用：medicine_expire_days 为 0，且不带已弃用的 expiring_medicine
+        call = self._append_fight(medicine_expire_days=0, weekday=0)
+        task_type, task_config = call.args
+        self.assertEqual(task_type, "Fight")
+        self.assertEqual(task_config["medicine_expire_days"], 0)
+        self.assertNotIn("expiring_medicine", task_config)
+
+    def test_configured_medicine_sends_days_regardless_of_weekday(self):
+        # 未勾选周末限定：任何一天都下发配置的天数
+        for weekday in (0, 6):
+            call = self._append_fight(medicine_expire_days=3, weekday=weekday)
+            task_config = call.args[1]
+            self.assertEqual(task_config["medicine_expire_days"], 3)
+
+    def test_weekend_only_weekday_sends_zero(self):
+        # 勾选周末限定：非周末传 0
+        call = self._append_fight(
+            medicine_expire_days=3, expiring_medicine_on_weekend=True, weekday=0
+        )
+        task_config = call.args[1]
+        self.assertEqual(task_config["medicine_expire_days"], 0)
+
+    def test_weekend_only_weekend_sends_configured_days(self):
+        # 勾选周末限定：周末传配置的天数
+        call = self._append_fight(
+            medicine_expire_days=3, expiring_medicine_on_weekend=True, weekday=6
+        )
+        task_config = call.args[1]
+        self.assertEqual(task_config["medicine_expire_days"], 3)
 
 
 class MaaStageInventorySchedulerTests(unittest.TestCase):

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -293,8 +293,8 @@ class RegularTaskPart(ConfModel):
     "日常任务"
     maa_gap: float = 3
     "日常任务间隔"
-    maa_expiring_medicine: bool = True
-    "自动使用将要过期（约3天）的理智药"
+    medicine_expire_days: int = 0
+    "自动使用将要过期的理智药（剩余天数，0 表示不使用）"
     expiring_medicine_on_weekend: bool = False
     "仅在周末使用将要过期的理智药"
     ap_fallback: int = 0

--- a/ui/src/components/MaaWeekly.vue
+++ b/ui/src/components/MaaWeekly.vue
@@ -19,7 +19,7 @@ const store = useConfigStore()
 const {
   maa_weekly_plan,
   maa_enable,
-  maa_expiring_medicine,
+  medicine_expire_days,
   expiring_medicine_on_weekend,
   ap_fallback
 } = storeToRefs(store)
@@ -261,16 +261,37 @@ function cancelCopyDialogLongPress() {
       <n-form-item :show-label="false">
         <n-flex vertical :size="8">
           <n-flex class="weekly-plan-toolbar" align="center">
-            <n-checkbox v-model:checked="maa_expiring_medicine">使用将要过期的理智药</n-checkbox>
-            <n-checkbox
-              v-model:checked="expiring_medicine_on_weekend"
-              :disabled="!maa_expiring_medicine"
+            <span>使用还剩</span>
+            <n-input-number
+              v-model:value="medicine_expire_days"
+              :min="0"
+              :max="999"
+              :show-button="false"
+              placeholder="0"
+              style="width: 90px"
             >
-              周末使用
-            </n-checkbox>
+              <template #suffix>天</template>
+            </n-input-number>
+            <span>过期的理智药</span>
+            <help-text>
+              <div>
+                实际会服用游戏内显示剩余天数小于此处填写天数的理智药（如填 3，则剩余不足 3
+                天才用）。
+              </div>
+              <div>填 0 表示不服用（默认）。</div>
+              <div>勾选「只在周末服用过期的理智药」后，只在周末服用，平时不用。</div>
+            </help-text>
             <div class="weekly-plan-selector-wrap">
               <WeeklyPlanSelector compact />
             </div>
+          </n-flex>
+          <n-flex>
+            <n-checkbox
+              v-model:checked="expiring_medicine_on_weekend"
+              :disabled="medicine_expire_days <= 0"
+            >
+              只在周末服用过期的理智药
+            </n-checkbox>
           </n-flex>
           <n-flex>
             <n-checkbox v-model:checked="filterStageByAvailability">只显示当日开放关卡</n-checkbox>

--- a/ui/src/stores/config.js
+++ b/ui/src/stores/config.js
@@ -19,7 +19,7 @@ export const useConfigStore = defineStore('config', () => {
   const maa_mirrorchyan_token = ref('')
   const maa_update_channel = ref('stable')
   const maa_auto_check_update = ref(false)
-  const maa_expiring_medicine = ref(true)
+  const medicine_expire_days = ref(0)
   const ap_fallback = ref(0)
   const maa_weekly_plan = ref([])
   const maa_weekly_plan_options = ref([])
@@ -365,7 +365,7 @@ export const useConfigStore = defineStore('config', () => {
     maa_auto_check_update.value = response.data.maa_auto_check_update ?? false
     maa_rg_enable.value = response.data.maa_rg_enable == 1
     maa_long_task_type.value = response.data.maa_long_task_type
-    maa_expiring_medicine.value = response.data.maa_expiring_medicine
+    medicine_expire_days.value = response.data.medicine_expire_days
     ap_fallback.value = Number(response.data.ap_fallback) || 0
     maa_weekly_plan.value = normalizeWeeklyPlan(response.data.maa_weekly_plan)
     maa_weekly_plan_active.value = response.data.maa_weekly_plan_active || ''
@@ -481,7 +481,7 @@ export const useConfigStore = defineStore('config', () => {
       maa_auto_check_update: maa_auto_check_update.value,
       maa_rg_enable: maa_rg_enable.value ? 1 : 0,
       maa_long_task_type: maa_long_task_type.value,
-      maa_expiring_medicine: maa_expiring_medicine.value,
+      medicine_expire_days: medicine_expire_days.value,
       ap_fallback: ap_fallback.value,
       maa_stage_inventory_enable: maa_stage_inventory_enable.value,
       maa_stage_limit_rules: normalizeStageLimitRules(maa_stage_limit_rules.value),
@@ -639,7 +639,7 @@ export const useConfigStore = defineStore('config', () => {
     maa_auto_check_update,
     maa_rg_enable,
     maa_long_task_type,
-    maa_expiring_medicine,
+    medicine_expire_days,
     ap_fallback,
     maa_weekly_plan,
     maa_weekly_plan_options,


### PR DESCRIPTION
## 变更

MAA v6.8.0 起协议弃用了 Fight 任务的 `expiring_medicine` 字段，改用 `medicine_expire_days`（剩余天数，默认 0 = 不使用过期理智药）。原先 mower 是下发布尔开关 `maa_expiring_medicine` 乘上 999，语义偏「吃到爽」；换成天数之后，改为按配置里可填的具体天数下发。

本票把这一逻辑收敛到天数配置上：

- 配置模型里把 `maa_expiring_medicine: bool` 替换成可填的 `medicine_expire_days: int`（默认 0）。
- 日常刷理智与本地作战两处读取，「>0 即启用，勾选周末限定则非周末传 0、周末传配置天数」的既有语义保持不变。
- Fight 下发改用 `medicine_expire_days`，去掉已弃用的 `expiring_medicine`。
- 前端把勾选框改成可填的天数输入，文案改为「只在周末服用过期的理智药」。

`exipring_medicine_on_weekend` → `expiring_medicine_on_weekend` 的键名修正与旧值迁移钩子已由 #258 完成，本票在其上只改逻辑，未重复迁移。

## 限制

- `medicine_expire_days` 的新默认值是 0（不使用），与旧默认 `maa_expiring_medicine=True` 的偏好不一致。旧配置里显式写过的 `maa_expiring_medicine` 键会被 pydantic 按 ignore 规则静默丢弃，没写过的字段本来就不落盘，因此升级后默认行为是「不使用过期理智药」，需要用户按需在设置页重新配置天数。
- 本票范围严格限定在 Fight 字段修正，未触及 E 档（MAA 出错不关游戏）等内容。

## 验证

- `config_tests.py` 与 `maa_stage_inventory_scheduler_tests.py` 共 37 项通过（含新增的 `medicine_expire_days` 默认值、落盘往返、Fight 下发取值与周末门控各分支）。
- 全量测试 1207 项：1206 通过，1 项因测试环境缺 `socksio` 包而失败（与本次改动无关），7 项跳过。
- 改动文件通过 ruff lint 与 `ruff format --check`，前端改动通过 prettier 检查。
