### PR TITLE
fix: 专精资源保留干员分支 subProfessionId

### DIFF
--- a/auto_get_res_new.py
+++ b/auto_get_res_new.py
@@ -992,6 +992,7 @@ class Arknights数据处理器:
                 "name": char_info.get("name", char_id),
                 "rarity": rarity,
                 "profession": char_info.get("profession", ""),
+                "subProfessionId": char_info["subProfessionId"],
                 "skills": skills,
             }
             skill_count += len(skills)


### PR DESCRIPTION
专精资源目前只保留八大职业，无法判断行医、领主等分支对应的教官加成。本次在 `skill_data.json` 的干员条目中保留游戏表原始 `subProfessionId`，例如桑葚为 `wandermedic`。现有字段和干员筛选范围保持兼容，新增字段参与现有资源内容哈希。

MowerResource 的生成流程从本仓库 `alpha` 读取 `auto_get_res_new.py`。此 PR 需先于资源仓库的分支校验改动合入，再手动触发资源出包；脚本变更本身不会触发资源仓库的每小时源变化检查。

验证：在最新 `alpha` 上，用真实 `character_table.json` 单独运行专精提取方法，482 名干员、74 种分支全部与源字段一致；`git diff --check` 通过。未运行依赖字体和图片的完整资源构建，未发布资源包。
