### PR TITLE
feat(maa): 支持访问好友由 mower 原生或 MAA 处理

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -3852,8 +3852,6 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
     def append_maa_task(self, type):
         if type == "StartUp":
             self.MAA.append_task("StartUp", {"client_type": _maa_client_type()})
-        elif type == "Visit":
-            self.MAA.append_task(type)
         elif type == "Fight":
             self.maybe_switch_expired_activity_plan()
             conf = config.conf
@@ -3904,6 +3902,8 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     and self.credit_fight is None,
                     "formation_index": max(0, min(4, conf.credit_fight.squad)),
                     "force_shopping_if_credit_full": conf.maa_mall_ignore_blacklist_when_full,
+                    "visit_friends": conf.visit_friend_enable
+                    and conf.visit_friend_mode == "maa",
                 },
             )
         elif type == "Award":
@@ -4683,7 +4683,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             return ReportSolver(self.device, self.recog).run()
 
     def visit_friend_plan_solver(self):
-        if config.conf.visit_friend:
+        if config.conf.visit_friend_enable and config.conf.visit_friend_mode == "mower":
             return CreditSolver(self.device, self.recog).run()
 
     def sign_in_plan_solver(self):

--- a/arknights_mower/tests/config_tests.py
+++ b/arknights_mower/tests/config_tests.py
@@ -433,6 +433,81 @@ class TestConfigPersistence(unittest.TestCase):
         self.assertIn("expiring_medicine_on_weekend", written)
         self.assertNotIn("exipring_medicine_on_weekend", written)
 
+    def test_visit_friend_defaults_enable_true_and_mode_maa_when_unset(self):
+        with _patched_conf(self.conf_path, Conf()):
+            # 未配置 → 默认开启且交 MAA（visit_friend_mode=maa），且都不被标记为已设置
+            self.assertTrue(config_module.conf.visit_friend_enable)
+            self.assertEqual(config_module.conf.visit_friend_mode, "maa")
+            self.assertNotIn("visit_friend_enable", config_module.conf.model_fields_set)
+            self.assertNotIn("visit_friend_mode", config_module.conf.model_fields_set)
+
+    def test_visit_friend_round_trips_when_configured(self):
+        with _patched_conf(
+            self.conf_path, Conf(visit_friend_enable=False, visit_friend_mode="mower")
+        ):
+            self.assertFalse(config_module.conf.visit_friend_enable)
+            self.assertEqual(config_module.conf.visit_friend_mode, "mower")
+            self.assertIn("visit_friend_enable", config_module.conf.model_fields_set)
+            config_module.save_conf()
+        written = self.conf_path.read_text(encoding="utf-8")
+        self.assertIn("visit_friend_enable", written)
+        self.assertIn("visit_friend_mode", written)
+
+    def test_legacy_visit_friend_true_migrates_to_enable_true_and_mower(self):
+        # `visit_friend: true`（原语义：mower 原生访问好友）迁移为 visit_friend_enable=true，
+        # 并保留 mode=mower，避免非 MAA 用户在迁移后静默失去访问好友
+        self._write_conf("visit_friend: true\n")
+        with _patched_conf(self.conf_path):
+            config_module.load_conf()
+            self.assertTrue(config_module.conf.visit_friend_enable)
+            self.assertEqual(config_module.conf.visit_friend_mode, "mower")
+            self.assertIn("visit_friend_enable", config_module.conf.model_fields_set)
+            config_module.save_conf()
+        written = self.conf_path.read_text(encoding="utf-8")
+        self.assertIn("visit_friend_enable", written)
+        self.assertIn("visit_friend_mode", written)
+        self.assertNotIn("visit_friend:", written)
+
+    def test_legacy_visit_friend_false_migrates_to_enable_false(self):
+        # `visit_friend: false`（用户显式关闭访问好友）迁移为 visit_friend_enable=false
+        self._write_conf("visit_friend: false\n")
+        with _patched_conf(self.conf_path):
+            config_module.load_conf()
+            self.assertFalse(config_module.conf.visit_friend_enable)
+
+    def test_legacy_visit_friend_not_migrated_when_absent(self):
+        self._write_conf("maa_eat_stone: false\n")
+        with _patched_conf(self.conf_path):
+            config_module.load_conf()
+            # 没配过旧键：新键用运行时默认（enable=true、mode=maa），且不被标记为已设置
+            self.assertTrue(config_module.conf.visit_friend_enable)
+            self.assertEqual(config_module.conf.visit_friend_mode, "maa")
+            self.assertNotIn("visit_friend_enable", config_module.conf.model_fields_set)
+
+    def test_new_visit_friend_enable_takes_precedence_when_both_present(self):
+        self._write_conf("visit_friend: true\nvisit_friend_enable: false\n")
+        with _patched_conf(self.conf_path):
+            config_module.load_conf()
+            # 新旧键同时出现时以新键为准，不覆盖已配置的值
+            self.assertFalse(config_module.conf.visit_friend_enable)
+
+    def test_migrated_visit_friend_survives_round_trip(self):
+        self._write_conf("visit_friend: true\n")
+        with _patched_conf(self.conf_path):
+            config_module.load_conf()
+            config_module.save_conf()
+            config_module.load_conf()
+            self.assertTrue(config_module.conf.visit_friend_enable)
+            self.assertEqual(config_module.conf.visit_friend_mode, "mower")
+
+    def test_conf_post_with_legacy_visit_friend_reconciles(self):
+        # 兼容：/conf POST 提交旧键名（旧前端整包）时，Conf 校验层统一迁移，不把新键重置成默认。
+        with _patched_conf(self.conf_path):
+            config_module.conf = config_module.Conf(**{"visit_friend": True})
+            self.assertTrue(config_module.conf.visit_friend_enable)
+            self.assertEqual(config_module.conf.visit_friend_mode, "mower")
+            self.assertIn("visit_friend_enable", config_module.conf.model_fields_set)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
+++ b/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
@@ -41,13 +41,22 @@ def _conf(
     )
 
 
-def _mall_conf(*, squad=1, credit_fight_enabled=True, ignore_blacklist=False):
+def _mall_conf(
+    *,
+    squad=1,
+    credit_fight_enabled=True,
+    ignore_blacklist=False,
+    visit_friend_enable=True,
+    visit_friend_mode="maa",
+):
     return SimpleNamespace(
         maa_mall_buy="招聘许可,技巧概要·卷2",
         maa_mall_blacklist="加急许可,碳,碳素,家具零件",
         maa_credit_fight=credit_fight_enabled,
         credit_fight=SimpleNamespace(squad=squad),
         maa_mall_ignore_blacklist_when_full=ignore_blacklist,
+        visit_friend_enable=visit_friend_enable,
+        visit_friend_mode=visit_friend_mode,
     )
 
 
@@ -243,6 +252,87 @@ class MaaClientTypeTests(unittest.TestCase):
         call = self._append("Fight", 2)
         task_config = call.args[1]
         self.assertEqual(task_config["client_type"], "Bilibili")
+
+
+class MaaVisitFriendModeTests(unittest.TestCase):
+    """#262：visit_friend_enable + visit_friend_mode 控制访问好友交给 mower 还是 MAA。
+
+    开启且 mode=mower 时走原生 CreditSolver、Mall 不下发 visit_friends；开启且 mode=maa
+    时 Mall 下发 visit_friends: true 且原生跳过；关闭时两者都不做；Visit 死分支已移除。
+    """
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda self: None)
+    def _append_mall(self, **overrides):
+        solver = BaseSchedulerSolver()
+        solver.MAA = MagicMock()
+        solver.stages = []
+        solver.credit_fight = None
+        with patch.object(base_schedule.config, "conf", _mall_conf(**overrides)):
+            solver.append_maa_task("Mall")
+        return solver.MAA.append_task.call_args
+
+    def test_mall_dispatches_visit_friends_when_enabled_and_maa(self):
+        # 开启且 mode=maa 时 Mall 下发 visit_friends: true，交给 MAA 处理
+        task_config = self._append_mall(
+            visit_friend_enable=True, visit_friend_mode="maa"
+        ).args[1]
+        self.assertEqual(task_config["visit_friends"], True)
+
+    def test_mall_dispatches_visit_friends_false_when_enabled_and_mower(self):
+        # 开启且 mode=mower 时 Mall 下发 visit_friends: false，访问好友走 mower 原生
+        task_config = self._append_mall(
+            visit_friend_enable=True, visit_friend_mode="mower"
+        ).args[1]
+        self.assertEqual(task_config["visit_friends"], False)
+
+    def test_mall_dispatches_visit_friends_false_when_disabled(self):
+        # 关闭时 Mall 下发 visit_friends: false（即使 mode=maa）
+        task_config = self._append_mall(
+            visit_friend_enable=False, visit_friend_mode="maa"
+        ).args[1]
+        self.assertEqual(task_config["visit_friends"], False)
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda self: None)
+    def _plan(self, enable, mode):
+        solver = BaseSchedulerSolver()
+        solver.device = MagicMock()
+        solver.recog = MagicMock()
+        with (
+            patch.object(
+                base_schedule.config,
+                "conf",
+                SimpleNamespace(visit_friend_enable=enable, visit_friend_mode=mode),
+            ),
+            patch.object(base_schedule, "CreditSolver") as credit,
+        ):
+            result = solver.visit_friend_plan_solver()
+        return result, credit
+
+    def test_enabled_mower_runs_native_credit_solver(self):
+        # 开启且 mode=mower 访问好友走原生 CreditSolver
+        result, credit = self._plan(True, "mower")
+        credit.assert_called_once()
+        self.assertTrue(result)
+
+    def test_enabled_maa_skips_native_credit_solver(self):
+        # 开启且 mode=maa 原生访问好友跳过，避免与 MAA 的 Mall.visit_friends 双跑
+        result, credit = self._plan(True, "maa")
+        credit.assert_not_called()
+        self.assertFalse(result)
+
+    def test_disabled_skips_native_credit_solver(self):
+        # 关闭时原生访问好友跳过（即使 mode=mower）
+        result, credit = self._plan(False, "mower")
+        credit.assert_not_called()
+        self.assertFalse(result)
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda self: None)
+    def test_visit_type_is_dead_and_omits_append_task(self):
+        # Visit 死分支已移除：下发 Visit 不再有任何 append_task 调用（功能并入 Mall.visit_friends）
+        solver = BaseSchedulerSolver()
+        solver.MAA = MagicMock()
+        solver.append_maa_task("Visit")
+        solver.MAA.append_task.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -319,8 +319,10 @@ class RegularTaskPart(ConfModel):
     "多关卡物品库存比例规则"
     maa_depot_enable: bool = False
     "仓库物品混合读取"
-    visit_friend: bool = True
+    visit_friend_enable: bool = True
     "访问好友"
+    visit_friend_mode: str = "maa"
+    "访问好友处理方式：mower 原生 / maa 交 MAA"
     report_enable: bool = True
     "读取基报"
 
@@ -563,6 +565,15 @@ class Conf(
     def migrate_legacy_keys(cls, data):
         if not isinstance(data, dict):
             return data
+        # visit_friend(bool) 已退役：迁移为 visit_friend_enable(bool)。原 true 语义是 mower
+        # 原生访问好友，迁移保留该行为（mode=mower），避免非 MAA 用户在迁移后静默失去访问
+        # 好友；未配置过旧键的新用户才取默认 maa。
+        old_visit_friend = data.pop("visit_friend", None)
+        if old_visit_friend is not None:
+            if "visit_friend_enable" not in data:
+                data["visit_friend_enable"] = old_visit_friend
+            if "visit_friend_mode" not in data:
+                data["visit_friend_mode"] = "mower" if old_visit_friend else "maa"
         for old, new in _LEGACY_KEY_MIGRATIONS.items():
             if old not in data:
                 continue

--- a/ui/src/components/Clue.vue
+++ b/ui/src/components/Clue.vue
@@ -11,7 +11,9 @@ const {
   maa_mall_ignore_blacklist_when_full,
   maa_enable,
   maa_credit_fight,
-  credit_fight
+  credit_fight,
+  visit_friend_enable,
+  visit_friend_mode
 } = storeToRefs(config_store)
 
 const plan_store = usePlanStore()
@@ -66,6 +68,11 @@ const squads = [
   { label: '第四编队', value: 4 }
 ]
 
+const visit_friend_mode_options = [
+  { label: 'mower', value: 'mower' },
+  { label: 'MAA', value: 'maa' }
+]
+
 const show_map = ref(false)
 </script>
 
@@ -84,6 +91,14 @@ const show_map = ref(false)
       </n-form-item>
       <n-form-item label="编队">
         <n-select :options="squads" v-model:value="credit_fight.squad" />
+      </n-form-item>
+      <n-form-item :show-label="false">
+        <n-checkbox v-model:checked="visit_friend_enable">
+          <div class="item">访问好友</div>
+        </n-checkbox>
+      </n-form-item>
+      <n-form-item v-if="visit_friend_enable" label="处理方式">
+        <n-select :options="visit_friend_mode_options" v-model:value="visit_friend_mode" />
       </n-form-item>
       <!--<n-form-item label="干员">
         <n-select

--- a/ui/src/components/DailyMission.vue
+++ b/ui/src/components/DailyMission.vue
@@ -6,8 +6,7 @@ const axios = inject('axios')
 
 const store = useConfigStore()
 
-const { check_mail_enable, report_enable, sign_in, visit_friend, skland_info, skland_enable } =
-  storeToRefs(store)
+const { check_mail_enable, report_enable, sign_in, skland_info, skland_enable } = storeToRefs(store)
 
 const sign_msg = ref('')
 
@@ -127,10 +126,6 @@ const SyncStatus = (item, game) => {
       <n-divider />
       <n-checkbox v-model:checked="check_mail_enable">
         <div class="item">领取邮件</div>
-      </n-checkbox>
-      <n-divider />
-      <n-checkbox v-model:checked="visit_friend">
-        <div class="item">访问好友</div>
       </n-checkbox>
       <n-divider />
       <n-flex>

--- a/ui/src/stores/config.js
+++ b/ui/src/stores/config.js
@@ -113,7 +113,8 @@ export const useConfigStore = defineStore('config', () => {
   const sign_in = ref({ enable: true })
   const droidcast = ref({})
   const mumu12IPC = ref(false)
-  const visit_friend = ref(true)
+  const visit_friend_enable = ref(true)
+  const visit_friend_mode = ref('maa')
   const credit_fight = ref({})
   const custom_screenshot = ref({})
   const hot_update_enable = ref(false)
@@ -443,7 +444,8 @@ export const useConfigStore = defineStore('config', () => {
     sign_in.value = response.data.sign_in
     droidcast.value = response.data.droidcast
     mumu12IPC.value = response.data.mumu12IPC
-    visit_friend.value = response.data.visit_friend
+    visit_friend_enable.value = response.data.visit_friend_enable ?? true
+    visit_friend_mode.value = response.data.visit_friend_mode ?? 'maa'
     credit_fight.value = response.data.credit_fight
     custom_screenshot.value = response.data.custom_screenshot
     workshop_settings.value = response.data.workshop_settings
@@ -563,7 +565,8 @@ export const useConfigStore = defineStore('config', () => {
       sign_in: sign_in.value,
       droidcast: droidcast.value,
       mumu12IPC: mumu12IPC.value,
-      visit_friend: visit_friend.value,
+      visit_friend_enable: visit_friend_enable.value,
+      visit_friend_mode: visit_friend_mode.value,
       credit_fight: credit_fight.value,
       custom_screenshot: custom_screenshot.value,
       workshop_settings: workshop_settings.value,
@@ -729,7 +732,8 @@ export const useConfigStore = defineStore('config', () => {
     sign_in,
     droidcast,
     mumu12IPC,
-    visit_friend,
+    visit_friend_enable,
+    visit_friend_mode,
     credit_fight,
     custom_screenshot,
     hot_update_enable,


### PR DESCRIPTION
对应 fork 票 NiceAfternoon/arknights-mower#262。让「访问好友」可由用户选择由 mower 原生还是 MAA 处理，默认交给 MAA。

## 目标

「访问好友」原来固定由 mower 原生处理。MAA 集成协议已移除 `Visit` 任务类型，好友访问并入 `Mall.visit_friends`，mower 原先向 MAA 下发 `Visit` 的分支不可达。本次把它改为由用户选择处理方。

## 主要改动

- 用 `visit_friend_enable`（bool，默认开启）与 `visit_friend_mode`（`"mower"` / `"maa"`，默认 `"maa"`）替换原来的 `visit_friend: bool`。
- `visit_friend_mode == "mower"` 时使用原生 `CreditSolver`，行为不变。
- `visit_friend_mode == "maa"` 时 Mall 下发 `visit_friends: true` 交由 MAA，原生 `visit_friend_plan_solver` 跳过，避免两边双跑。
- `visit_friend_enable == false` 时不访问好友。
- 删除 `append_maa_task` 里的 `elif type == "Visit"` 分支（协议已无此类型）。
- 前端控件从「日常任务」移到「maa设置 → 获取信用及购物」，改为「访问好友」复选 + 「处理方式」下拉（`mower` / `MAA`），勾选才显示处理方式。

## 验证与限制

- 默认值取 `"maa"`（原票面写的是 `"mower"`），并把「关闭」并入 `visit_friend_enable`（不再有 `"off"` 档）。这是维护者的决定：访问好友归 MAA 设置页管理、新用户默认交给 MAA。
- 旧 `visit_friend` 布尔键迁移为 `visit_friend_enable`，并把原 `true` 的「mower 原生」语义保留为 `visit_friend_mode == "mower"`，避免不跑 MAA 的用户升级后丢失访问好友；未配置旧键的用户才取默认 `"maa"`。
- 新增 `MaaVisitFriendModeTests`：断言 Mall 下发 `visit_friends` 的取值、原生 `visit_friend_plan_solver` 的门控，以及 `Visit` 分支移除后不再调用 `append_task`。配置侧新增旧键迁移、round-trip、`/conf` POST 兼容用例。
- 相关 schedule / config 测试通过；全量套件 1265 通过，1 个 `socks_proxy` 失败是既有问题，与本次改动无关。
