### PR TITLE
fix(maa): 修复调用 maa 信用作战时设置指定的编队不生效

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -3895,7 +3895,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     "credit_fight": conf.maa_credit_fight
                     and "" not in self.stages
                     and self.credit_fight is None,
-                    "select_formation": conf.credit_fight.squad,
+                    "formation_index": max(0, min(4, conf.credit_fight.squad)),
                     "force_shopping_if_credit_full": conf.maa_mall_ignore_blacklist_when_full,
                 },
             )

--- a/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
+++ b/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
@@ -39,6 +39,16 @@ def _conf(
     )
 
 
+def _mall_conf(*, squad=1, credit_fight_enabled=True, ignore_blacklist=False):
+    return SimpleNamespace(
+        maa_mall_buy="招聘许可,技巧概要·卷2",
+        maa_mall_blacklist="加急许可,碳,碳素,家具零件",
+        maa_credit_fight=credit_fight_enabled,
+        credit_fight=SimpleNamespace(squad=squad),
+        maa_mall_ignore_blacklist_when_full=ignore_blacklist,
+    )
+
+
 class MaaFightMedicineExpireDaysTests(unittest.TestCase):
     """#263：Fight 下发 medicine_expire_days，替换已弃用的 expiring_medicine。"""
 
@@ -94,6 +104,38 @@ class MaaFightMedicineExpireDaysTests(unittest.TestCase):
         )
         task_config = call.args[1]
         self.assertEqual(task_config["medicine_expire_days"], 3)
+
+
+class MaaMallFormationIndexTests(unittest.TestCase):
+    """#261：Mall 下发协议字段 formation_index，替换非协议字段 select_formation。"""
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda self: None)
+    def _append_mall(self, **overrides):
+        solver = BaseSchedulerSolver()
+        solver.MAA = MagicMock()
+        solver.stages = []
+        solver.credit_fight = None
+        with patch.object(base_schedule.config, "conf", _mall_conf(**overrides)):
+            solver.append_maa_task("Mall")
+        return solver.MAA.append_task.call_args
+
+    def test_mall_uses_formation_index_and_drops_select_formation(self):
+        call = self._append_mall(squad=1)
+        task_type, task_config = call.args
+        self.assertEqual(task_type, "Mall")
+        self.assertIn("formation_index", task_config)
+        self.assertNotIn("select_formation", task_config)
+
+    def test_mall_formation_index_is_squad_without_mapping(self):
+        # 0 = 当前编队，1–4 指定对应编队，直接透传 squad
+        for squad in (0, 1, 2, 3, 4):
+            task_config = self._append_mall(squad=squad).args[1]
+            self.assertEqual(task_config["formation_index"], squad)
+
+    def test_mall_formation_index_clamps_out_of_range(self):
+        # 钳制到 0–4，防御未来配置越界（不做 -1 变换）
+        self.assertEqual(self._append_mall(squad=9).args[1]["formation_index"], 4)
+        self.assertEqual(self._append_mall(squad=-3).args[1]["formation_index"], 0)
 
 
 class MaaStageInventorySchedulerTests(unittest.TestCase):


### PR DESCRIPTION
## 变更

mower 下发 Mall MAA 任务时使用的 `select_formation` 不是协议字段（协议里 Mall 没有它，且旧字段为布尔，当前却塞了整数编队号），下发给 MAA 会被忽略，信用作战不生效。本提交改为使用协议字段 `formation_index`（0 = 当前编队，1–4 指定），值取 `credit_fight.squad` 直传并钳制到 0–4，不做 -1 变换，避免脆弱的映射。

同时新增测试，断言 `MAA.append_task` 收到的 Mall 参数，覆盖字段名、直传取值与越界钳制。

## 限制

前端「获取信用及购物」页的编队下拉当前只提供第一到第四编队（值 1–4），经 `credit_fight.squad` 正确往返并映射到 `formation_index` 1–4；未新增「0 = 当前编队」选项，该语义由协议支持、非本提交范围。配置默认 `squad = 1`（第一编队），沿用既有语义，本次未改动。

## 验证

- 新增 Mall 用例及其余调度/相关文件测试通过（123 passed）。
- 全量测试 1246 passed、7 skipped、1 failed，该失败为 `socks_proxy_tests.py` 在本地解释器缺 `socksio` 包的既有环境问题，与本改动无关。
- ruff check 与 ruff format --check 均通过。

Part of NiceAfternoon/arknights-mower#206（A2 档），对应 NiceAfternoon/arknights-mower#235 A 档 User Story 4。
