### PR TITLE
fix(maa): 修复 StartUp 与 Fight 未下发协议必填的 client_type

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -108,6 +108,11 @@ def _add_group_to_fix_plan(fix_plan: dict, op_data: Operators, group: str) -> No
         fix_plan[agent.room][agent.index] = name
 
 
+def _maa_client_type() -> str:
+    """推导 MAA 集成协议的客户端类型：官服 Official，B 服 Bilibili。"""
+    return "Official" if config.conf.package_type == 1 else "Bilibili"
+
+
 class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
     """
     收集基建的产物：物资、赤金、信赖
@@ -3845,7 +3850,9 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             raise Exception("MAA 连接失败")
 
     def append_maa_task(self, type):
-        if type in ["StartUp", "Visit"]:
+        if type == "StartUp":
+            self.MAA.append_task("StartUp", {"client_type": _maa_client_type()})
+        elif type == "Visit":
             self.MAA.append_task(type)
         elif type == "Fight":
             self.maybe_switch_expired_activity_plan()
@@ -3875,7 +3882,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         "times": 999,
                         "series": 0,
                         "report_to_penguin": True,
-                        "client_type": "",
+                        "client_type": _maa_client_type(),
                         "penguin_id": "",
                         "DrGrandet": False,
                         "server": "CN",

--- a/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
+++ b/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
@@ -13,10 +13,12 @@ from arknights_mower.solvers.base_schedule import BaseSchedulerSolver  # noqa: E
 def _conf(
     *,
     enabled=True,
+    package_type=1,
     medicine_expire_days=0,
     expiring_medicine_on_weekend=False,
 ):
     return SimpleNamespace(
+        package_type=package_type,
         maa_stage_inventory_enable=enabled,
         maa_stage_limit_rules=[
             {
@@ -154,6 +156,51 @@ class MaaStageInventorySchedulerTests(unittest.TestCase):
 
         self.assertEqual(stages, ["1-7", "CE-6"])
         refresh_solver.assert_not_called()
+
+
+class MaaClientTypeTests(unittest.TestCase):
+    """#260：StartUp 与 Fight 下发协议必填的 client_type，由 package_type 推导。"""
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda self: None)
+    def _append(self, task_type, package_type):
+        solver = BaseSchedulerSolver()
+        solver.MAA = MagicMock()
+        solver.stages = []
+        with (
+            patch.object(solver, "maybe_switch_expired_activity_plan"),
+            patch.object(
+                base_schedule.config,
+                "conf",
+                _conf(enabled=False, package_type=package_type),
+            ),
+            patch.object(base_schedule, "get_server_weekday", return_value=0),
+            patch.object(base_schedule, "cultivateDepotSolver"),
+        ):
+            solver.append_maa_task(task_type)
+        return solver.MAA.append_task.call_args
+
+    def test_startup_sends_official_for_official_package(self):
+        # 官服（package_type=1）推导为 Official
+        call = self._append("StartUp", 1)
+        self.assertEqual(call.args, ("StartUp", {"client_type": "Official"}))
+
+    def test_startup_sends_bilibili_for_bilibili_package(self):
+        # B 服（package_type != 1）推导为 Bilibili
+        call = self._append("StartUp", 2)
+        self.assertEqual(call.args, ("StartUp", {"client_type": "Bilibili"}))
+
+    def test_fight_sends_official_for_official_package(self):
+        # 官服 package_type=1 时 Fight 与 StartUp 一致下发 Official
+        call = self._append("Fight", 1)
+        task_type, task_config = call.args
+        self.assertEqual(task_type, "Fight")
+        self.assertEqual(task_config["client_type"], "Official")
+
+    def test_fight_sends_bilibili_for_bilibili_package(self):
+        # B 服 package_type=2 时 Fight 下发 Bilibili
+        call = self._append("Fight", 2)
+        task_config = call.args[1]
+        self.assertEqual(task_config["client_type"], "Bilibili")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 变更

对照 MAA 集成协议，StartUp 的 `client_type` 被标为必填，Fight 也要求携带。此前 StartUp 空参下发、Fight 下发空串，只能依赖 MAA 用连接时默认的客户端类型兜底。

本次统一按服务器配置 `package_type` 推导：为 1 时下发 `Official`，否则下发 `Bilibili`，StartUp 与 Fight 两处一致。推导逻辑收敛到模块级 `_maa_client_type()`，避免两处各自内联、后续漂移。

## 限制

- 推导映射与伞票 NiceAfternoon/arknights-mower#206 的 A3/A6、spec NiceAfternoon/arknights-mower#235 的 User Story 5 与 6 一致（NiceAfternoon/arknights-mower#260）。
- 配置字段 `package_type`（int，默认 1）已存在，未新增配置键，也未改动 conf.py。
- 长任务块与其它 task 分支经全量检索无其它 `client_type` 下发点，未触及。
- 不在本票范围的 `Visit` 死分支在拆分 StartUp 时保持原样，未做删除（另票处理）。

## 验证

- 新增 `MaaClientTypeTests`：StartUp 与 Fight 在各 `package_type` 下的下发值均断言到 `self.MAA.append_task` 收到的参数。
- 相关调度测试 119 项通过；全量套件 1246 通过、7 跳过（唯二失败为本改动无关的既有问题：socks_proxy 缺 socksio 环境包、resource_pkg 的测试隔离抖动）。
- `ruff check` 与 `ruff format --check` 对改动文件均通过。
