### PR TITLE
feat(maa): 新增 Mall 只买折扣与保留最大信用、Fight 一图流上报

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -3885,6 +3885,8 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         "DrGrandet": False,
                         "server": "CN",
                         "medicine_expire_days": medicine_expire_days,
+                        "report_to_yituliu": conf.maa_report_to_yituliu,
+                        "yituliu_id": conf.maa_yituliu_id,
                     },
                 )
                 self.stages.append(stage)
@@ -3904,6 +3906,8 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     "force_shopping_if_credit_full": conf.maa_mall_ignore_blacklist_when_full,
                     "visit_friends": conf.visit_friend_enable
                     and conf.visit_friend_mode == "maa",
+                    "only_buy_discount": conf.maa_mall_only_buy_discount,
+                    "reserve_max_credit": conf.maa_mall_reserve_max_credit,
                 },
             )
         elif type == "Award":

--- a/arknights_mower/tests/config_tests.py
+++ b/arknights_mower/tests/config_tests.py
@@ -373,6 +373,47 @@ class TestConfigPersistence(unittest.TestCase):
         written = self.conf_path.read_text(encoding="utf-8")
         self.assertIn("medicine_expire_days", written)
 
+    def test_mall_and_fight_new_fields_default_without_injection(self):
+        # #265：Mall/Fight 新字段未配置时用运行时默认值，且不被标记为已设置（不落盘）
+        with _patched_conf(self.conf_path, Conf()):
+            conf = config_module.conf
+            self.assertFalse(conf.maa_mall_only_buy_discount)
+            self.assertFalse(conf.maa_mall_reserve_max_credit)
+            self.assertFalse(conf.maa_report_to_yituliu)
+            self.assertEqual(conf.maa_yituliu_id, "")
+            for field in (
+                "maa_mall_only_buy_discount",
+                "maa_mall_reserve_max_credit",
+                "maa_report_to_yituliu",
+                "maa_yituliu_id",
+            ):
+                self.assertNotIn(field, conf.model_fields_set)
+
+    def test_mall_and_fight_new_fields_round_trip_when_configured(self):
+        # #265：四个新字段配置后如实读回并落盘
+        with _patched_conf(
+            self.conf_path,
+            Conf(
+                maa_mall_only_buy_discount=True,
+                maa_mall_reserve_max_credit=True,
+                maa_report_to_yituliu=True,
+                maa_yituliu_id="yituliu-abc",
+            ),
+        ):
+            conf = config_module.conf
+            self.assertTrue(conf.maa_mall_only_buy_discount)
+            self.assertTrue(conf.maa_mall_reserve_max_credit)
+            self.assertTrue(conf.maa_report_to_yituliu)
+            self.assertEqual(conf.maa_yituliu_id, "yituliu-abc")
+            config_module.save_conf()
+        written = self.conf_path.read_text(encoding="utf-8")
+        self.assertIn("maa_mall_only_buy_discount", written)
+        self.assertIn("maa_mall_reserve_max_credit", written)
+        self.assertIn("maa_report_to_yituliu", written)
+        self.assertIn("maa_yituliu_id", written)
+        # 未配置的默认字段仍不落盘
+        self.assertNotIn("maa_eat_stone", written)
+
     def test_legacy_key_migrates_to_new_key_when_configured(self):
         self._write_conf("exipring_medicine_on_weekend: true\n")
         with _patched_conf(self.conf_path):

--- a/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
+++ b/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
@@ -16,6 +16,8 @@ def _conf(
     package_type=1,
     medicine_expire_days=0,
     expiring_medicine_on_weekend=False,
+    maa_report_to_yituliu=False,
+    maa_yituliu_id="",
 ):
     return SimpleNamespace(
         package_type=package_type,
@@ -38,6 +40,8 @@ def _conf(
         medicine_expire_days=medicine_expire_days,
         expiring_medicine_on_weekend=expiring_medicine_on_weekend,
         maa_eat_stone=False,
+        maa_report_to_yituliu=maa_report_to_yituliu,
+        maa_yituliu_id=maa_yituliu_id,
     )
 
 
@@ -48,6 +52,8 @@ def _mall_conf(
     ignore_blacklist=False,
     visit_friend_enable=True,
     visit_friend_mode="maa",
+    maa_mall_only_buy_discount=False,
+    maa_mall_reserve_max_credit=False,
 ):
     return SimpleNamespace(
         maa_mall_buy="招聘许可,技巧概要·卷2",
@@ -57,6 +63,8 @@ def _mall_conf(
         maa_mall_ignore_blacklist_when_full=ignore_blacklist,
         visit_friend_enable=visit_friend_enable,
         visit_friend_mode=visit_friend_mode,
+        maa_mall_only_buy_discount=maa_mall_only_buy_discount,
+        maa_mall_reserve_max_credit=maa_mall_reserve_max_credit,
     )
 
 
@@ -117,6 +125,45 @@ class MaaFightMedicineExpireDaysTests(unittest.TestCase):
         self.assertEqual(task_config["medicine_expire_days"], 3)
 
 
+class MaaFightYituliuTests(unittest.TestCase):
+    """#265：Fight 补齐协议可加字段 report_to_yituliu / yituliu_id，默认关闭。"""
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda self: None)
+    def _append_fight(self, **overrides):
+        solver = BaseSchedulerSolver()
+        solver.MAA = MagicMock()
+        solver.stages = []
+        with (
+            patch.object(solver, "maybe_switch_expired_activity_plan"),
+            patch.object(
+                base_schedule.config, "conf", _conf(enabled=False, **overrides)
+            ),
+            patch.object(base_schedule, "get_server_weekday", return_value=0),
+            patch.object(base_schedule, "cultivateDepotSolver"),
+        ):
+            solver.append_maa_task("Fight")
+        return solver.MAA.append_task.call_args
+
+    def test_fight_defaults_report_disabled_and_id_empty(self):
+        # 默认关闭：report_to_yituliu 为 false，yituliu_id 为空字符串
+        task_config = self._append_fight().args[1]
+        self.assertEqual(task_config["report_to_yituliu"], False)
+        self.assertEqual(task_config["yituliu_id"], "")
+
+    def test_fight_enabled_report_and_id_round_trip(self):
+        # 开启上报并填 id：如实下发
+        task_config = self._append_fight(
+            maa_report_to_yituliu=True, maa_yituliu_id="yituliu-abc"
+        ).args[1]
+        self.assertEqual(task_config["report_to_yituliu"], True)
+        self.assertEqual(task_config["yituliu_id"], "yituliu-abc")
+
+    def test_fight_id_is_string_type(self):
+        # yituliu_id 按协议为 string：默认下发空字符串而非 null
+        task_config = self._append_fight().args[1]
+        self.assertIsInstance(task_config["yituliu_id"], str)
+
+
 class MaaMallFormationIndexTests(unittest.TestCase):
     """#261：Mall 下发协议字段 formation_index，替换非协议字段 select_formation。"""
 
@@ -147,6 +194,44 @@ class MaaMallFormationIndexTests(unittest.TestCase):
         # 钳制到 0–4，防御未来配置越界（不做 -1 变换）
         self.assertEqual(self._append_mall(squad=9).args[1]["formation_index"], 4)
         self.assertEqual(self._append_mall(squad=-3).args[1]["formation_index"], 0)
+
+
+class MaaMallDiscountCreditTests(unittest.TestCase):
+    """#265：Mall 补齐协议可加字段 only_buy_discount / reserve_max_credit，默认均 false。"""
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda self: None)
+    def _append_mall(self, **overrides):
+        solver = BaseSchedulerSolver()
+        solver.MAA = MagicMock()
+        solver.stages = []
+        solver.credit_fight = None
+        with patch.object(base_schedule.config, "conf", _mall_conf(**overrides)):
+            solver.append_maa_task("Mall")
+        return solver.MAA.append_task.call_args
+
+    def test_mall_defaults_send_false_for_both_discount_fields(self):
+        # 默认未开启：两个字段都下发 false（协议默认值，不省略）
+        task_config = self._append_mall().args[1]
+        self.assertEqual(task_config["only_buy_discount"], False)
+        self.assertEqual(task_config["reserve_max_credit"], False)
+
+    def test_mall_enabled_both_discount_fields_round_trip(self):
+        # 两个开关开启时如实下发 true
+        task_config = self._append_mall(
+            maa_mall_only_buy_discount=True,
+            maa_mall_reserve_max_credit=True,
+        ).args[1]
+        self.assertEqual(task_config["only_buy_discount"], True)
+        self.assertEqual(task_config["reserve_max_credit"], True)
+
+    def test_mall_discount_fields_each_controlled_independently(self):
+        # 两个开关互不影响：各开启一个，另一个保持 false
+        task_config = self._append_mall(
+            maa_mall_only_buy_discount=True,
+            maa_mall_reserve_max_credit=False,
+        ).args[1]
+        self.assertEqual(task_config["only_buy_discount"], True)
+        self.assertEqual(task_config["reserve_max_credit"], False)
 
 
 class MaaStageInventorySchedulerTests(unittest.TestCase):

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -64,6 +64,10 @@ class CluePart(ConfModel):
     "优先购买"
     maa_mall_ignore_blacklist_when_full: bool = False
     "信用溢出时无视黑名单"
+    maa_mall_only_buy_discount: bool = False
+    "只购买折扣物品（仅第二轮购买）"
+    maa_mall_reserve_max_credit: bool = False
+    "保留最大信用点：信用点低于 300 时停止购买（仅第二轮购买）"
 
 
 class EmailPart(ConfModel):
@@ -301,6 +305,10 @@ class RegularTaskPart(ConfModel):
     "关卡体力消耗默认值（数据中找不到关卡时的兜底，0 表示不启用）"
     maa_eat_stone: bool = False
     "无限吃源石"
+    maa_report_to_yituliu: bool = False
+    "向一图流上报作战结果"
+    maa_yituliu_id: str = ""
+    "一图流上报 id（仅在开启上报时有效）"
     maa_weekly_plan: list[MaaDailyPlan] = [
         {"medicine": 0, "sanity_threshold": 0, "stage": [""], "weekday": "周一"},
         {"medicine": 0, "sanity_threshold": 0, "stage": [""], "weekday": "周二"},

--- a/ui/src/components/Clue.vue
+++ b/ui/src/components/Clue.vue
@@ -9,6 +9,8 @@ const {
   maa_mall_buy,
   maa_mall_blacklist,
   maa_mall_ignore_blacklist_when_full,
+  maa_mall_only_buy_discount,
+  maa_mall_reserve_max_credit,
   maa_enable,
   maa_credit_fight,
   credit_fight,
@@ -148,6 +150,17 @@ const show_map = ref(false)
       label-width="72"
       label-align="left"
     >
+      <n-form-item label="购物设置">
+        <n-space :size="24">
+          <n-checkbox v-model:checked="maa_mall_only_buy_discount">只购买折扣物品</n-checkbox>
+          <n-checkbox v-model:checked="maa_mall_reserve_max_credit">
+            保留最大信用点（低于 300 停止购买）
+          </n-checkbox>
+        </n-space>
+        <help-text>
+          <div>两个设置均仅作用于第二轮购买。</div>
+        </help-text>
+      </n-form-item>
       <n-form-item label="信用溢出">
         <n-radio-group v-model:value="maa_mall_ignore_blacklist_when_full">
           <n-space>

--- a/ui/src/components/MaaWeekly.vue
+++ b/ui/src/components/MaaWeekly.vue
@@ -21,6 +21,8 @@ const {
   maa_enable,
   medicine_expire_days,
   expiring_medicine_on_weekend,
+  maa_report_to_yituliu,
+  maa_yituliu_id,
   ap_fallback
 } = storeToRefs(store)
 
@@ -281,9 +283,6 @@ function cancelCopyDialogLongPress() {
               <div>填 0 表示不服用（默认）。</div>
               <div>勾选「只在周末服用过期的理智药」后，只在周末服用，平时不用。</div>
             </help-text>
-            <div class="weekly-plan-selector-wrap">
-              <WeeklyPlanSelector compact />
-            </div>
           </n-flex>
           <n-flex>
             <n-checkbox
@@ -292,6 +291,28 @@ function cancelCopyDialogLongPress() {
             >
               只在周末服用过期的理智药
             </n-checkbox>
+          </n-flex>
+          <n-flex align="center">
+            <n-checkbox v-model:checked="maa_report_to_yituliu">上报至一图流</n-checkbox>
+            <n-input
+              v-model:value="maa_yituliu_id"
+              :disabled="!maa_report_to_yituliu"
+              placeholder="一图流 id"
+              style="width: 200px"
+            />
+            <help-text>
+              <div>
+                默认上传关卡掉落数据至
+                <n-a href="https://penguin-stats.io/" target="_blank" rel="noopener noreferrer">
+                  企鹅物流
+                </n-a>
+                ，勾选后额外上传至
+                <n-a href="https://yituliu.site/" target="_blank" rel="noopener noreferrer">
+                  一图流
+                </n-a>
+                。
+              </div>
+            </help-text>
           </n-flex>
           <n-flex>
             <n-checkbox v-model:checked="filterStageByAvailability">只显示当日开放关卡</n-checkbox>
@@ -309,6 +330,10 @@ function cancelCopyDialogLongPress() {
         </n-flex>
       </n-form-item>
     </n-form>
+
+    <div class="weekly-plan-selector-wrap">
+      <WeeklyPlanSelector compact />
+    </div>
 
     <n-tabs v-model:value="editorMode" type="segment" animated class="weekly-plan-editors">
       <n-tab-pane name="list" tab="列表计划">

--- a/ui/src/stores/config.js
+++ b/ui/src/stores/config.js
@@ -20,6 +20,8 @@ export const useConfigStore = defineStore('config', () => {
   const maa_update_channel = ref('stable')
   const maa_auto_check_update = ref(false)
   const medicine_expire_days = ref(0)
+  const maa_report_to_yituliu = ref(false)
+  const maa_yituliu_id = ref('')
   const ap_fallback = ref(0)
   const maa_weekly_plan = ref([])
   const maa_weekly_plan_options = ref([])
@@ -71,6 +73,8 @@ export const useConfigStore = defineStore('config', () => {
   const maa_conn_preset = ref('General')
   const maa_touch_option = ref('maatouch')
   const maa_mall_ignore_blacklist_when_full = ref(false)
+  const maa_mall_only_buy_discount = ref(false)
+  const maa_mall_reserve_max_credit = ref(false)
   const maa_rg_sleep_min = ref('00:00')
   const maa_rg_sleep_max = ref('00:00')
   const maa_credit_fight = ref(true)
@@ -367,6 +371,8 @@ export const useConfigStore = defineStore('config', () => {
     maa_rg_enable.value = response.data.maa_rg_enable == 1
     maa_long_task_type.value = response.data.maa_long_task_type
     medicine_expire_days.value = response.data.medicine_expire_days
+    maa_report_to_yituliu.value = response.data.maa_report_to_yituliu ?? false
+    maa_yituliu_id.value = response.data.maa_yituliu_id ?? ''
     ap_fallback.value = Number(response.data.ap_fallback) || 0
     maa_weekly_plan.value = normalizeWeeklyPlan(response.data.maa_weekly_plan)
     maa_weekly_plan_active.value = response.data.maa_weekly_plan_active || ''
@@ -403,6 +409,8 @@ export const useConfigStore = defineStore('config', () => {
     maa_conn_preset.value = response.data.maa_conn_preset
     maa_touch_option.value = response.data.maa_touch_option
     maa_mall_ignore_blacklist_when_full.value = response.data.maa_mall_ignore_blacklist_when_full
+    maa_mall_only_buy_discount.value = response.data.maa_mall_only_buy_discount ?? false
+    maa_mall_reserve_max_credit.value = response.data.maa_mall_reserve_max_credit ?? false
     maa_rg_sleep_max.value = response.data.maa_rg_sleep_max
     maa_rg_sleep_min.value = response.data.maa_rg_sleep_min
     maa_credit_fight.value = response.data.maa_credit_fight
@@ -484,6 +492,8 @@ export const useConfigStore = defineStore('config', () => {
       maa_rg_enable: maa_rg_enable.value ? 1 : 0,
       maa_long_task_type: maa_long_task_type.value,
       medicine_expire_days: medicine_expire_days.value,
+      maa_report_to_yituliu: maa_report_to_yituliu.value,
+      maa_yituliu_id: maa_yituliu_id.value,
       ap_fallback: ap_fallback.value,
       maa_stage_inventory_enable: maa_stage_inventory_enable.value,
       maa_stage_limit_rules: normalizeStageLimitRules(maa_stage_limit_rules.value),
@@ -520,6 +530,8 @@ export const useConfigStore = defineStore('config', () => {
       maa_conn_preset: maa_conn_preset.value,
       maa_touch_option: maa_touch_option.value,
       maa_mall_ignore_blacklist_when_full: maa_mall_ignore_blacklist_when_full.value,
+      maa_mall_only_buy_discount: maa_mall_only_buy_discount.value,
+      maa_mall_reserve_max_credit: maa_mall_reserve_max_credit.value,
       maa_rg_sleep_max: maa_rg_sleep_max.value,
       maa_rg_sleep_min: maa_rg_sleep_min.value,
       maa_credit_fight: maa_credit_fight.value,
@@ -643,6 +655,8 @@ export const useConfigStore = defineStore('config', () => {
     maa_rg_enable,
     maa_long_task_type,
     medicine_expire_days,
+    maa_report_to_yituliu,
+    maa_yituliu_id,
     ap_fallback,
     maa_weekly_plan,
     maa_weekly_plan_options,
@@ -690,6 +704,8 @@ export const useConfigStore = defineStore('config', () => {
     maa_conn_preset,
     maa_touch_option,
     maa_mall_ignore_blacklist_when_full,
+    maa_mall_only_buy_discount,
+    maa_mall_reserve_max_credit,
     maa_rg_sleep_min,
     maa_rg_sleep_max,
     maa_credit_fight,


### PR DESCRIPTION
## 目标与结果

补齐 MAA 集成协议里有、mower 此前未下发的四个可加字段（NiceAfternoon/arknights-mower#265），让 Mall 与 Fight 的任务参数覆盖协议的全部往返能力，并落到配置模型与前端开关。作为 NiceAfternoon/arknights-mower#206 的 B2（Mall）+ B3（Fight）落地。

## 主要改动

- Mall 下发 `only_buy_discount`（只买折扣）与 `reserve_max_credit`（保留最大信用点），默认均关闭，仅作用于第二轮购买。
- Fight 下发 `report_to_yituliu` 与 `yituliu_id`（一图流上报），默认关闭，在企鹅统计之外支持双报。
- 配置新增键 `maa_mall_only_buy_discount` / `maa_mall_reserve_max_credit`（CluePart）与 `maa_report_to_yituliu` / `maa_yituliu_id`（RegularTaskPart）。沿用 #977 的做法：默认值由 pydantic 在运行时补齐、未配置不落盘（`exclude_unset`），无旧键迁移，配置文件保持精简。
- 前端在 Clue.vue（购物设置）加两个开关、MaaWeekly.vue（一图流上报开关 + id 输入）加控件，`config.js` 在读写与导出四处一致。

## 验证与限制

- 扩充 `maa_stage_inventory_scheduler_tests.py` 与 `config_tests.py`，用假 MAA 断言 `append_task` 实参携带四个字段、默认关闭/空，并覆盖默认值不落盘；两文件共 67 项测试通过。
- 仅对改动文件跑 `ruff check` 与 `ruff format --check` 通过；前端 `prettier` 全量检查通过。
- 默认无行为变更：仅在用户显式开启后，Mall / Fight 参数才携带非默认值；`yituliu_id` 依协议仅在上报开启时生效。

测试命令（本地）：`python -m pytest arknights_mower/tests/maa_stage_inventory_scheduler_tests.py arknights_mower/tests/config_tests.py -o python_files="*_tests.py" --ignore=arknights_mower/tests/software_update_tests.py`
