### PR TITLE
fix(ui): 修复 WebUI 深色模式下输入框和选择框显示白色

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -884,7 +884,7 @@ html[data-window-shell-theme='dark'] .provider--window-shell {
   --n-placeholder-color: #71717a !important;
   --n-box-shadow-focus: 0 0 0 2px #ffffff, 0 0 0 4px rgba(24, 160, 88, 0.4) !important;
 }
-html[data-window-shell-theme='dark'] .n-input {
+html[data-mower-theme='dark'] .n-input {
   --n-border: 1px solid #27272a !important;
   --n-border-hover: 1px solid #3f3f46 !important;
   --n-border-focus: 1px solid #27272a !important;
@@ -919,7 +919,7 @@ html[data-window-shell-theme='dark'] .n-input {
   --n-option-color-active: rgba(24, 160, 88, 0.1) !important;
   --n-option-color-active-pending: rgba(24, 160, 88, 0.14) !important;
 }
-html[data-window-shell-theme='dark'] .n-base-selection {
+html[data-mower-theme='dark'] .n-base-selection {
   --n-border: 1px solid #27272a !important;
   --n-border-hover: 1px solid #3f3f46 !important;
   --n-border-focus: 1px solid #27272a !important;
@@ -929,7 +929,7 @@ html[data-window-shell-theme='dark'] .n-base-selection {
   --n-placeholder-color: #71717a !important;
   --n-box-shadow-focus: 0 0 0 2px #101014, 0 0 0 4px rgba(99, 226, 183, 0.4) !important;
 }
-html[data-window-shell-theme='dark'] .n-base-select-menu {
+html[data-mower-theme='dark'] .n-base-select-menu {
   --n-color: #101014 !important;
   --n-option-color-pending: rgba(99, 226, 183, 0.12) !important;
   --n-option-color-active: rgba(99, 226, 183, 0.16) !important;


### PR DESCRIPTION
浏览器 WebUI 切换到深色模式后，输入框、选择框和下拉菜单仍显示白色背景。#979 新增的控件样式依赖 `data-window-shell-theme`，该属性只在桌面窗口启用后设置，普通浏览器无法命中深色规则。

将 `App.vue` 中 `.n-input`、`.n-base-selection` 和 `.n-base-select-menu` 的深色选择器统一改为跟随 `data-mower-theme`，恢复现有的深色背景、文字、边框和高亮。该属性位于 `html`，也能覆盖挂载到页面外层及弹窗内的下拉菜单。

## 验证

- `npm run build` 通过。
- `npm test -- src/theme/mower.test.js`：16 项通过。
- `npx --yes prettier@latest --check src/App.vue` 与 `git diff --check` 通过。
- Playwright 组件验证通过：浏览器与桌面主题状态下的亮暗切换、单选/多选、输入框、数字输入框、多行输入框及弹窗下拉菜单；已对比修复前后的截图。
