### PR TITLE
fix(ui): 修复仓库加载、404兜底及下拉头像显示

### DIFF
--- a/arknights_mower/tests/depot_route_tests.py
+++ b/arknights_mower/tests/depot_route_tests.py
@@ -1,0 +1,57 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import server
+from arknights_mower.utils import depot
+from arknights_mower.utils import resource_pkg as rp
+
+
+class DepotRouteTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.client = server.app.test_client()
+
+    def test_depot_api_returns_inventory_with_active_resource_package(self):
+        inventory = [
+            {"A常用": {"龙门币": {"number": 123, "sort": 1, "icon": "龙门币"}}},
+            '{"4001": 123}',
+            "2026-09-08 12:00:00",
+        ]
+        with (
+            patch.object(rp, "resource_ui_path", return_value=self.root),
+            patch.object(depot, "读取仓库", return_value=inventory) as read_inventory,
+            patch.object(server, "get_path", return_value=self.root / "cultivate.json"),
+        ):
+            response = self.client.get("/depot/readdepot")
+
+        self.addCleanup(response.close)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.is_json)
+        self.assertEqual(response.get_json()["depot"], inventory)
+        self.assertFalse(response.get_json()["cultivate_ok"])
+        read_inventory.assert_called_once_with()
+
+    def test_resource_images_still_use_active_package(self):
+        for directory in ("depot", "avatar", "building_skill"):
+            with self.subTest(directory=directory):
+                image = self.root / directory / "test.webp"
+                image.parent.mkdir()
+                image.write_bytes(b"resource image")
+                with patch.object(rp, "resource_ui_path", return_value=self.root):
+                    response = self.client.get(f"/{directory}/test.webp")
+                try:
+                    self.assertEqual(response.status_code, 200)
+                    self.assertEqual(response.data, b"resource image")
+                    self.assertEqual(response.mimetype, "image/webp")
+                    self.assertEqual(response.headers["Cache-Control"], "no-cache")
+                finally:
+                    response.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/tests/software_update_transaction_tests.py
+++ b/arknights_mower/tests/software_update_transaction_tests.py
@@ -15,6 +15,7 @@ import time
 import unittest
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 from arknights_mower.utils import update_runtime as runtime
 from arknights_mower.utils.software_update_worker import Worker
@@ -24,6 +25,16 @@ from arknights_mower.utils.software_update_worker import Worker
     shutil.which("git") and shutil.which("npm"), "requires Git and npm"
 )
 class SourceTransactionTests(unittest.TestCase):
+    def wait_for_ready_instances(self, state):
+        deadline = time.monotonic() + 10
+        while True:
+            records = runtime.instances(state)
+            if len(records) == 3 and all(record.get("ready") for record in records):
+                return records
+            if time.monotonic() >= deadline:
+                self.fail(f"three fixture instances did not become ready: {records}")
+            time.sleep(0.05)
+
     def transaction(
         self,
         fail_build=False,
@@ -204,16 +215,11 @@ class SourceTransactionTests(unittest.TestCase):
                     )
                     original.append(process)
                     threading.Thread(target=process.wait, daemon=True).start()
-                deadline = time.monotonic() + 10
-                while (
-                    len(runtime.instances(state)) != 3 and time.monotonic() < deadline
-                ):
-                    time.sleep(0.05)
-                self.assertEqual(len(runtime.instances(state)), 3)
+                records = self.wait_for_ready_instances(state)
                 # On Windows a venv python.exe can be a launcher that re-execs
                 # the real interpreter, so Popen.pid differs from the registered
                 # os.getpid(). Compare registered pids, not Popen pids.
-                original_pids = {r["pid"] for r in runtime.instances(state)}
+                original_pids = {r["pid"] for r in records}
                 work = directory / "job"
                 job = {
                     "id": "transaction",
@@ -284,12 +290,9 @@ class SourceTransactionTests(unittest.TestCase):
                 )
                 worker.execute()
                 replacements = worker.new_processes + worker.recovery_processes
-                deadline = time.monotonic() + 10
-                while (
-                    len(runtime.instances(state)) != 3 and time.monotonic() < deadline
-                ):
-                    time.sleep(0.05)
-                records = sorted(runtime.instances(state), key=lambda row: row["name"])
+                records = sorted(
+                    self.wait_for_ready_instances(state), key=lambda row: row["name"]
+                )
                 self.assertEqual(len(records), 3)
                 self.assertEqual(
                     [row["running"] for row in records], [True, False, True]
@@ -421,6 +424,28 @@ class SourceTransactionTests(unittest.TestCase):
 
     def test_failure_after_dependency_install_restores_original_environment(self):
         self.transaction(fail_install=True)
+
+
+class SourceReadinessTests(unittest.TestCase):
+    def test_registration_count_does_not_imply_fixture_readiness(self):
+        pending = [{"ready": False} for _ in range(3)]
+        ready = [{"ready": True, "fixture_version": "old"} for _ in range(3)]
+        transaction = SourceTransactionTests()
+        with (
+            patch.object(runtime, "instances", side_effect=[pending, ready]),
+            patch.object(time, "sleep") as sleep,
+        ):
+            self.assertEqual(transaction.wait_for_ready_instances(None), ready)
+        sleep.assert_called_once_with(0.05)
+
+    def test_readiness_wait_times_out_instead_of_accepting_partial_records(self):
+        transaction = SourceTransactionTests()
+        with (
+            patch.object(runtime, "instances", return_value=[{"ready": False}] * 3),
+            patch.object(time, "monotonic", side_effect=[0, 11]),
+        ):
+            with self.assertRaisesRegex(AssertionError, "did not become ready"):
+                transaction.wait_for_ready_instances(None)
 
 
 if __name__ == "__main__":

--- a/arknights_mower/tests/update_compat_tests.py
+++ b/arknights_mower/tests/update_compat_tests.py
@@ -49,6 +49,57 @@ class UpdateCompatibilityTests(unittest.TestCase):
             "restart_job": "compat",
         }
 
+    def test_windows_worktree_cleanup_retries_released_directory_handle(self):
+        worker = installer.Worker(self.job_path)
+        worker.job["git"] = "git"
+        worker.source_stage.mkdir()
+        (worker.source_stage / "fixture").write_text("temporary")
+        worker.run_command = Mock(side_effect=subprocess.CalledProcessError(255, "git"))
+        remove_tree = installer.shutil.rmtree
+        locked = PermissionError("directory handle still open")
+        locked.winerror = 32
+        attempts = 0
+
+        def remove(path):
+            nonlocal attempts
+            self.assertEqual(path, worker.source_stage)
+            attempts += 1
+            if attempts == 1:
+                raise locked
+            remove_tree(path)
+
+        with (
+            patch.object(installer.sys, "platform", "win32"),
+            patch.object(installer.shutil, "rmtree", side_effect=remove),
+            patch.object(installer.time, "sleep") as sleep,
+        ):
+            worker.cleanup_preparation()
+        self.assertEqual(attempts, 2)
+        self.assertFalse(worker.source_stage.exists())
+        self.assertTrue(self.root.exists())
+        worker.run_command.assert_called_once()
+        sleep.assert_called_once_with(0.1)
+
+    def test_windows_worktree_cleanup_is_bounded_and_reports_permanent_lock(self):
+        worker = installer.Worker(self.job_path)
+        worker.job["git"] = "git"
+        worker.source_stage.mkdir()
+        worker.run_command = Mock(side_effect=subprocess.CalledProcessError(255, "git"))
+        locked = PermissionError("directory stays open")
+        locked.winerror = 32
+        with (
+            patch.object(installer.sys, "platform", "win32"),
+            patch.object(installer.shutil, "rmtree", side_effect=locked) as remove,
+            patch.object(installer.time, "monotonic", side_effect=[0, 6]),
+            patch.object(installer.time, "sleep") as sleep,
+            patch.object(installer.traceback, "print_exc") as report,
+        ):
+            worker.cleanup_preparation()
+        remove.assert_called_once_with(worker.source_stage)
+        sleep.assert_not_called()
+        report.assert_called_once()
+        self.assertTrue(worker.source_stage.exists())
+
     def test_settings_apis_report_unreadable_registration_without_server_error(self):
         app = Flask(__name__)
         app.register_blueprint(software_update_bp)

--- a/arknights_mower/tests/web_routing_tests.py
+++ b/arknights_mower/tests/web_routing_tests.py
@@ -1,0 +1,137 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from flask import abort
+
+import server
+from arknights_mower.utils import resource_pkg as rp
+
+
+class WebRoutingTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.shell = b"<html>mower fixture</html>"
+        (self.root / "index.html").write_bytes(self.shell)
+        manifest = Path(server.__file__).parent / "ui/public/frontend-routes.json"
+        (self.root / manifest.name).write_bytes(manifest.read_bytes())
+        self.pages = json.loads(manifest.read_text("utf-8"))
+        for mock in (
+            patch.object(server.app, "_static_folder", str(self.root)),
+            patch.object(rp, "resource_ui_path", return_value=None),
+        ):
+            mock.start()
+            self.addCleanup(mock.stop)
+        self.client = server.app.test_client()
+
+    def get(self, path, **kwargs):
+        response = self.client.get(path, **kwargs)
+        self.addCleanup(response.close)
+        return response
+
+    def test_frontend_pages_refresh_with_query_trailing_slash_and_case(self):
+        # /mastery-recommendation 已有同名 API，由原接口处理，不经过页面 404 兜底。
+        for page in self.pages:
+            if page == "/mastery-recommendation":
+                continue
+            for path in {page, page.upper(), page.rstrip("/") + "/?token=fixture"}:
+                with self.subTest(path=path):
+                    response = self.get(path)
+                    self.assertEqual(response.status_code, 200)
+                    self.assertEqual(response.data, self.shell)
+        with self.client.head("/record/depot") as response:
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.data, b"")
+
+    def test_unknown_apis_and_missing_assets_remain_404_even_for_browser_navigation(
+        self,
+    ):
+        for path in (
+            "/report/nonexistent-api",
+            "/record/nonexistent-api",
+            "/depot/nonexistent-api",
+            "/assets/missing.js",
+            "/avatar/missing.webp",
+            "/building_skill/missing.webp",
+            "/missing.css",
+        ):
+            for accept in ("application/json, text/plain, */*", "text/html", "*/*"):
+                with self.subTest(path=path, accept=accept):
+                    response = self.get(path, headers={"Accept": accept})
+                    self.assertEqual(response.status_code, 404)
+                    self.assertNotEqual(response.data, self.shell)
+
+    def test_existing_api_not_found_is_not_replaced_by_spa(self):
+        def missing():
+            abort(404)
+
+        with patch.dict(server.app.view_functions, {"load_config": missing}):
+            for method in ("get", "post"):
+                with getattr(self.client, method)(
+                    "/conf", headers={"Accept": "text/html"}
+                ) as response:
+                    self.assertEqual(response.status_code, 404)
+                    self.assertEqual(response.get_json(), {"error": "Not Found"})
+
+    def test_unknown_frontend_navigation_retains_vue_not_found_page(self):
+        response = self.get(
+            "/unknown-page",
+            headers={"Accept": "text/html", "Sec-Fetch-Dest": "document"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, self.shell)
+        for headers in (
+            {},
+            {"Accept": "*/*"},
+            {"Accept": "application/json"},
+            {"Accept": "text/html;q=0,*/*"},
+            {"Accept": "text/html", "Sec-Fetch-Dest": "image"},
+        ):
+            with self.subTest(headers=headers):
+                self.assertEqual(
+                    self.get("/unknown-page", headers=headers).status_code, 404
+                )
+
+    def test_docs_directory_index_and_static_files_are_preserved(self):
+        (self.root / "docs/guide").mkdir(parents=True)
+        (self.root / "docs/guide/index.html").write_bytes(b"guide")
+        (self.root / "docs/manual.html").write_bytes(b"manual")
+        (self.root / "app.js").write_bytes(b"app")
+        for path, body in (
+            ("/docs/guide", b"guide"),
+            ("/docs/guide/", b"guide"),
+            ("/docs/manual.html", b"manual"),
+            ("/app.js", b"app"),
+        ):
+            with self.subTest(path=path):
+                response = self.get(path)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.data, body)
+        self.assertEqual(self.get("/docs/missing").status_code, 404)
+
+    def test_source_checkout_with_older_frontend_uses_source_route_manifest(self):
+        (self.root / "frontend-routes.json").unlink()
+        self.assertEqual(self.get("/record/depot").data, self.shell)
+
+    def test_builtin_images_remain_available_without_external_package(self):
+        (self.root / "avatar").mkdir()
+        (self.root / "avatar/operator.webp").write_bytes(b"builtin avatar")
+        response = self.get("/avatar/operator.webp")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, b"builtin avatar")
+
+    def test_missing_external_image_does_not_mix_in_builtin_version(self):
+        (self.root / "avatar").mkdir()
+        (self.root / "avatar/operator.webp").write_bytes(b"builtin avatar")
+        with patch.object(rp, "resource_ui_path", return_value=self.root / "package"):
+            response = self.get("/avatar/operator.webp")
+        self.assertEqual(response.status_code, 404)
+        self.assertNotIn(b"builtin avatar", response.data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/utils/software_update_worker.py
+++ b/arknights_mower/utils/software_update_worker.py
@@ -555,6 +555,26 @@ class Worker:
                     timeout=120,
                     cancellable=False,
                 )
+            except subprocess.CalledProcessError:
+                # Git removes the worktree registration even when Windows still
+                # holds a directory handle after taskkill. Retrying git remove
+                # then fails with "not a working tree"; clean only our staging
+                # directory and give those handles a bounded time to close.
+                if sys.platform == "win32" and self.source_stage.is_dir():
+                    deadline = time.monotonic() + 5
+                    while self.source_stage.exists():
+                        try:
+                            shutil.rmtree(self.source_stage)
+                        except OSError as exc:
+                            if (
+                                getattr(exc, "winerror", None) not in {5, 32, 33}
+                                or time.monotonic() >= deadline
+                            ):
+                                traceback.print_exc()
+                                break
+                            time.sleep(0.1)
+                else:
+                    traceback.print_exc()
             except Exception:
                 traceback.print_exc()
         for path in (

--- a/server.py
+++ b/server.py
@@ -584,12 +584,56 @@ def gzip_static(response):
 
 @app.errorhandler(404)
 def not_found(e):
-    if (path := request.path).startswith("/docs"):
+    path = request.path
+    static_route = request.endpoint in {None, "static", "serve_index"}
+    if not static_route or request.method not in {"GET", "HEAD"}:
+        return {"error": "Not Found"}, 404
+
+    if path == "/docs" or path.startswith("/docs/"):
         try:
-            return send_from_directory("ui/dist" + path, "index.html")
+            return send_from_directory(
+                app.static_folder, path.strip("/") + "/index.html"
+            )
         except NotFound:
             return "<h1>404 Not Found</h1>", 404
-    return send_from_directory("ui/dist", "index.html")
+
+    # 与 Vue 路由表保持一致（routes.test.js 校验）；源码部署兼容尚未重建的 dist。
+    manifest = Path(app.static_folder) / "frontend-routes.json"
+    if not manifest.is_file():
+        manifest = get_path("@internal/ui/public/frontend-routes.json")
+    try:
+        pages = {
+            p.rstrip("/").lower() or "/"
+            for p in json.loads(manifest.read_text("utf-8"))
+        }
+    except (OSError, ValueError):
+        pages = set()
+    if (path.rstrip("/").lower() or "/") in pages:
+        return send_from_directory(app.static_folder, "index.html")
+
+    # 未知 API 和缺失资源必须保留 404，不能用首页掩盖错误。
+    root = path.strip("/").split("/", 1)[0]
+    api_roots = {
+        rule.rule.strip("/").split("/", 1)[0]
+        for rule in app.url_map.iter_rules()
+        if rule.endpoint not in {"static", "serve_index"}
+    }
+    resource_roots = {
+        "assets",
+        "avatar",
+        "depot",
+        "building_skill",
+        "basement_skill",
+        "screenshots",
+    }
+    navigation = any(
+        mime == "text/html" and quality > 0
+        for mime, quality in request.accept_mimetypes
+    ) and request.headers.get("Sec-Fetch-Dest", "") in {"", "document", "iframe"}
+    if navigation and root not in api_roots | resource_roots and not Path(path).suffix:
+        # 保留 Vue 的未知页面提示；接口客户端和静态资源请求不进入该兜底。
+        return send_from_directory(app.static_folder, "index.html")
+    return {"error": "Not Found"}, 404
 
 
 @app.route("/conf", methods=["GET", "POST"])

--- a/server.py
+++ b/server.py
@@ -518,6 +518,10 @@ def _serve_resource(base_dir: Path, relative: str):
 @app.before_request
 def serve_resource_overlay():
     """图片与本实例当前加载的数据使用同一个完整资源版本。"""
+    # /depot/readdepot 等 API 与图片共用路径前缀，只接管静态文件路由。
+    if request.endpoint not in {"static", "serve_index"}:
+        return None
+
     from arknights_mower.utils.resource_pkg import resource_ui_path
 
     path = request.path.lstrip("/")

--- a/ui/public/frontend-routes.json
+++ b/ui/public/frontend-routes.json
@@ -1,0 +1,16 @@
+[
+  "/",
+  "/readme",
+  "/plan-editor",
+  "/mowersettings",
+  "/maasettings",
+  "/doc",
+  "/mastery-recommendation",
+  "/BasementSkill",
+  "/record",
+  "/record/line",
+  "/record/depot",
+  "/record/pie",
+  "/record/report",
+  "/record/trading_analysis"
+]

--- a/ui/src/routes.test.js
+++ b/ui/src/routes.test.js
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { routes } from './routes'
+
+describe('backend page fallback contract', () => {
+  it('lists every concrete frontend route, including parent routes', () => {
+    const paths = new Set()
+    function visit(records, parent = '') {
+      for (const route of records) {
+        if (route.path === '/:pathMatch(.*)') continue
+        const path = route.path.startsWith('/') ? route.path : `${parent}/${route.path}`
+        const normalized = path.replace(/\/+/g, '/').replace(/\/$/, '') || '/'
+        paths.add(normalized)
+        if (route.children) visit(route.children, normalized)
+      }
+    }
+    visit(routes)
+    const manifest = JSON.parse(
+      readFileSync(new URL('../public/frontend-routes.json', import.meta.url), 'utf8')
+    )
+    expect(manifest.toSorted()).toEqual([...paths].toSorted())
+  })
+})

--- a/ui/src/utils/op_select.js
+++ b/ui/src/utils/op_select.js
@@ -55,7 +55,10 @@ export const render_op_label = (option) => {
       h(NAvatar, {
         src: 'avatar/' + option.value + '.webp',
         round: true,
-        size: 'small'
+        size: 'small',
+        style: {
+          flexShrink: 0
+        }
       }),
       option.label
     ]


### PR DESCRIPTION
启用资源包后，仓库接口 `/depot/readdepot` 被图片资源处理逻辑误拦截并返回 404，导致仓库内容无法显示。全局 404 兜底还会把未知 API 和缺失资源替换成 `200 + HTML`。本 PR 修复请求分类，保留资源包优先加载、前端页面导航和干员下拉头像显示。

## 改动

- 图片处理只接管静态文件端点，让业务接口正常执行。仍从实例当前选中的资源包加载仓库图片、头像和基建图标；外部包缺文件时保留 404，不混用旧版内置资源。此次仓库回归由 #959 的缺文件返回 404 逻辑触发，#923 的资源更新功能继续保留。
- 已知前端页面使用路由清单保留直达、刷新、查询参数、大小写及尾斜杠行为；清单随前端打包，并由测试校验其与 Vue 路由表一致。保留文档目录入口和浏览器访问未知前端页面时的 Vue 提示；已匹配接口的 404、未知 API 命名空间、缺失 JS/CSS/图片不再兜底成首页。
- 保留 `536d5688` 的干员下拉列表头像修复，防止头像在 flex 布局中被压缩。
- 修复本 PR 的 Windows CI 暴露的两处更新问题：Git 删除 worktree 失败后已经移除登记，改为对本次更新的临时目录执行最多 5 秒的 Windows 文件占用重试；事务测试等待三个实例明确就绪后再读取字段，避免把初始登记误当成完整状态。保留失败场景、目录清理断言和三端 CI 检查。

## 验证

- 仓库、页面路由、资源包及基建技能相关 31 项测试通过。
- 更新兼容性及新增就绪等待测试 11 项通过，覆盖短暂占用后清理成功、永久占用限时退出，以及登记存在但尚未就绪的情况。
- 前端 103 项测试、生产构建通过；构建产物包含 14 条前端页面路由。
- 修改文件 Ruff 检查、格式检查和 `git diff --check` 通过。
- 下拉头像文件与 `536d5688` 完全一致。
- 原 Windows CI 失败的两个完整事务场景已在本机复跑通过。
- [提交 `36cb13ea` 的 9 项 CI 全部通过](https://github.com/ArkMowers/arknights-mower/actions/runs/34214276211)：三端更新专项各 128 项（Windows 跳过 1 项、macOS/Linux 各跳过 2 项平台专属测试）；Linux 完整单元测试 1343 项（跳过 18 项）、脚本测试 87 项（跳过 1 项）、识别等价性测试 10 项均通过。

本机全量运行时曾出现一项桌面辅助进程退出测试超时，该项单独复跑通过。最终提交的完整回归结果见上述 CI。

接口回归使用 Flask 测试客户端；Windows 清理及更新恢复已通过原生 CI，未进行完整桌面发行包实测。
