### PR TITLE
feat(maa): 补齐 MAA 肉鸽任务通用字段并按主题和策略显示对应字段

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -113,6 +113,28 @@ def _maa_client_type() -> str:
     return "Official" if config.conf.package_type == 1 else "Bilibili"
 
 
+# 战术分队类（对照 RoguelikeSquadIsProfessional），凹开局直升精二仅对这类分队下发
+_PROFESSIONAL_SQUADS = (
+    "突击战术分队",
+    "堡垒战术分队",
+    "远程战术分队",
+    "破坏战术分队",
+)
+
+# 刷开局期望奖励键，与协议 collectible_mode_start_list 的九项一致
+_COLLECTIBLE_START_KEYS = (
+    "hot_water",
+    "shield",
+    "ingot",
+    "hope",
+    "random",
+    "key",
+    "dice",
+    "ideas",
+    "ticket",
+)
+
+
 class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
     """
     收集基建的产物：物资、赤金、信赖
@@ -4050,22 +4072,88 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     self.recog.update()
                     self.back_to_index()
                     if conf.RG:
-                        self.MAA.append_task(
-                            "Roguelike",
-                            {
-                                "theme": conf.maa_rg_theme,
-                                "squad": conf.rogue.squad,
-                                "roles": conf.rogue.roles,
-                                "core_char": conf.rogue.core_char,
-                                "use_support": conf.rogue.use_support,
-                                "use_nonfriend_support": conf.rogue.use_nonfriend_support,
-                                "mode": conf.rogue.mode,
-                                "refresh_trader_with_dice": conf.rogue.refresh_trader_with_dice,
-                                "starts_count": 9999999,
-                                "investments_count": 9999999,
-                                "expected_collapsal_paradigms": conf.rogue.expected_collapsal_paradigms,
-                            },
-                        )
+                        # Roguelike 通用字段按协议条件下发（#264）：投资类字段仅在
+                        # investment_enabled 时下发（值内联各自的策略/主题限制，与 MAA 一致），
+                        # stop_at_final_boss 除 Phantom 外可用且仅策略 0 下发，
+                        # expected_collapsal_paradigms 仅 Sami + 策略 5 且列表非空时下发，
+                        # 烧水字段仅策略 4 下发，勾选「只凹开局干员直升精二」时
+                        # 撤销 collectible_mode_start_list，指路鳞的值内联 Mizuki 限制。
+                        professional = conf.rogue.squad in _PROFESSIONAL_SQUADS
+                        rogue_params = {
+                            "theme": conf.maa_rg_theme,
+                            "squad": conf.rogue.squad,
+                            "roles": conf.rogue.roles,
+                            "core_char": conf.rogue.core_char,
+                            "use_support": conf.rogue.use_support,
+                            "use_nonfriend_support": conf.rogue.use_nonfriend_support,
+                            "mode": conf.rogue.mode,
+                            "starts_count": 9999999,
+                            "investments_count": 9999999,
+                            "difficulty": conf.rogue.difficulty,
+                            "investment_enabled": conf.rogue.investment_enabled,
+                            "refresh_trader_with_dice": (
+                                conf.maa_rg_theme == "Mizuki"
+                                and conf.rogue.refresh_trader_with_dice
+                            ),
+                        }
+                        if conf.rogue.investment_enabled:
+                            rogue_params["investment_with_more_score"] = (
+                                conf.maa_rg_theme != "BlackFlow"
+                                and conf.rogue.investment_with_more_score
+                                and conf.rogue.mode == 1
+                            )
+                            rogue_params["stop_when_investment_full"] = (
+                                conf.rogue.stop_when_investment_full
+                                and conf.rogue.mode == 1
+                            )
+                        if conf.maa_rg_theme != "Phantom" and conf.rogue.mode == 0:
+                            rogue_params["stop_at_final_boss"] = (
+                                conf.rogue.stop_at_final_boss
+                            )
+                        if conf.rogue.mode == 0:
+                            rogue_params["stop_at_max_level"] = (
+                                conf.rogue.stop_at_max_level
+                            )
+                        if (
+                            conf.maa_rg_theme == "Sami"
+                            and conf.rogue.mode == 5
+                            and conf.rogue.expected_collapsal_paradigms
+                        ):
+                            rogue_params["expected_collapsal_paradigms"] = (
+                                conf.rogue.expected_collapsal_paradigms
+                            )
+                        if conf.rogue.mode == 4:
+                            rogue_params["collectible_mode_shopping"] = (
+                                conf.rogue.collectible_mode_shopping
+                            )
+                            rogue_params["collectible_mode_squad"] = (
+                                conf.rogue.collectible_mode_squad
+                            )
+                            # 协议值语义：直升需与战术分队类同步，只凹仅受主题/策略限制
+                            rogue_params["start_with_elite_two"] = (
+                                conf.rogue.start_with_elite_two
+                                and professional
+                                and conf.maa_rg_theme in ("Mizuki", "Sami")
+                            )
+                            rogue_params["only_start_with_elite_two"] = (
+                                conf.rogue.only_start_with_elite_two
+                                and conf.maa_rg_theme in ("Mizuki", "Sami")
+                            )
+                            # 勾选「只凹开局干员直升精二」时不刷奖励，撤销下发
+                            elite_two_only = (
+                                conf.rogue.only_start_with_elite_two
+                                and conf.rogue.start_with_elite_two
+                                and conf.maa_rg_theme != "Phantom"
+                                and professional
+                            )
+                            if not elite_two_only:
+                                rogue_params["collectible_mode_start_list"] = {
+                                    key: conf.rogue.collectible_mode_start_list.get(
+                                        key, False
+                                    )
+                                    for key in _COLLECTIBLE_START_KEYS
+                                }
+                        self.MAA.append_task("Roguelike", rogue_params)
                     elif conf.SSS:
                         copilot = get_path("@app/sss.json")
                         if (

--- a/arknights_mower/tests/config_tests.py
+++ b/arknights_mower/tests/config_tests.py
@@ -414,6 +414,80 @@ class TestConfigPersistence(unittest.TestCase):
         # 未配置的默认字段仍不落盘
         self.assertNotIn("maa_eat_stone", written)
 
+    def test_rogue_new_fields_default_without_injection(self):
+        # #264：Roguelike 通用字段未配置时用协议默认值，且不被标记为已设置（不落盘）
+        with _patched_conf(self.conf_path, Conf()):
+            rogue = config_module.conf.rogue
+            self.assertEqual(rogue.difficulty, -1)
+            self.assertFalse(rogue.stop_at_final_boss)
+            self.assertFalse(rogue.stop_at_max_level)
+            self.assertTrue(rogue.investment_enabled)
+            self.assertFalse(rogue.stop_when_investment_full)
+            self.assertFalse(rogue.investment_with_more_score)
+            self.assertFalse(rogue.collectible_mode_shopping)
+            self.assertEqual(rogue.collectible_mode_squad, "")
+            self.assertFalse(rogue.start_with_elite_two)
+            self.assertFalse(rogue.only_start_with_elite_two)
+            self.assertEqual(rogue.collectible_mode_start_list, {})
+            self.assertEqual(
+                rogue.expected_collapsal_paradigms,
+                ["目空一些", "睁眼瞎", "图像损坏", "一抹黑"],
+            )
+            config_module.save_conf()
+        written = self.conf_path.read_text(encoding="utf-8")
+        for field in (
+            "difficulty",
+            "stop_at_final_boss",
+            "investment_enabled",
+            "expected_collapsal_paradigms",
+        ):
+            self.assertNotIn(field, written)
+
+    def test_rogue_new_fields_round_trip_when_configured(self):
+        # #264：Roguelike 通用字段配置后如实读回并落盘（collectible_mode_squad 默认与 squad 同步）
+        with _patched_conf(
+            self.conf_path,
+            Conf(
+                rogue={
+                    "difficulty": 2,
+                    "stop_at_final_boss": True,
+                    "stop_at_max_level": True,
+                    "investment_enabled": False,
+                    "stop_when_investment_full": True,
+                    "investment_with_more_score": True,
+                    "collectible_mode_shopping": True,
+                    "collectible_mode_squad": "指挥分队",
+                    "start_with_elite_two": True,
+                    "only_start_with_elite_two": True,
+                    "collectible_mode_start_list": {"hot_water": True},
+                    "expected_collapsal_paradigms": ["目空一些", "一抹黑"],
+                }
+            ),
+        ):
+            rogue = config_module.conf.rogue
+            self.assertEqual(rogue.difficulty, 2)
+            self.assertTrue(rogue.stop_at_final_boss)
+            self.assertTrue(rogue.stop_at_max_level)
+            self.assertFalse(rogue.investment_enabled)
+            self.assertTrue(rogue.stop_when_investment_full)
+            self.assertTrue(rogue.investment_with_more_score)
+            self.assertTrue(rogue.collectible_mode_shopping)
+            self.assertEqual(rogue.collectible_mode_squad, "指挥分队")
+            self.assertTrue(rogue.start_with_elite_two)
+            self.assertTrue(rogue.only_start_with_elite_two)
+            self.assertEqual(rogue.collectible_mode_start_list, {"hot_water": True})
+            self.assertEqual(rogue.expected_collapsal_paradigms, ["目空一些", "一抹黑"])
+            config_module.save_conf()
+        written = self.conf_path.read_text(encoding="utf-8")
+        self.assertIn("difficulty", written)
+        self.assertIn("stop_at_final_boss", written)
+        self.assertIn("collectible_mode_squad", written)
+        self.assertIn("start_with_elite_two", written)
+        self.assertIn("only_start_with_elite_two", written)
+        self.assertIn("collectible_mode_start_list", written)
+        self.assertIn("expected_collapsal_paradigms", written)
+        self.assertIn("investment_with_more_score", written)
+
     def test_legacy_key_migrates_to_new_key_when_configured(self):
         self._write_conf("exipring_medicine_on_weekend: true\n")
         with _patched_conf(self.conf_path):

--- a/arknights_mower/tests/maa_error_no_exit_tests.py
+++ b/arknights_mower/tests/maa_error_no_exit_tests.py
@@ -128,6 +128,14 @@ class MaaErrorNoExitTests(unittest.TestCase):
                 mode=0,
                 refresh_trader_with_dice=False,
                 expected_collapsal_paradigms=[],
+                difficulty=-1,
+                stop_at_final_boss=False,
+                stop_at_max_level=False,
+                investment_enabled=True,
+                stop_when_investment_full=False,
+                investment_with_more_score=False,
+                collectible_mode_shopping=False,
+                collectible_mode_squad="",
             ),
         )
         mock_maa = MagicMock()

--- a/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
+++ b/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -418,6 +419,368 @@ class MaaVisitFriendModeTests(unittest.TestCase):
         solver.MAA = MagicMock()
         solver.append_maa_task("Visit")
         solver.MAA.append_task.assert_not_called()
+
+
+def _rg_conf(
+    *,
+    theme="Sami",
+    mode=0,
+    squad="",
+    difficulty=-1,
+    stop_at_final_boss=False,
+    stop_at_max_level=False,
+    investment_enabled=True,
+    stop_when_investment_full=False,
+    investment_with_more_score=False,
+    collectible_mode_shopping=False,
+    collectible_mode_squad="",
+    refresh_trader_with_dice=False,
+    start_with_elite_two=False,
+    only_start_with_elite_two=False,
+    collectible_mode_start_list=None,
+    expected_collapsal_paradigms=("目空一些", "睁眼瞎"),
+):
+    """Roguelike 长任务走 maa_plan_solver 的 conf，构造 .RG 分支所需的最小实例。"""
+    return SimpleNamespace(
+        maa_gap=4,
+        RG=True,
+        SSS=False,
+        RCL=False,
+        RA=False,
+        SF=False,
+        maa_rg_sleep_min="12:00",
+        maa_rg_sleep_max="12:00",
+        maa_rg_theme=theme,
+        rogue=SimpleNamespace(
+            squad=squad,
+            roles="",
+            core_char="",
+            use_support=False,
+            use_nonfriend_support=False,
+            start_with_elite_two=start_with_elite_two,
+            only_start_with_elite_two=only_start_with_elite_two,
+            mode=mode,
+            refresh_trader_with_dice=refresh_trader_with_dice,
+            expected_collapsal_paradigms=list(expected_collapsal_paradigms),
+            difficulty=difficulty,
+            stop_at_final_boss=stop_at_final_boss,
+            stop_at_max_level=stop_at_max_level,
+            investment_enabled=investment_enabled,
+            stop_when_investment_full=stop_when_investment_full,
+            investment_with_more_score=investment_with_more_score,
+            collectible_mode_shopping=collectible_mode_shopping,
+            collectible_mode_squad=collectible_mode_squad,
+            collectible_mode_start_list=collectible_mode_start_list or {},
+        ),
+    )
+
+
+class MaaRoguelikeTests(unittest.TestCase):
+    """#264：Roguelike 下发补齐通用字段；协议注明「仅某主题/某模式」的字段按条件省略。"""
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda self: None)
+    def _run_rogue(self, **overrides):
+        solver = BaseSchedulerSolver()
+        solver.recog = MagicMock()
+        solver.last_execution = {"maa": None}
+        solver.credit_fight = None
+        solver.tasks = [SimpleNamespace(time=datetime.now() + timedelta(days=1))]
+        mock_maa = MagicMock()
+        # running() 立即返回 False：MAA 运行循环一次都不进，只断言 append_task 参数。
+        mock_maa.running.return_value = False
+
+        def _init_maa():
+            solver.MAA = mock_maa
+
+        with (
+            patch.object(base_schedule.config, "conf", _rg_conf(**overrides)),
+            patch.object(solver, "back_to_index"),
+            patch.object(solver, "initialize_maa", side_effect=_init_maa),
+            patch.object(solver, "append_maa_task"),
+            patch.object(solver, "rest_until_next_task"),
+            patch.object(solver, "maa_stop"),
+            patch.object(base_schedule, "get_server_weekday", return_value=1),
+            patch.object(base_schedule, "send_message"),
+        ):
+            solver.maa_plan_solver()
+        return mock_maa.append_task.call_args
+
+    def test_rogue_sends_common_fields_with_protocol_defaults(self):
+        # 默认值对照活文档：difficulty=-1、investment_enabled=True；这里 mode=0、主题 Sami
+        # 满足 stop_at_final_boss/stop_at_max_level 的条件（如实下发配置值），
+        # 投资/指路鳞字段按协议在 investment_enabled 时整体下发（值内联条件，此处为 False），
+        # 烧水/直升字段不满足各自条件，不进入任务参数。
+        call = self._run_rogue(theme="Sami")
+        task_type, task_config = call.args
+        self.assertEqual(task_type, "Roguelike")
+        self.assertEqual(task_config["difficulty"], -1)
+        self.assertIs(task_config["stop_at_final_boss"], False)
+        self.assertEqual(task_config["stop_at_max_level"], False)
+        self.assertEqual(task_config["investment_enabled"], True)
+        self.assertIs(task_config["stop_when_investment_full"], False)
+        self.assertIs(task_config["investment_with_more_score"], False)
+        self.assertIs(task_config["refresh_trader_with_dice"], False)
+        self.assertNotIn("collectible_mode_shopping", task_config)
+        self.assertNotIn("collectible_mode_squad", task_config)
+        self.assertNotIn("start_with_elite_two", task_config)
+        self.assertNotIn("only_start_with_elite_two", task_config)
+
+    def test_rogue_includes_stop_at_final_boss_for_non_phantom(self):
+        # Phantom 之外的主题下发 stop_at_final_boss（协议：除 Phantom 外均适用）
+        task_config = self._run_rogue(theme="Mizuki", stop_at_final_boss=True).args[1]
+        self.assertIs(task_config["stop_at_final_boss"], True)
+
+    def test_rogue_omits_stop_at_final_boss_for_phantom(self):
+        # Phantom 主题不适用：不下发 stop_at_final_boss（stop_at_max_level 无主题限制仍下发）
+        task_config = self._run_rogue(theme="Phantom").args[1]
+        self.assertNotIn("stop_at_final_boss", task_config)
+        self.assertIn("stop_at_max_level", task_config)
+
+    def test_rogue_omits_stop_at_levels_outside_mode0(self):
+        # stop_at_final_boss/stop_at_max_level 仅在策略为 0（刷等级）时下发（MAA 的 Mode==Exp 分支）
+        for theme, mode in (
+            ("Sami", 1),
+            ("Sami", 4),
+            ("Mizuki", 5),
+            ("BlackFlow", 30001),
+        ):
+            task_config = self._run_rogue(
+                theme=theme, mode=mode, stop_at_final_boss=True, stop_at_max_level=True
+            ).args[1]
+            self.assertNotIn("stop_at_final_boss", task_config)
+            self.assertNotIn("stop_at_max_level", task_config)
+
+    def test_rogue_includes_expected_collapsal_for_sami_mode5(self):
+        # 协议注明 expected_collapsal_paradigms 仅在主题为 Sami 且策略为 5 时有效：
+        # 该组合下如实下发配置的坍缩范式列表。
+        task_config = self._run_rogue(
+            theme="Sami", mode=5, expected_collapsal_paradigms=("目空一些", "一抹黑")
+        ).args[1]
+        self.assertEqual(
+            task_config["expected_collapsal_paradigms"], ["目空一些", "一抹黑"]
+        )
+
+    def test_rogue_omits_expected_collapsal_outside_sami_mode5(self):
+        # Sami+其它策略、其它主题都不适用：不下发 expected_collapsal_paradigms
+        # （与 stop_at_final_boss 的 Phantom 处理一致，字段隐藏即不进入任务参数）。
+        for theme, mode in (("Sami", 0), ("Sami", 6), ("Mizuki", 5), ("Phantom", 5)):
+            task_config = self._run_rogue(theme=theme, mode=mode).args[1]
+            self.assertNotIn("expected_collapsal_paradigms", task_config)
+
+    def test_rogue_omits_expected_collapsal_when_list_empty(self):
+        # Sami + 策略 5 但坍缩范式列表为空：不下发 expected_collapsal_paradigms
+        task_config = self._run_rogue(
+            theme="Sami", mode=5, expected_collapsal_paradigms=()
+        ).args[1]
+        self.assertNotIn("expected_collapsal_paradigms", task_config)
+
+    def test_rogue_forwards_blackflow_theme_and_mode_30001(self):
+        # 主题 BlackFlow 与模式 30001 原样转发（新增枚举穿透后端）；
+        # 策略非 0 时 stop_at_final_boss/stop_at_max_level 不下发。
+        task_config = self._run_rogue(theme="BlackFlow", mode=30001).args[1]
+        self.assertEqual(task_config["theme"], "BlackFlow")
+        self.assertEqual(task_config["mode"], 30001)
+        self.assertNotIn("stop_at_final_boss", task_config)
+        self.assertNotIn("stop_at_max_level", task_config)
+
+    def test_rogue_forwards_theme_gated_modes(self):
+        # 主题限定模式原样转发：Sarkaz 的 10001 与 JieGarden 的 20001（后端只透传数值）
+        sarkaz = self._run_rogue(theme="Sarkaz", mode=10001).args[1]
+        self.assertEqual(sarkaz["theme"], "Sarkaz")
+        self.assertEqual(sarkaz["mode"], 10001)
+        jiegarden = self._run_rogue(theme="JieGarden", mode=20001).args[1]
+        self.assertEqual(jiegarden["theme"], "JieGarden")
+        self.assertEqual(jiegarden["mode"], 20001)
+
+    def test_rogue_forwards_elite_two_fields_for_mizuki_sami_mode4(self):
+        # 协议注明 start_with_elite_two 仅适用于模式 4，MAA 另限主题 Mizuki/Sami 且直升值
+        # 需与战术分队类同步（RoguelikeSquadIsProfessional）；只凹仅受模式/主题限制。
+        task_config = self._run_rogue(
+            theme="Mizuki",
+            mode=4,
+            squad="突击战术分队",
+            start_with_elite_two=True,
+            only_start_with_elite_two=True,
+        ).args[1]
+        self.assertIs(task_config["start_with_elite_two"], True)
+        self.assertIs(task_config["only_start_with_elite_two"], True)
+        # 非战术分队时直升下发 False、只凹仍为 True（协议值语义如此；start=false 与 only=true
+        # 的组合会被 MAA 核心判定非法，由前端联动在直升不可见时清除只凹，见 only_elite_two_needs_reset）
+        task_config = self._run_rogue(
+            theme="Sami",
+            mode=4,
+            squad="指挥分队",
+            start_with_elite_two=True,
+            only_start_with_elite_two=True,
+        ).args[1]
+        self.assertIs(task_config["start_with_elite_two"], False)
+        self.assertIs(task_config["only_start_with_elite_two"], True)
+
+    def test_rogue_omits_elite_two_fields_outside_mode4(self):
+        # 策略 4 之外：不下发 start_with_elite_two/only_start_with_elite_two
+        for theme, mode in (
+            ("Mizuki", 0),
+            ("Sami", 5),
+            ("BlackFlow", 30001),
+        ):
+            task_config = self._run_rogue(
+                theme=theme,
+                mode=mode,
+                squad="突击战术分队",
+                start_with_elite_two=True,
+                only_start_with_elite_two=True,
+            ).args[1]
+            self.assertNotIn("start_with_elite_two", task_config)
+            self.assertNotIn("only_start_with_elite_two", task_config)
+
+    def test_rogue_forwards_elite_two_fields_false_on_other_themes_mode4(self):
+        # 策略 4 且主题非 Mizuki/Sami：两个键仍下发但值为 False（与 MAA 一致，
+        # 勾选值不会在 Phantom/萨卡兹/界园/黑流树海上生效）
+        for theme in ("Phantom", "Sarkaz", "JieGarden", "BlackFlow"):
+            task_config = self._run_rogue(
+                theme=theme,
+                mode=4,
+                squad="突击战术分队",
+                start_with_elite_two=True,
+                only_start_with_elite_two=True,
+            ).args[1]
+            self.assertIs(task_config["start_with_elite_two"], False)
+            self.assertIs(task_config["only_start_with_elite_two"], False)
+
+    def test_rogue_forwards_common_configured_fields(self):
+        # 通用字段配置后如实下发（难度、投资开关、等级停止）
+        task_config = self._run_rogue(
+            difficulty=2,
+            investment_enabled=False,
+            stop_at_max_level=True,
+        ).args[1]
+        self.assertEqual(task_config["difficulty"], 2)
+        self.assertEqual(task_config["investment_enabled"], False)
+        self.assertIs(task_config["stop_at_max_level"], True)
+
+    def test_rogue_forwards_collectible_fields_for_mode4(self):
+        # 协议注明 collectible_mode_* 仅用于策略 4（刷开局）：配置后如实下发，
+        # collectible_mode_squad 填了分队名则不再跟随 squad。
+        task_config = self._run_rogue(
+            mode=4,
+            collectible_mode_shopping=True,
+            collectible_mode_squad="指挥分队",
+        ).args[1]
+        self.assertIs(task_config["collectible_mode_shopping"], True)
+        self.assertEqual(task_config["collectible_mode_squad"], "指挥分队")
+
+    def test_rogue_omits_collectible_fields_outside_mode4(self):
+        # 策略 4 之外的组合不下发 collectible_mode_*
+        for theme, mode in (
+            ("Sami", 0),
+            ("Sami", 1),
+            ("Sami", 5),
+            ("Mizuki", 6),
+            ("BlackFlow", 30001),
+        ):
+            task_config = self._run_rogue(
+                theme=theme,
+                mode=mode,
+                collectible_mode_shopping=True,
+                collectible_mode_squad="指挥分队",
+            ).args[1]
+            self.assertNotIn("collectible_mode_shopping", task_config)
+            self.assertNotIn("collectible_mode_squad", task_config)
+
+    def test_rogue_forwards_collectible_start_list_for_mode4(self):
+        # 协议注明 collectible_mode_start_list 仅在策略为 4 时有效：未勾「只凹」时
+        # 下发完整奖励表，未配置的键为 False（与 MAA 一致）
+        task_config = self._run_rogue(
+            mode=4, collectible_mode_start_list={"hot_water": True, "key": True}
+        ).args[1]
+        self.assertEqual(
+            task_config["collectible_mode_start_list"],
+            {
+                "hot_water": True,
+                "shield": False,
+                "ingot": False,
+                "hope": False,
+                "random": False,
+                "key": True,
+                "dice": False,
+                "ideas": False,
+                "ticket": False,
+            },
+        )
+
+    def test_rogue_omits_collectible_start_list_when_only_start_elite_two(self):
+        # MAA：勾选「只凹开局干员直升精二」（战术分队类 + 非 Phantom 主题）时不下发奖励表
+        task_config = self._run_rogue(
+            theme="Sami",
+            mode=4,
+            squad="突击战术分队",
+            start_with_elite_two=True,
+            only_start_with_elite_two=True,
+            collectible_mode_start_list={"hot_water": True},
+        ).args[1]
+        self.assertNotIn("collectible_mode_start_list", task_config)
+
+    def test_rogue_omits_collectible_start_list_outside_mode4(self):
+        # 策略 4 之外不下发 collectible_mode_start_list
+        for theme, mode in (("Sami", 0), ("Sami", 1), ("Mizuki", 6)):
+            task_config = self._run_rogue(
+                theme=theme, mode=mode, collectible_mode_start_list={"hot_water": True}
+            ).args[1]
+            self.assertNotIn("collectible_mode_start_list", task_config)
+
+    def test_rogue_forwards_stop_when_investment_full_for_mode1(self):
+        # MAA 在 investment_enabled 时下发投资类字段，值内联策略 1（刷源石锭）限制，主题不限
+        for theme in ("Sami", "BlackFlow"):
+            task_config = self._run_rogue(
+                theme=theme, mode=1, stop_when_investment_full=True
+            ).args[1]
+            self.assertIs(task_config["stop_when_investment_full"], True)
+
+    def test_rogue_false_value_outside_mode1_when_investment_enabled(self):
+        # 投资开启但策略不是 1：stop_when_investment_full 仍下发，值为 False（与 MAA 一致）
+        for theme, mode in (("Sami", 0), ("Sami", 4), ("Sarkaz", 10001)):
+            task_config = self._run_rogue(
+                theme=theme, mode=mode, stop_when_investment_full=True
+            ).args[1]
+            self.assertIs(task_config["stop_when_investment_full"], False)
+
+    def test_rogue_omits_stop_when_investment_fields_when_investment_disabled(self):
+        # 未投资源石锭时不下发 stop_when_investment_full 与 investment_with_more_score
+        task_config = self._run_rogue(
+            mode=1, investment_enabled=False, stop_when_investment_full=True
+        ).args[1]
+        self.assertNotIn("stop_when_investment_full", task_config)
+        self.assertNotIn("investment_with_more_score", task_config)
+
+    def test_rogue_forwards_investment_with_more_score_for_mode1(self):
+        # investment_with_more_score 仅在策略 1 且主题非 BlackFlow 时值为 True
+        task_config = self._run_rogue(
+            theme="Sami", mode=1, investment_with_more_score=True
+        ).args[1]
+        self.assertIs(task_config["investment_with_more_score"], True)
+        task_config = self._run_rogue(
+            theme="BlackFlow", mode=1, investment_with_more_score=True
+        ).args[1]
+        self.assertIs(task_config["investment_with_more_score"], False)
+        task_config = self._run_rogue(
+            theme="Sami", mode=0, investment_with_more_score=True
+        ).args[1]
+        self.assertIs(task_config["investment_with_more_score"], False)
+
+    def test_rogue_forwards_refresh_trader_for_mizuki(self):
+        # 协议注明 refresh_trader_with_dice（指路鳞）仅支持主题 Mizuki
+        task_config = self._run_rogue(
+            theme="Mizuki", refresh_trader_with_dice=True
+        ).args[1]
+        self.assertIs(task_config["refresh_trader_with_dice"], True)
+
+    def test_rogue_forwards_refresh_trader_false_outside_mizuki(self):
+        # 指路鳞键始终下发，值内联 Mizuki 限制：其他主题为 False（与 MAA 一致）
+        for theme in ("Sami", "Sarkaz", "Phantom"):
+            task_config = self._run_rogue(
+                theme=theme, refresh_trader_with_dice=True
+            ).args[1]
+            self.assertIs(task_config["refresh_trader_with_dice"], False)
 
 
 if __name__ == "__main__":

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -146,6 +146,12 @@ class LongTaskPart(ConfModel):
         "开局干员使用助战"
         use_nonfriend_support: bool = False
         "开局干员使用非好友助战"
+        start_with_elite_two: bool = False
+        "凹开局干员直升精二（仅刷开局策略下的水月/萨米主题，且开局分队为战术分队类）"
+        only_start_with_elite_two: bool = False
+        "只凹开局干员直升精二，不进行作战（仅在刷开局策略且已勾直升时生效）"
+        collectible_mode_start_list: dict[str, bool] = Field(default_factory=dict)
+        "刷开局期望的奖励（键值见协议，仅刷开局策略生效）"
         mode: int = 1
         "策略"
         refresh_trader_with_dice: bool = False
@@ -157,6 +163,22 @@ class LongTaskPart(ConfModel):
             "一抹黑",
         ]
         "需要刷的坍缩范式"
+        difficulty: int = -1
+        "肉鸽难度（-1 = 不指定难度；2147483647 = 主题最高难度）"
+        stop_at_final_boss: bool = False
+        "打到第 5 层险路恶敌节点前停止（Phantom 主题不适用）"
+        stop_at_max_level: bool = False
+        "肉鸽等级刷满后停止"
+        investment_enabled: bool = True
+        "是否投资源石锭"
+        stop_when_investment_full: bool = False
+        "源石锭投资满时停止"
+        investment_with_more_score: bool = False
+        "投资模式启用购物、招募、进2层"
+        collectible_mode_shopping: bool = False
+        "烧水时是否启用购物"
+        collectible_mode_squad: str = ""
+        "烧水使用的分队（默认与 squad 同步）"
 
     class SSSConf(ConfModel):
         type: int = 1

--- a/ui/src/components/MaaRogue.vue
+++ b/ui/src/components/MaaRogue.vue
@@ -2,7 +2,7 @@
 import { useConfigStore } from '@/stores/config'
 import { usePlanStore } from '@/stores/plan'
 import { storeToRefs } from 'pinia'
-import { inject } from 'vue'
+import { computed, inject, watch } from 'vue'
 
 const mobile = inject('mobile')
 
@@ -15,22 +15,27 @@ const { operators } = storeToRefs(plan_store)
 
 import { pinyin_match } from '@/utils/common'
 import { render_op_label } from '@/utils/op_select'
+import HelpText from '@/components/HelpText.vue'
+import {
+  collectible_start_visible,
+  difficulty_options,
+  elite_two_visible,
+  is_field_enabled,
+  modes_for_theme,
+  only_elite_two_needs_reset,
+  only_elite_two_visible,
+  rogue_themes
+} from '@/utils/roguelike_options'
 
-const rogue_themes = [
-  { label: '傀影与猩红孤钻', value: 'Phantom' },
-  { label: '水月与深蓝之树', value: 'Mizuki' },
-  { label: '探索者的银凇止境', value: 'Sami' },
-  { label: '萨卡兹的无终奇语', value: 'Sarkaz' },
-  { label: '界园志异', value: 'JieGarden' }
-]
-
+// 分队名与顺序对照 RoguelikeSettingsUserControlModel（主题分队 + 通用分队 + 高规格）；
+// 高规格仅傀影/水月/萨米/萨卡兹/界园有，黑流树海无。
 const squad = {
   Phantom: [
+    '集群',
+    '矛头',
     '研究',
     '指挥',
-    '集群',
     '后勤',
-    '矛头',
     '突击战术',
     '堡垒战术',
     '远程战术',
@@ -38,14 +43,14 @@ const squad = {
     '高规格'
   ],
   Mizuki: [
+    '集群',
+    '矛头',
     '心胜于物',
     '物尽其用',
     '以人为本',
     '研究',
     '指挥',
-    '集群',
     '后勤',
-    '矛头',
     '突击战术',
     '堡垒战术',
     '远程战术',
@@ -53,14 +58,14 @@ const squad = {
     '高规格'
   ],
   Sami: [
+    '集群',
+    '矛头',
     '永恒狩猎',
     '生活至上',
     '科学主义',
     '特训',
     '指挥',
-    '集群',
     '后勤',
-    '矛头',
     '突击战术',
     '堡垒战术',
     '远程战术',
@@ -68,17 +73,18 @@ const squad = {
     '高规格'
   ],
   Sarkaz: [
-    '因地制宜',
+    '集群',
+    '矛头',
     '魂灵护送',
     '博闻广记',
     '蓝图测绘',
+    '因地制宜',
     '异想天开',
     '点刺成锭',
     '拟态学者',
+    '专业人士',
     '指挥',
-    '集群',
     '后勤',
-    '矛头',
     '突击战术',
     '堡垒战术',
     '远程战术',
@@ -86,42 +92,136 @@ const squad = {
     '高规格'
   ],
   JieGarden: [
-    '指挥',
     '特勤',
-    '突击战术',
-    '堡垒战术',
-    '远程战术',
     '高台突破',
     '地面突破',
-    '高规格',
     '游客',
     '司岁台',
     '天师府',
+    '花团锦簇',
+    '棋行险着',
+    '岁影回音',
+    '代理人',
+    '知学',
+    '商贾',
+    '指挥',
+    '后勤',
+    '突击战术',
+    '堡垒战术',
+    '远程战术',
+    '破坏战术',
+    '高规格'
+  ],
+  BlackFlow: [
+    '特勤',
+    '矛头',
+    '高台突破',
+    '地面突破',
+    '本源研修',
+    '文明开化',
+    '开拓者',
+    '多边贸易',
+    '地质调查',
+    '指挥',
+    '后勤',
+    '突击战术',
+    '堡垒战术',
+    '远程战术',
     '破坏战术'
   ]
 }
 
+// 个别分队显示带注解（代理人分队（不支持）），值仍为干净分队名。
+const squad_display_override = { 代理人: '代理人分队（不支持）' }
+
 for (const s in squad) {
   squad[s] = squad[s].map((x) => {
-    return { label: x + '分队', value: x + '分队' }
+    const value = x + '分队'
+    return { label: squad_display_override[x] ?? value, value }
   })
 }
 
-const roles = [
-  { label: '先手必胜（先锋、狙击、特种）', value: '先手必胜' },
-  { label: '稳扎稳打（重装、术师、狙击）', value: '稳扎稳打' },
-  { label: '取长补短（近卫、辅助、医疗）', value: '取长补短' },
-  { label: '随心所欲（随机）', value: '随心所欲' }
-]
+// 职业组按主题变化：界园/黑流树海额外有「灵活部署」「坚不可摧」，其余主题没有。
+const roles = computed(() => {
+  const base = [
+    { label: '先手必胜（先锋、狙击、特种）', value: '先手必胜' },
+    { label: '稳扎稳打（重装、术师、狙击）', value: '稳扎稳打' },
+    { label: '取长补短（近卫、辅助、医疗）', value: '取长补短' }
+  ]
+  if (maa_rg_theme.value === 'JieGarden' || maa_rg_theme.value === 'BlackFlow') {
+    base.push({ label: '灵活部署（先锋、辅助、特种）', value: '灵活部署' })
+    base.push({ label: '坚不可摧（重装、术师、医疗）', value: '坚不可摧' })
+  }
+  base.push({ label: '随心所欲（三张随机）', value: '随心所欲' })
+  return base
+})
 
-const mode_list = [
-  { label: '刷蜡烛，尽可能稳定地打更多层数', value: 0 },
-  { label: '刷源石锭，第一层投资完就退出', value: 1 },
-  { label: '【即将弃用】兼顾', value: 2 },
-  // { label: '开发中...', value: 3 },
-  { label: '刷开局，到达第三层后直接退出', value: 4 },
-  { label: '刷坍缩范式', value: 5 }
-]
+// MAA 各主题「推荐配置」提示（RoguelikeThemeTip*，{key=...} 已解析），挂在开局干员旁的 ？ 上；
+// 开头照 MAA 的 StartingCoreCharTip（「不填写则使用默认策略。」）并标注来源，
+// 主题名用 MAA 的缩写（傀影/水月/萨米/萨卡兹/界园/黑流树海）。
+const rogue_theme_tip_header = '以下提示来自 MAA：\n不填写则使用默认策略。\n\n'
+const rogue_theme_tip = computed(() => {
+  const tips = {
+    Phantom: `傀影推荐配置：
+
+开局分队: 指挥分队 / 突击战术分队
+开局职业组: 取长补短（近卫、辅助、医疗）
+开局干员: 丰川祥子 / 棘刺
+
+当前难度 ≥3 时，可能无法在开局招募 6★ 干员，导致出错或失败`,
+    Mizuki: `水月推荐配置：
+
+开局分队: 以人为本分队 / 心胜于物分队
+开局职业组: 稳扎稳打（重装、术师、狙击）
+开局干员: 维什戴尔
+
+1. box 里强力 6★ 干员较多时推荐选择 ｢以人为本分队｣
+2. 当前难度 ≥4 时，6★ 干员希望消耗 +1，使用部分分队时可能无法在开局招募 6★ 干员，导致出错或失败`,
+    Sami: `萨米推荐配置：
+
+开局分队: 特训分队 / 远程战术分队
+开局职业组: 稳扎稳打（重装、术师、狙击）
+开局干员: 维什戴尔
+
+当前难度 ≥6 时，6★ 干员希望消耗 +1，使用部分分队时可能无法在开局招募 6★ 干员，导致出错或失败`,
+    Sarkaz: `萨卡兹推荐配置：
+
+开局分队: 蓝图测绘分队 / 远程战术分队
+开局职业组: 稳扎稳打（重装、术师、狙击）
+开局干员: 维什戴尔
+
+1. 使用 ｢蓝图测绘分队｣ 时将完全采用避战策略，适合快速刷等级，不追求通关
+2. 使用 ｢点刺成锭分队｣ 可提升刷源石锭效率，但需要注意策略选择为 ｢刷源石锭｣
+3. 当前难度 ≥15 时，6★ 干员希望消耗 +1，使用部分分队时可能无法招募开局 6★ 干员，导致出错或失败`,
+    JieGarden: `界园推荐配置：
+
+开局分队: 指挥分队 / 远程战术分队
+开局职业组: 稳扎稳打（重装、术师、狙击）
+开局干员: 维什戴尔
+
+1. 当策略选择 ｢刷源石锭｣，难度选择 ≥3 或 ｢MAX｣，开局分队选择 ｢指挥分队｣ 时将启用指挥避战策略
+2. 使用指挥避战策略将大幅提高刷源石锭效率，也可用于快速刷等级（不追求通关），但需要注意策略选择为 ｢刷源石锭｣
+3. 已解锁的最高难度 <3 或未解锁相关科技时，请不要使用指挥避战策略，否则会导致出错
+4. 当前难度 ≥15 时，6★ 干员希望消耗 +1，使用部分分队时可能无法招募开局 6★ 干员，导致出错或失败`,
+    BlackFlow: `黑流树海推荐配置：
+
+开局干员: 机械师（要精二）
+开局分队: ｢特勤分队｣ / ｢堡垒战术分队｣
+开局职业组: ｢稳扎稳打（重装、术师、狙击）｣ / ｢坚不可摧（重装、术师、医疗）｣
+
+1. 目前没有专用战斗策略，作战由招募评分自动决策；
+    刷源石锭、刷等级、刷襁褓动物目前全部围绕精二机械师的飞展开。
+    本次肉鸽机制繁多，不按上述配置开局就只能使用默认寻路与战斗，大概率失败，
+    强烈推荐精二机械师开局（精二机械师只需通关一次 N1，相对简单）
+2. 机械师精二后，完成 ｢招募精通 II｣ ｢效果提升 II｣ 科技，开局即可携带 ｢结构性原理｣（全图任意飞 3 次）；
+    解锁很简单，精二后累计卖出 10 个零件即可，强烈推荐。
+    未解锁时只能向周围 8 格飞 3 次，虽然也能刷，但效率会低不少
+3. 刷等级时，机械师（要精二）+ 上述分队与职业组 + 重装券，可以快速飞完三层
+4. 没有精二机械师就不要选机械师，可以正常刷钱，但战斗大概率暴毙，其他策略待后续优化
+5. 刷等级 + 不勾选 ｢投资源石锭｣，即可跳过商店`
+  }
+  return tips[maa_rg_theme.value] ? rogue_theme_tip_header + tips[maa_rg_theme.value] : ''
+})
 
 const col = [
   '去量化',
@@ -149,27 +249,141 @@ const col_list = []
 for (const c of col) {
   col_list.push({ label: c, value: c })
 }
+
+// 烧水分队：未填写时默认跟随 squad（协议：默认与 squad 同步，两者皆空时为指挥分队）
+const collectible_squad_options = computed(() => [
+  { label: '默认（跟随分队）', value: '' },
+  ...(squad[maa_rg_theme.value] ?? [])
+])
+
+// 凹开局/只凹直升的可见性与「只凹需先勾直升」的联动清理规则都在 roguelike_options.js
+// 维护（与协议条件同处）：直升取消勾选或直升不再可见（主题/策略/分队变化）时只凹一并
+// 清除，避免下发 start_with_elite_two=false 与 only_start_with_elite_two=true 的非法组合。
+watch(
+  [
+    () => rogue.value.only_start_with_elite_two,
+    () => rogue.value.start_with_elite_two,
+    () => rogue.value.mode,
+    () => rogue.value.squad,
+    maa_rg_theme
+  ],
+  () => {
+    if (
+      only_elite_two_needs_reset(
+        maa_rg_theme.value,
+        rogue.value.mode,
+        rogue.value.squad,
+        rogue.value.start_with_elite_two,
+        rogue.value.only_start_with_elite_two
+      )
+    ) {
+      rogue.value.only_start_with_elite_two = false
+    }
+  },
+  { immediate: true }
+)
+
+// 策略下拉：按当前主题过滤主题限定模式（10001/20001/30001 等），其余主题不可见。
+const mode_options = computed(() => modes_for_theme(maa_rg_theme.value))
+
+// 切主题后（含载入时）若当前策略已不属于该主题，回退到通用策略 0（刷等级），避免下发无效组合。
+watch(
+  maa_rg_theme,
+  () => {
+    if (!mode_options.value.some((m) => m.value === rogue.value.mode)) {
+      rogue.value.mode = 0
+    }
+  },
+  { immediate: true }
+)
+
+// 策略切到「刷源石锭」时强制开启投资（对照 RoguelikeMode 设置器），该模式下投资勾选随之禁用。
+watch(
+  () => rogue.value.mode,
+  (mode) => {
+    if (mode === 1 && !rogue.value.investment_enabled) {
+      rogue.value.investment_enabled = true
+    }
+  },
+  { immediate: true }
+)
+// 刷开局期望奖励：选项按主题变化（对照 UpdateRoguelikeStartWithAllDict），
+// 存储只保留选中的奖励键（协议 collectible_mode_start_list）。
+const start_reward_options = computed(() => {
+  const base = [
+    { label: '热水壶', value: 'hot_water' },
+    { label: '盾', value: 'shield' },
+    { label: '锭', value: 'ingot' },
+    { label: '希望', value: 'hope' },
+    { label: '随机奖励', value: 'random' }
+  ]
+  const theme = maa_rg_theme.value
+  if (theme === 'JieGarden') {
+    base.splice(
+      base.findIndex((o) => o.value === 'hope'),
+      1
+    )
+  }
+  if (theme === 'Mizuki') {
+    base.push({ label: '钥匙', value: 'key' }, { label: '骰子', value: 'dice' })
+  }
+  if (theme === 'Sarkaz') base.push({ label: '构想', value: 'ideas' })
+  if (theme === 'JieGarden') base.push({ label: '票券', value: 'ticket' })
+  return base
+})
+const start_reward_values = computed({
+  get: () =>
+    Object.entries(rogue.value.collectible_mode_start_list ?? {})
+      .filter(([, v]) => v)
+      .map(([k]) => k),
+  set: (v) => {
+    rogue.value.collectible_mode_start_list = Object.fromEntries(v.map((k) => [k, true]))
+  }
+})
 </script>
 
 <template>
   <n-form :label-placement="mobile ? 'top' : 'left'" :show-feedback="false" class="rogue">
-    <n-form-item label="主题">
+    <n-form-item label="肉鸽主题">
       <n-select v-model:value="maa_rg_theme" :options="rogue_themes" />
     </n-form-item>
-    <n-form-item label="分队">
+    <n-form-item label="开局分队">
       <n-select v-model:value="rogue.squad" :options="squad[maa_rg_theme]" />
     </n-form-item>
-    <n-form-item label="职业">
+    <n-form-item label="开局职业组">
       <n-select v-model:value="rogue.roles" :options="roles" />
     </n-form-item>
-    <n-form-item label="干员">
+    <n-form-item>
+      <template #label>
+        开局干员
+        <HelpText>
+          <span style="white-space: pre-line">{{ rogue_theme_tip }}</span>
+        </HelpText>
+      </template>
       <n-select
         filterable
+        clearable
         :options="operators"
         v-model:value="rogue.core_char"
         :filter="(p, o) => pinyin_match(o.label, p)"
         :render-label="render_op_label"
       />
+    </n-form-item>
+    <n-form-item
+      v-if="elite_two_visible(maa_rg_theme, rogue.mode, rogue.squad)"
+      :show-label="false"
+    >
+      <n-checkbox v-model:checked="rogue.start_with_elite_two">凹开局干员直升精二</n-checkbox>
+    </n-form-item>
+    <n-form-item
+      v-if="
+        only_elite_two_visible(maa_rg_theme, rogue.mode, rogue.squad, rogue.start_with_elite_two)
+      "
+      :show-label="false"
+    >
+      <n-checkbox v-model:checked="rogue.only_start_with_elite_two"
+        >只凹开局干员直升精二，不进行作战</n-checkbox
+      >
     </n-form-item>
     <n-form-item :show-label="false">
       <n-checkbox v-model:checked="rogue.use_support">开局干员使用助战</n-checkbox>
@@ -178,13 +392,79 @@ for (const c of col) {
       <n-checkbox v-model:checked="rogue.use_nonfriend_support">开局干员使用非好友助战</n-checkbox>
     </n-form-item>
     <n-form-item label="策略">
-      <n-select :options="mode_list" v-model:value="rogue.mode" />
+      <n-select :options="mode_options" v-model:value="rogue.mode" />
     </n-form-item>
-    <n-form-item :show-label="false">
+    <n-form-item
+      v-if="is_field_enabled('refresh_trader_with_dice', maa_rg_theme, rogue.mode)"
+      :show-label="false"
+    >
       <n-checkbox v-model:checked="rogue.refresh_trader_with_dice">刷新商店（指路鳞）</n-checkbox>
     </n-form-item>
-    <n-form-item label="坍缩范式">
+    <n-form-item
+      label="坍缩范式"
+      v-if="is_field_enabled('expected_collapsal_paradigms', maa_rg_theme, rogue.mode)"
+    >
       <n-select multiple :options="col_list" v-model:value="rogue.expected_collapsal_paradigms" />
+    </n-form-item>
+    <n-form-item label="难度">
+      <n-select v-model:value="rogue.difficulty" :options="difficulty_options(maa_rg_theme)" />
+    </n-form-item>
+    <n-form-item
+      v-if="is_field_enabled('stop_at_final_boss', maa_rg_theme, rogue.mode)"
+      :show-label="false"
+    >
+      <n-checkbox v-model:checked="rogue.stop_at_final_boss">到达险路恶敌前停止</n-checkbox>
+    </n-form-item>
+    <n-form-item
+      v-if="is_field_enabled('stop_at_max_level', maa_rg_theme, rogue.mode)"
+      :show-label="false"
+    >
+      <n-checkbox v-model:checked="rogue.stop_at_max_level">肉鸽等级刷满后停止</n-checkbox>
+    </n-form-item>
+    <n-form-item :show-label="false">
+      <n-checkbox v-model:checked="rogue.investment_enabled" :disabled="rogue.mode === 1"
+        >投资源石锭</n-checkbox
+      >
+    </n-form-item>
+    <n-form-item
+      v-if="is_field_enabled('stop_when_investment_full', maa_rg_theme, rogue.mode)"
+      :show-label="false"
+    >
+      <n-checkbox v-model:checked="rogue.stop_when_investment_full">源石锭投资满时停止</n-checkbox>
+    </n-form-item>
+    <n-form-item
+      v-if="is_field_enabled('investment_with_more_score', maa_rg_theme, rogue.mode)"
+      :show-label="false"
+    >
+      <n-checkbox v-model:checked="rogue.investment_with_more_score"
+        >投资模式启用购物、招募、进2层</n-checkbox
+      >
+    </n-form-item>
+    <n-form-item
+      v-if="is_field_enabled('collectible_mode_shopping', maa_rg_theme, rogue.mode)"
+      :show-label="false"
+    >
+      <n-checkbox v-model:checked="rogue.collectible_mode_shopping">烧水时启用购物</n-checkbox>
+    </n-form-item>
+    <n-form-item
+      v-if="is_field_enabled('collectible_mode_squad', maa_rg_theme, rogue.mode)"
+      label="烧水分队"
+    >
+      <n-select v-model:value="rogue.collectible_mode_squad" :options="collectible_squad_options" />
+    </n-form-item>
+    <n-form-item
+      v-if="
+        collectible_start_visible(
+          maa_rg_theme,
+          rogue.mode,
+          rogue.squad,
+          rogue.only_start_with_elite_two,
+          rogue.start_with_elite_two
+        )
+      "
+      label="刷开局期望奖励"
+    >
+      <n-select multiple :options="start_reward_options" v-model:value="start_reward_values" />
     </n-form-item>
   </n-form>
 </template>

--- a/ui/src/utils/roguelike_options.js
+++ b/ui/src/utils/roguelike_options.js
@@ -1,0 +1,131 @@
+// Roguelike 主题与模式枚举（#264）。MAA 集成协议的主题/模式值列表，界面与测试共用；
+// 主题补 BlackFlow；模式弃用 2（已移除）与 3（未开放），新增 6/7/30001 及主题限定模式
+// 10001/20001。主题限定模式用 theme 字段标注，界面按当前主题过滤。
+export const rogue_themes = [
+  { label: '傀影与猩红孤钻', value: 'Phantom' },
+  { label: '水月与深蓝之树', value: 'Mizuki' },
+  { label: '探索者的银凇止境', value: 'Sami' },
+  { label: '萨卡兹的无终奇语', value: 'Sarkaz' },
+  { label: '界园志异', value: 'JieGarden' },
+  { label: '沉沦者的黑流树海', value: 'BlackFlow' }
+]
+
+export const mode_list = [
+  { label: '刷等级，尽可能稳定地打更多层数', value: 0 },
+  { label: '刷源石锭，投资完成后自动退出', value: 1 },
+  { label: '刷开局，刷取热水壶或精二干员开局', value: 4 },
+  { label: '刷坍缩范式，遇到非稀有坍缩范式后直接重开', value: 5, theme: 'Sami' },
+  { label: '刷月度小队，尽可能稳定地打更多层数', value: 6 },
+  { label: '刷深入调查，尽可能稳定地打更多层数', value: 7 },
+  { label: '快速通过第一层', value: 10001, theme: 'Sarkaz' },
+  { label: '刷常乐节点，第一层进洞，找不到需要的节点就重开', value: 20001, theme: 'JieGarden' },
+  { label: '刷襁褓动物', value: 30001, theme: 'BlackFlow' }
+]
+
+// 黑流树海用独立的三套策略（对照：刷等级快速飞三层 / 刷源石锭 / 刷襁褓动物），
+// 不用通用策略列表；其余主题共用通用策略并按主题追加限定策略。
+const blackflow_modes = [
+  { label: '刷等级，快速飞三层', value: 0 },
+  { label: '刷源石锭，投资完成后自动退出', value: 1 },
+  { label: '刷襁褓动物', value: 30001 }
+]
+
+// 当前主题可选的策略列表：黑流树海走专属列表，其余按 theme 过滤主题限定策略，
+// 未标注 theme 的通用策略始终可选。
+export function modes_for_theme(theme) {
+  if (theme === 'BlackFlow') {
+    return blackflow_modes
+  }
+  return mode_list.filter((m) => !m.theme || m.theme === theme)
+}
+
+// 协议字段随所选主题/策略展示的条件（#264）：只在协议明确注明「仅某主题/某模式」的
+// 字段上做条件展示，其余字段始终展示。谓词返回 false 则界面隐藏且后端不下发该字段。
+export const field_conditions = {
+  // 协议注明 stop_at_final_boss 仅适用于除 Phantom 以外的主题，且仅在其策略为 0（刷等级）时下发
+  stop_at_final_boss: (theme, mode) => theme !== 'Phantom' && mode === 0,
+  // 仅在策略为 0（刷等级）时下发 stop_at_max_level
+  stop_at_max_level: (theme, mode) => mode === 0,
+  // 协议注明 expected_collapsal_paradigms 仅在主题为 Sami 且策略为 5 时有效
+  expected_collapsal_paradigms: (theme, mode) => theme === 'Sami' && mode === 5,
+  // 协议注明 stop_when_investment_full 仅在投资源石锭且策略为 1（刷源石锭）时生效；
+  // 策略 1 在模式切换时强制开启投资（对照 RoguelikeMode 设置器），此处只判模式
+  stop_when_investment_full: (theme, mode) => mode === 1,
+  // 协议注明 collectible_mode_shopping 与 collectible_mode_squad 仅用于策略 4（刷开局）
+  collectible_mode_shopping: (theme, mode) => mode === 4,
+  collectible_mode_squad: (theme, mode) => mode === 4,
+  // 协议注明 collectible_mode_start_list 仅在策略为 4（刷开局）时有效
+  collectible_mode_start_list: (theme, mode) => mode === 4,
+  // 协议注明 start_with_elite_two 仅适用于模式 4，MAA 在策略为 4 的主题均下发，
+  // 值内联主题 Mizuki/Sami 限制（见 elite_two_visible 的分队判断）
+  start_with_elite_two: (theme, mode) => mode === 4 && (theme === 'Mizuki' || theme === 'Sami'),
+  // 协议注明 only_start_with_elite_two 仅在模式为 4 且 start_with_elite_two 为 true 时有效，
+  // 主题同样仅限 Mizuki/Sami
+  only_start_with_elite_two: (theme, mode) =>
+    mode === 4 && (theme === 'Mizuki' || theme === 'Sami'),
+  // 协议注明 refresh_trader_with_dice（指路鳞）仅支持主题 Mizuki
+  refresh_trader_with_dice: (theme) => theme === 'Mizuki',
+  // 协议注明 investment_with_more_score 仅在策略为 1（刷源石锭）且非黑流树海主题时生效
+  investment_with_more_score: (theme, mode) => mode === 1 && theme !== 'BlackFlow'
+}
+
+// 当前主题/策略下某协议字段是否应展示（且应下发）。
+export function is_field_enabled(name, theme, mode) {
+  const cond = field_conditions[name]
+  return cond ? cond(theme, mode) : true
+}
+
+// 战术分队类（对照 RoguelikeSquadIsProfessional），凹开局直升精二仅对这类分队生效。
+export const professional_squads = ['突击战术分队', '堡垒战术分队', '远程战术分队', '破坏战术分队']
+
+// 凹开局干员直升精二：主题/策略门限由 is_field_enabled 判过，此处再查分队是否战术分队类。
+export function elite_two_visible(theme, mode, squad) {
+  return (
+    is_field_enabled('start_with_elite_two', theme, mode) && professional_squads.includes(squad)
+  )
+}
+
+// 只凹开局干员直升精二需先勾选直升（对照 RoguelikeOnlyStartWithEliteTwoRaw 的可见条件）。
+export function only_elite_two_visible(theme, mode, squad, start) {
+  return is_field_enabled('only_start_with_elite_two', theme, mode) && start
+}
+
+// 勾选「只凹开局干员直升精二」时奖励选择隐藏（非 Phantom 主题 + 战术分队类，
+// 与后端撤销 collectible_mode_start_list 的条件一致）。
+export function collectible_start_visible(theme, mode, squad, only, start) {
+  return (
+    is_field_enabled('collectible_mode_start_list', theme, mode) &&
+    !(only && start && theme !== 'Phantom' && professional_squads.includes(squad))
+  )
+}
+
+// 「只凹需先勾直升」的联动清理规则：直升取消勾选或直升不再可见（主题/策略/分队变化）时，
+// 只凹必须一并清除，否则会下发 start_with_elite_two=false 与
+// only_start_with_elite_two=true 的组合，被 MAA 核心判定非法。
+export function only_elite_two_needs_reset(theme, mode, squad, start, only) {
+  return only && (!start || !elite_two_visible(theme, mode, squad))
+}
+
+// 各主题肉鸽难度范围（对照：萨卡兹/水月/界园 0-18，其余 0-15）。
+const difficulty_max = {
+  Phantom: 15,
+  Mizuki: 18,
+  Sami: 15,
+  Sarkaz: 18,
+  JieGarden: 18,
+  BlackFlow: 15
+}
+
+// 难度下拉：不切换(-1)、最高难度(MAX)、N0..当前主题最高难度（如 N15/N18）。
+// MAX 与 MAA 一致下发 int.MaxValue，由 MAA 核心按主题最大难度处理。
+export function difficulty_options(theme) {
+  const max = difficulty_max[theme] ?? 15
+  const options = [
+    { label: '不切换难度', value: -1 },
+    { label: `MAX (${max})`, value: 2147483647 }
+  ]
+  for (let value = 0; value <= max; value++) {
+    options.push({ label: `N${value}`, value })
+  }
+  return options
+}

--- a/ui/src/utils/roguelike_options.test.js
+++ b/ui/src/utils/roguelike_options.test.js
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  collectible_start_visible,
+  difficulty_options,
+  elite_two_visible,
+  field_conditions,
+  is_field_enabled,
+  mode_list,
+  modes_for_theme,
+  only_elite_two_needs_reset,
+  only_elite_two_visible,
+  professional_squads,
+  rogue_themes
+} from './roguelike_options'
+
+describe('roguelike_options', () => {
+  it('主题含 BlackFlow 及既有主题', () => {
+    const values = rogue_themes.map((t) => t.value)
+    expect(values).toEqual(
+      expect.arrayContaining(['Phantom', 'Mizuki', 'Sami', 'Sarkaz', 'JieGarden', 'BlackFlow'])
+    )
+    // 黑流树海下拉用游戏内全名（提示文本里才用 MAA 缩写）
+    expect(rogue_themes.find((t) => t.value === 'BlackFlow').label).toBe('沉沦者的黑流树海')
+  })
+
+  it('模式含 6/7/10001/20001/30001，不含已弃用的 2 与开发中的 3', () => {
+    const values = mode_list.map((m) => m.value)
+    expect(values).toEqual(expect.arrayContaining([0, 1, 4, 5, 6, 7, 10001, 20001, 30001]))
+    expect(values).not.toContain(2)
+    expect(values).not.toContain(3)
+  })
+
+  it('主题限定模式标注了对应主题', () => {
+    const themed = Object.fromEntries(
+      mode_list.filter((m) => m.theme).map((m) => [m.value, m.theme])
+    )
+    expect(themed[10001]).toBe('Sarkaz')
+    expect(themed[20001]).toBe('JieGarden')
+    expect(themed[30001]).toBe('BlackFlow')
+    expect(themed[5]).toBe('Sami')
+  })
+
+  it('按主题过滤出可选模式', () => {
+    const values = (t) => modes_for_theme(t).map((m) => m.value)
+    expect(values('Sarkaz')).toContain(10001)
+    expect(values('Sarkaz')).not.toContain(20001)
+    expect(values('Sarkaz')).not.toContain(30001)
+    expect(values('BlackFlow')).toContain(30001)
+    expect(values('BlackFlow')).not.toContain(10001)
+    expect(values('Mizuki')).not.toContain(10001)
+    expect(values('Mizuki')).not.toContain(20001)
+    expect(values('Mizuki')).not.toContain(30001)
+    // 通用模式始终可选
+    expect(values('Mizuki')).toContain(0)
+    expect(values('Mizuki')).toContain(6)
+    // 黑流树海用专属策略（0/1/30001），不走通用 4/6/7
+    expect(values('BlackFlow')).toContain(0)
+    expect(values('BlackFlow')).toContain(1)
+    expect(values('BlackFlow')).not.toContain(4)
+    expect(values('BlackFlow')).not.toContain(6)
+  })
+
+  it('字段条件覆盖协议注明的主题/模式限定字段', () => {
+    expect(Object.keys(field_conditions).sort()).toEqual(
+      [
+        'collectible_mode_shopping',
+        'collectible_mode_squad',
+        'collectible_mode_start_list',
+        'expected_collapsal_paradigms',
+        'investment_with_more_score',
+        'only_start_with_elite_two',
+        'refresh_trader_with_dice',
+        'start_with_elite_two',
+        'stop_at_final_boss',
+        'stop_at_max_level',
+        'stop_when_investment_full'
+      ].sort()
+    )
+  })
+
+  it('stop_at_final_boss 仅非 Phantom 且策略 0 展示', () => {
+    expect(is_field_enabled('stop_at_final_boss', 'Mizuki', 0)).toBe(true)
+    expect(is_field_enabled('stop_at_final_boss', 'Sami', 5)).toBe(false)
+    expect(is_field_enabled('stop_at_final_boss', 'Phantom', 0)).toBe(false)
+    expect(is_field_enabled('stop_at_final_boss', 'Mizuki', 4)).toBe(false)
+  })
+
+  it('stop_at_max_level 仅策略 0 展示（无主题限制）', () => {
+    expect(is_field_enabled('stop_at_max_level', 'Mizuki', 0)).toBe(true)
+    expect(is_field_enabled('stop_at_max_level', 'Phantom', 0)).toBe(true)
+    expect(is_field_enabled('stop_at_max_level', 'Sami', 5)).toBe(false)
+    expect(is_field_enabled('stop_at_max_level', 'Mizuki', 4)).toBe(false)
+  })
+
+  it('expected_collapsal_paradigms 仅 Sami + 策略 5 展示', () => {
+    expect(is_field_enabled('expected_collapsal_paradigms', 'Sami', 5)).toBe(true)
+    expect(is_field_enabled('expected_collapsal_paradigms', 'Sami', 0)).toBe(false)
+    expect(is_field_enabled('expected_collapsal_paradigms', 'Mizuki', 5)).toBe(false)
+  })
+
+  it('start_with_elite_two/only_start_with_elite_two 仅 Mizuki/Sami + 策略 4 展示', () => {
+    expect(is_field_enabled('start_with_elite_two', 'Mizuki', 4)).toBe(true)
+    expect(is_field_enabled('start_with_elite_two', 'Sami', 4)).toBe(true)
+    expect(is_field_enabled('only_start_with_elite_two', 'Mizuki', 4)).toBe(true)
+    expect(is_field_enabled('only_start_with_elite_two', 'Sami', 4)).toBe(true)
+    expect(is_field_enabled('start_with_elite_two', 'Sarkaz', 4)).toBe(false)
+    expect(is_field_enabled('only_start_with_elite_two', 'Phantom', 4)).toBe(false)
+    expect(is_field_enabled('start_with_elite_two', 'Mizuki', 0)).toBe(false)
+    expect(is_field_enabled('only_start_with_elite_two', 'Sami', 0)).toBe(false)
+  })
+
+  it('collectible_mode_shopping/collectible_mode_squad 仅策略 4 展示', () => {
+    expect(is_field_enabled('collectible_mode_shopping', 'BlackFlow', 4)).toBe(true)
+    expect(is_field_enabled('collectible_mode_squad', 'Phantom', 4)).toBe(true)
+    expect(is_field_enabled('collectible_mode_shopping', 'Sami', 0)).toBe(false)
+    expect(is_field_enabled('collectible_mode_squad', 'BlackFlow', 30001)).toBe(false)
+  })
+
+  it('collectible_mode_start_list 仅策略 4 展示（无主题限制）', () => {
+    expect(is_field_enabled('collectible_mode_start_list', 'Sami', 4)).toBe(true)
+    expect(is_field_enabled('collectible_mode_start_list', 'Phantom', 4)).toBe(true)
+    expect(is_field_enabled('collectible_mode_start_list', 'Mizuki', 0)).toBe(false)
+    expect(is_field_enabled('collectible_mode_start_list', 'Sarkaz', 5)).toBe(false)
+  })
+
+  it('refresh_trader_with_dice 仅 Mizuki 展示', () => {
+    expect(is_field_enabled('refresh_trader_with_dice', 'Mizuki', 0)).toBe(true)
+    expect(is_field_enabled('refresh_trader_with_dice', 'Mizuki', 4)).toBe(true)
+    expect(is_field_enabled('refresh_trader_with_dice', 'Sami', 0)).toBe(false)
+    expect(is_field_enabled('refresh_trader_with_dice', 'Phantom', 4)).toBe(false)
+  })
+
+  it('stop_when_investment_full 仅策略 1 展示', () => {
+    expect(is_field_enabled('stop_when_investment_full', 'Sami', 1)).toBe(true)
+    expect(is_field_enabled('stop_when_investment_full', 'BlackFlow', 1)).toBe(true)
+    expect(is_field_enabled('stop_when_investment_full', 'Mizuki', 4)).toBe(false)
+    expect(is_field_enabled('stop_when_investment_full', 'Sami', 0)).toBe(false)
+  })
+
+  it('协议未限定主题/模式的字段始终展示', () => {
+    expect(is_field_enabled('difficulty', 'Sami', 0)).toBe(true)
+    expect(is_field_enabled('difficulty', 'Phantom', 0)).toBe(true)
+    expect(is_field_enabled('investment_enabled', 'Sami', 0)).toBe(true)
+  })
+
+  it('investment_with_more_score 仅策略 1 且非黑流树海展示', () => {
+    expect(is_field_enabled('investment_with_more_score', 'Sami', 1)).toBe(true)
+    expect(is_field_enabled('investment_with_more_score', 'BlackFlow', 1)).toBe(false)
+    expect(is_field_enabled('investment_with_more_score', 'Mizuki', 0)).toBe(false)
+    expect(is_field_enabled('investment_with_more_score', 'Phantom', 4)).toBe(false)
+  })
+
+  it('professional_squads 为四支战术分队', () => {
+    expect(professional_squads).toEqual([
+      '突击战术分队',
+      '堡垒战术分队',
+      '远程战术分队',
+      '破坏战术分队'
+    ])
+  })
+
+  it('凹开局直升仅战术分队可见，只凹需先勾直升', () => {
+    expect(elite_two_visible('Mizuki', 4, '突击战术分队')).toBe(true)
+    expect(elite_two_visible('Mizuki', 4, '指挥分队')).toBe(false)
+    expect(elite_two_visible('Sarkaz', 4, '突击战术分队')).toBe(false)
+    expect(only_elite_two_visible('Mizuki', 4, '突击战术分队', true)).toBe(true)
+    expect(only_elite_two_visible('Mizuki', 4, '突击战术分队', false)).toBe(false)
+  })
+
+  it('只凹勾选时奖励选择隐藏（含非 Phantom 主题条件）', () => {
+    expect(collectible_start_visible('Sami', 4, '突击战术分队', false, false)).toBe(true)
+    expect(collectible_start_visible('Sami', 4, '突击战术分队', true, true)).toBe(false)
+    // Phantom 主题没有只凹隐藏项：奖励选择仍显示（与后端撤销下发条件一致）
+    expect(collectible_start_visible('Phantom', 4, '突击战术分队', true, true)).toBe(true)
+    expect(collectible_start_visible('Mizuki', 0, '突击战术分队', true, true)).toBe(false)
+  })
+
+  it('直升取消勾选或不可见时只凹需要清除', () => {
+    expect(only_elite_two_needs_reset('Mizuki', 4, '突击战术分队', false, true)).toBe(true)
+    expect(only_elite_two_needs_reset('Mizuki', 4, '指挥分队', true, true)).toBe(true)
+    expect(only_elite_two_needs_reset('Sarkaz', 4, '突击战术分队', true, true)).toBe(true)
+    expect(only_elite_two_needs_reset('Mizuki', 4, '突击战术分队', true, true)).toBe(false)
+    expect(only_elite_two_needs_reset('Mizuki', 4, '突击战术分队', true, false)).toBe(false)
+  })
+
+  it('难度下拉含不切换、MAX 与当前主题难度范围', () => {
+    // 萨卡兹/水月/界园 0-18，其余 0-15；首项恒为不切换(-1)，次项为 MAX（int.MaxValue）
+    const rows = {
+      Sarkaz: 19,
+      Mizuki: 19,
+      JieGarden: 19,
+      Phantom: 16,
+      Sami: 16,
+      BlackFlow: 16
+    }
+    for (const [theme, count] of Object.entries(rows)) {
+      expect(difficulty_options(theme).map((o) => o.value)).toEqual([
+        -1,
+        2147483647,
+        ...Array.from({ length: count }, (_, i) => i)
+      ])
+    }
+    // 端档给 N 前缀：最低 N0、最高 N18，中间 N5
+    const sarkaz = difficulty_options('Sarkaz')
+    expect(sarkaz.find((o) => o.value === 0).label).toBe('N0')
+    expect(sarkaz.find((o) => o.value === 18).label).toBe('N18')
+    expect(sarkaz.find((o) => o.value === 5).label).toBe('N5')
+    expect(sarkaz.find((o) => o.value === 2147483647).label).toBe('MAX (18)')
+  })
+})


### PR DESCRIPTION
# 变更

补齐 MAA 集成协议缺失的肉鸽通用字段，并让界面按所选主题和策略自动显示对应的设置项；字段下发条件与 AsstRoguelikeTask.Serialize 一致（NiceAfternoon/arknights-mower#264 的协议核对结论）。

- 主题新增 BlackFlow；策略新增 6/7/10001/20001/30001，不再提供已弃用的 2 与开发中的 3
- 新增字段（协议英文名 → 中文含义）：

| 字段 | 中文含义 | 默认值 |
|---|---|---|
| difficulty | 肉鸽难度（-1 不指定；MAX 为主题最高难度，下发 int.MaxValue） | -1 |
| stop_at_final_boss | 第 5 层险路恶敌前停止（仅非 Phantom 主题） | 关 |
| stop_at_max_level | 肉鸽等级刷满后停止 | 关 |
| investment_enabled | 是否投资源石锭 | 开 |
| stop_when_investment_full | 源石锭投资满即停 | 关 |
| investment_with_more_score | 投资模式启用购物、招募、进2层 | 关 |
| collectible_mode_shopping | 烧水时是否开启购物 | 关 |
| collectible_mode_squad | 烧水使用的分队（默认跟随分队） | 空 |
| collectible_mode_start_list | 刷开局期望奖励（9 键全量下发） | 全 False |
| start_with_elite_two / only_start_with_elite_two | 凹开局干员直升精二 / 只凹不作战 | 关 |
| expected_collapsal_paradigms | 需要刷的坍缩范式 | 4 项默认列表 |
| refresh_trader_with_dice | 刷新商店（指路鳞，仅 Mizuki） | 关 |

- 下发语义对齐 Serialize：投资类字段仅在 investment_enabled 时下发；指路鳞与直升、只凹键始终下发、值内联主题和分队限制；坍缩范式列表为空时不发；勾选「只凹」时撤销 collectible_mode_start_list
- 界面按主题和策略显示字段（谓词集中在 roguelike_options.js，与后端共用）；策略切到刷源石锭时强制开启投资；直升取消勾选或不可见时清除只凹，避免 start_with_elite_two=false 与 only_start_with_elite_two=true 的组合被 MAA 核心拒绝

# 限制

- 配置文件里手写的「只凹已勾、直升未勾」陈旧组合仍按协议原样下发（与 MAA 行为一致）；界面路径已由联动清除兜住

# 验证

- vitest 122 例通过
- pytest 1295 通过、17 跳过（排除 software_update_tests.py）
- dev_tools（ruff format/check、prettier）通过

Part of NiceAfternoon/arknights-mower#206（B1 档）；设计参考 NiceAfternoon/arknights-mower#235。
