### PR TITLE
feat(maa): 补齐 MAA 调用肉鸽任务的相关字段并支持掉落数据上传至企鹅物流

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -3903,7 +3903,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         "series": 0,
                         "report_to_penguin": True,
                         "client_type": _maa_client_type(),
-                        "penguin_id": "",
+                        "penguin_id": conf.maa_penguin_id,
                         "DrGrandet": False,
                         "server": "CN",
                         "medicine_expire_days": medicine_expire_days,
@@ -4078,6 +4078,10 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         # expected_collapsal_paradigms 仅 Sami + 策略 5 且列表非空时下发，
                         # 烧水字段仅策略 4 下发，勾选「只凹开局干员直升精二」时
                         # 撤销 collectible_mode_start_list，指路鳞的值内联 Mizuki 限制。
+                        # 月度小队/深入调查字段仅策略 6/7 下发（通信检查需先勾自动切换），
+                        # first_floor_foldartal 与 start_foldartal_list 仅 Sami + 策略 4
+                        # （板子列表另限生活至上分队），黑流树海字段仅刷襁褓动物模式下发，
+                        # find_playTime_target 仅界园刷常乐节点模式下发。
                         professional = conf.rogue.squad in _PROFESSIONAL_SQUADS
                         rogue_params = {
                             "theme": conf.maa_rg_theme,
@@ -4153,6 +4157,51 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                                     )
                                     for key in _COLLECTIBLE_START_KEYS
                                 }
+                        if conf.rogue.mode == 6:
+                            rogue_params["monthly_squad_auto_iterate"] = (
+                                conf.rogue.monthly_squad_auto_iterate
+                            )
+                            if conf.rogue.monthly_squad_auto_iterate:
+                                rogue_params["monthly_squad_check_comms"] = (
+                                    conf.rogue.monthly_squad_check_comms
+                                )
+                        if conf.rogue.mode == 7:
+                            rogue_params["deep_exploration_auto_iterate"] = (
+                                conf.rogue.deep_exploration_auto_iterate
+                            )
+                        if (
+                            conf.maa_rg_theme == "Sami"
+                            and conf.rogue.mode == 4
+                            and conf.rogue.first_floor_foldartal
+                        ):
+                            rogue_params["first_floor_foldartal"] = (
+                                conf.rogue.first_floor_foldartal
+                            )
+                        if (
+                            conf.maa_rg_theme == "Sami"
+                            and conf.rogue.mode == 4
+                            and conf.rogue.squad == "生活至上分队"
+                            and conf.rogue.start_foldartal_list
+                        ):
+                            rogue_params["start_foldartal_list"] = (
+                                conf.rogue.start_foldartal_list
+                            )
+                        if (
+                            conf.maa_rg_theme == "BlackFlow"
+                            and conf.rogue.mode == 30001
+                        ):
+                            # 协议固定刷襁褓动物策略，仅目标品种可选
+                            rogue_params["blackflow_strategy"] = "baby_animal"
+                            rogue_params["blackflow_cultivation_target"] = (
+                                conf.rogue.blackflow_cultivation_target
+                            )
+                        if (
+                            conf.maa_rg_theme == "JieGarden"
+                            and conf.rogue.mode == 20001
+                        ):
+                            rogue_params["find_playTime_target"] = (
+                                conf.rogue.find_playtime_target
+                            )
                         self.MAA.append_task("Roguelike", rogue_params)
                     elif conf.SSS:
                         copilot = get_path("@app/sss.json")

--- a/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
+++ b/arknights_mower/tests/maa_stage_inventory_scheduler_tests.py
@@ -19,6 +19,7 @@ def _conf(
     expiring_medicine_on_weekend=False,
     maa_report_to_yituliu=False,
     maa_yituliu_id="",
+    maa_penguin_id="",
 ):
     return SimpleNamespace(
         package_type=package_type,
@@ -43,6 +44,7 @@ def _conf(
         maa_eat_stone=False,
         maa_report_to_yituliu=maa_report_to_yituliu,
         maa_yituliu_id=maa_yituliu_id,
+        maa_penguin_id=maa_penguin_id,
     )
 
 
@@ -163,6 +165,42 @@ class MaaFightYituliuTests(unittest.TestCase):
         # yituliu_id 按协议为 string：默认下发空字符串而非 null
         task_config = self._append_fight().args[1]
         self.assertIsInstance(task_config["yituliu_id"], str)
+
+
+class MaaFightPenguinTests(unittest.TestCase):
+    """#206：penguin_id 由硬编码空串改为配置下发，企鹅上报原为硬编码常开。"""
+
+    @patch.object(BaseSchedulerSolver, "__init__", lambda self: None)
+    def _append_fight(self, **overrides):
+        solver = BaseSchedulerSolver()
+        solver.MAA = MagicMock()
+        solver.stages = []
+        with (
+            patch.object(solver, "maybe_switch_expired_activity_plan"),
+            patch.object(
+                base_schedule.config, "conf", _conf(enabled=False, **overrides)
+            ),
+            patch.object(base_schedule, "get_server_weekday", return_value=0),
+            patch.object(base_schedule, "cultivateDepotSolver"),
+        ):
+            solver.append_maa_task("Fight")
+        return solver.MAA.append_task.call_args
+
+    def test_fight_sends_empty_penguin_id_by_default(self):
+        # 默认空串：行为与旧硬编码 "" 一致，企鹅上报不受影响
+        task_config = self._append_fight().args[1]
+        self.assertIs(task_config["report_to_penguin"], True)
+        self.assertEqual(task_config["penguin_id"], "")
+
+    def test_fight_sends_configured_penguin_id(self):
+        # 填写企鹅 id：如实下发
+        task_config = self._append_fight(maa_penguin_id="penguin-abc").args[1]
+        self.assertEqual(task_config["penguin_id"], "penguin-abc")
+
+    def test_fight_penguin_id_is_string_type(self):
+        # penguin_id 按协议为 string：默认下发空字符串而非 null
+        task_config = self._append_fight().args[1]
+        self.assertIsInstance(task_config["penguin_id"], str)
 
 
 class MaaMallFormationIndexTests(unittest.TestCase):
@@ -439,6 +477,13 @@ def _rg_conf(
     only_start_with_elite_two=False,
     collectible_mode_start_list=None,
     expected_collapsal_paradigms=("目空一些", "睁眼瞎"),
+    monthly_squad_auto_iterate=False,
+    monthly_squad_check_comms=False,
+    deep_exploration_auto_iterate=False,
+    first_floor_foldartal="",
+    start_foldartal_list=None,
+    blackflow_cultivation_target="swaddled_cat",
+    find_playtime_target=1,
 ):
     """Roguelike 长任务走 maa_plan_solver 的 conf，构造 .RG 分支所需的最小实例。"""
     return SimpleNamespace(
@@ -471,6 +516,13 @@ def _rg_conf(
             collectible_mode_shopping=collectible_mode_shopping,
             collectible_mode_squad=collectible_mode_squad,
             collectible_mode_start_list=collectible_mode_start_list or {},
+            monthly_squad_auto_iterate=monthly_squad_auto_iterate,
+            monthly_squad_check_comms=monthly_squad_check_comms,
+            deep_exploration_auto_iterate=deep_exploration_auto_iterate,
+            first_floor_foldartal=first_floor_foldartal,
+            start_foldartal_list=start_foldartal_list or [],
+            blackflow_cultivation_target=blackflow_cultivation_target,
+            find_playtime_target=find_playtime_target,
         ),
     )
 
@@ -591,6 +643,113 @@ class MaaRoguelikeTests(unittest.TestCase):
         jiegarden = self._run_rogue(theme="JieGarden", mode=20001).args[1]
         self.assertEqual(jiegarden["theme"], "JieGarden")
         self.assertEqual(jiegarden["mode"], 20001)
+
+    def test_rogue_sends_monthly_squad_fields_for_mode6(self):
+        # 模式 6（月度小队）：协议两键在模式匹配时下发，通信检查先勾自动切换后才下发
+        task_config = self._run_rogue(
+            theme="Sami",
+            mode=6,
+            squad="生活至上分队",
+            monthly_squad_auto_iterate=True,
+            monthly_squad_check_comms=True,
+        ).args[1]
+        self.assertIs(task_config["monthly_squad_auto_iterate"], True)
+        self.assertIs(task_config["monthly_squad_check_comms"], True)
+
+    def test_rogue_omits_check_comms_without_auto_iterate(self):
+        # 自动切换未勾选：通信检查不下发（与 MAA XAML 的可视条件一致）
+        task_config = self._run_rogue(
+            theme="Mizuki", mode=6, monthly_squad_check_comms=True
+        ).args[1]
+        self.assertIs(task_config["monthly_squad_auto_iterate"], False)
+        self.assertNotIn("monthly_squad_check_comms", task_config)
+
+    def test_rogue_sends_deep_exploration_for_mode7(self):
+        # 模式 7（深入调查）：deep_exploration_auto_iterate 在模式匹配时下发
+        task_config = self._run_rogue(
+            theme="Sarkaz", mode=7, deep_exploration_auto_iterate=True
+        ).args[1]
+        self.assertIs(task_config["deep_exploration_auto_iterate"], True)
+
+    def test_rogue_omits_mode_gated_fields_outside_modes(self):
+        # 模式 0：月度小队/深入调查字段均不下发
+        task_config = self._run_rogue(theme="Sami", mode=0).args[1]
+        self.assertNotIn("monthly_squad_auto_iterate", task_config)
+        self.assertNotIn("deep_exploration_auto_iterate", task_config)
+
+    def test_rogue_sends_first_floor_foldartal_for_sami_collectible(self):
+        # Sami + 模式 4：板子名非空时下发 first_floor_foldartal（协议值为字符串）
+        task_config = self._run_rogue(
+            theme="Sami", mode=4, squad="指挥分队", first_floor_foldartal="远见"
+        ).args[1]
+        self.assertEqual(task_config["first_floor_foldartal"], "远见")
+
+    def test_rogue_omits_first_floor_foldartal_outside_conditions(self):
+        # 非 Sami 或非模式 4：不下发；板子名为空同样不下发
+        task_config = self._run_rogue(
+            theme="Mizuki", mode=4, squad="指挥分队", first_floor_foldartal="远见"
+        ).args[1]
+        self.assertNotIn("first_floor_foldartal", task_config)
+        task_config = self._run_rogue(
+            theme="Sami", mode=0, squad="指挥分队", first_floor_foldartal="远见"
+        ).args[1]
+        self.assertNotIn("first_floor_foldartal", task_config)
+        task_config = self._run_rogue(theme="Sami", mode=4, squad="指挥分队").args[1]
+        self.assertNotIn("first_floor_foldartal", task_config)
+
+    def test_rogue_sends_start_foldartal_list_for_foldartal_squad(self):
+        # Sami + 模式 4 + 生活至上分队 + 列表非空：下发 start_foldartal_list
+        task_config = self._run_rogue(
+            theme="Sami",
+            mode=4,
+            squad="生活至上分队",
+            start_foldartal_list=["板子一", "板子二"],
+        ).args[1]
+        self.assertEqual(task_config["start_foldartal_list"], ["板子一", "板子二"])
+
+    def test_rogue_omits_start_foldartal_list_outside_foldartal_squad(self):
+        # 非生活至上分队或列表为空：不下发 start_foldartal_list
+        task_config = self._run_rogue(
+            theme="Sami",
+            mode=4,
+            squad="指挥分队",
+            start_foldartal_list=["板子一"],
+        ).args[1]
+        self.assertNotIn("start_foldartal_list", task_config)
+        task_config = self._run_rogue(theme="Sami", mode=4, squad="生活至上分队").args[
+            1
+        ]
+        self.assertNotIn("start_foldartal_list", task_config)
+
+    def test_rogue_sends_blackflow_fields_for_baby_animal(self):
+        # BlackFlow + 模式 30001：策略固定 baby_animal，目标品种取自配置
+        task_config = self._run_rogue(
+            theme="BlackFlow",
+            mode=30001,
+            blackflow_cultivation_target="swaddled_dog",
+        ).args[1]
+        self.assertEqual(task_config["blackflow_strategy"], "baby_animal")
+        self.assertEqual(task_config["blackflow_cultivation_target"], "swaddled_dog")
+
+    def test_rogue_omits_blackflow_fields_outside_baby_animal(self):
+        # 非 30001 模式：黑流树海字段不下发
+        task_config = self._run_rogue(theme="BlackFlow", mode=0).args[1]
+        self.assertNotIn("blackflow_strategy", task_config)
+        self.assertNotIn("blackflow_cultivation_target", task_config)
+
+    def test_rogue_sends_playtime_target_for_jiegarden(self):
+        # 界园 + 模式 20001：下发 find_playTime_target（协议键为大写 T）
+        task_config = self._run_rogue(
+            theme="JieGarden", mode=20001, find_playtime_target=2
+        ).args[1]
+        self.assertEqual(task_config["find_playTime_target"], 2)
+
+    def test_rogue_omits_playtime_target_outside_conditions(self):
+        # 界园非 20001 或其他主题：不下发 find_playTime_target
+        task_config = self._run_rogue(theme="JieGarden", mode=0).args[1]
+        self.assertNotIn("find_playTime_target", task_config)
+        task_config = self._run_rogue(theme="Sarkaz", mode=20001).args[1]
+        self.assertNotIn("find_playTime_target", task_config)
 
     def test_rogue_forwards_elite_two_fields_for_mizuki_sami_mode4(self):
         # 协议注明 start_with_elite_two 仅适用于模式 4，MAA 另限主题 Mizuki/Sami 且直升值

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -179,6 +179,20 @@ class LongTaskPart(ConfModel):
         "烧水时是否启用购物"
         collectible_mode_squad: str = ""
         "烧水使用的分队（默认与 squad 同步）"
+        monthly_squad_auto_iterate: bool = False
+        "月度小队自动切换（仅策略 6 生效）"
+        monthly_squad_check_comms: bool = False
+        "将月度小队通信也作为切换依据（需勾选月度小队自动切换）"
+        deep_exploration_auto_iterate: bool = False
+        "深入调查自动切换（仅策略 7 生效）"
+        first_floor_foldartal: str = ""
+        "凹第一层远见板子（板子名，非空才生效，仅萨米刷开局）"
+        start_foldartal_list: list[str] = Field(default_factory=list)
+        "凹开局板子列表（最多 3 个，仅萨米刷开局且生活至上分队）"
+        blackflow_cultivation_target: str = "swaddled_cat"
+        "刷襁褓动物目标品种（swaddled_cat/swaddled_feathered_serpent/swaddled_dog/swaddled_cerberus）"
+        find_playtime_target: int = 1
+        "目标常乐节点子类型（1=令/2=黍/3=年，仅界园刷常乐节点）"
 
     class SSSConf(ConfModel):
         type: int = 1
@@ -331,6 +345,8 @@ class RegularTaskPart(ConfModel):
     "向一图流上报作战结果"
     maa_yituliu_id: str = ""
     "一图流上报 id（仅在开启上报时有效）"
+    maa_penguin_id: str = ""
+    "企鹅物流上报 id（可选，留空为匿名上报）"
     maa_weekly_plan: list[MaaDailyPlan] = [
         {"medicine": 0, "sanity_threshold": 0, "stage": [""], "weekday": "周一"},
         {"medicine": 0, "sanity_threshold": 0, "stage": [""], "weekday": "周二"},

--- a/ui/src/components/MaaRogue.vue
+++ b/ui/src/components/MaaRogue.vue
@@ -22,9 +22,11 @@ import {
   elite_two_visible,
   is_field_enabled,
   modes_for_theme,
+  monthly_squad_check_comms_visible,
   only_elite_two_needs_reset,
   only_elite_two_visible,
-  rogue_themes
+  rogue_themes,
+  start_foldartal_visible
 } from '@/utils/roguelike_options'
 
 // 分队名与顺序对照 RoguelikeSettingsUserControlModel（主题分队 + 通用分队 + 高规格）；
@@ -340,6 +342,33 @@ const start_reward_values = computed({
     rogue.value.collectible_mode_start_list = Object.fromEntries(v.map((k) => [k, true]))
   }
 })
+
+// 凹开局板子输入（协议 start_foldartal_list，最多 3 个，与 MAA 模型一致）；逗号分隔。
+const start_foldartal_values = computed({
+  get: () => (rogue.value.start_foldartal_list ?? []).join(','),
+  set: (v) => {
+    rogue.value.start_foldartal_list = v
+      .split(/[,，]/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .slice(0, 3)
+  }
+})
+
+// 黑流树海刷襁褓动物目标品种（对照协议枚举与 MAA 显示名）。
+const blackflow_target_options = [
+  { label: '襁褓中的猫', value: 'swaddled_cat' },
+  { label: '襁褓羽蛇', value: 'swaddled_feathered_serpent' },
+  { label: '襁褓中的狗', value: 'swaddled_dog' },
+  { label: '襁褓三头犬', value: 'swaddled_cerberus' }
+]
+
+// 界园刷常乐节点目标子类型（对照 MAA 显示名）。
+const find_playtime_options = [
+  { label: '令 - 掷地有声', value: 1 },
+  { label: '黍 - 种因得果', value: 2 },
+  { label: '年 - 三缺一', value: 3 }
+]
 </script>
 
 <template>
@@ -393,6 +422,34 @@ const start_reward_values = computed({
     </n-form-item>
     <n-form-item label="策略">
       <n-select :options="mode_options" v-model:value="rogue.mode" />
+    </n-form-item>
+    <n-form-item
+      v-if="is_field_enabled('monthly_squad_auto_iterate', maa_rg_theme, rogue.mode)"
+      :show-label="false"
+    >
+      <n-checkbox v-model:checked="rogue.monthly_squad_auto_iterate">月度小队自动切换</n-checkbox>
+    </n-form-item>
+    <n-form-item
+      v-if="
+        monthly_squad_check_comms_visible(
+          maa_rg_theme,
+          rogue.mode,
+          rogue.monthly_squad_auto_iterate
+        )
+      "
+      :show-label="false"
+    >
+      <n-checkbox v-model:checked="rogue.monthly_squad_check_comms"
+        >将月度小队通信也作为切换依据</n-checkbox
+      >
+    </n-form-item>
+    <n-form-item
+      v-if="is_field_enabled('deep_exploration_auto_iterate', maa_rg_theme, rogue.mode)"
+      :show-label="false"
+    >
+      <n-checkbox v-model:checked="rogue.deep_exploration_auto_iterate"
+        >深入调查自动切换</n-checkbox
+      >
     </n-form-item>
     <n-form-item
       v-if="is_field_enabled('refresh_trader_with_dice', maa_rg_theme, rogue.mode)"
@@ -453,6 +510,26 @@ const start_reward_values = computed({
       <n-select v-model:value="rogue.collectible_mode_squad" :options="collectible_squad_options" />
     </n-form-item>
     <n-form-item
+      v-if="is_field_enabled('first_floor_foldartal', maa_rg_theme, rogue.mode)"
+      label="第一层远见板子"
+    >
+      <n-input
+        v-model:value="rogue.first_floor_foldartal"
+        placeholder="板子名，留空不凹"
+        style="width: 200px"
+      />
+    </n-form-item>
+    <n-form-item
+      v-if="start_foldartal_visible(maa_rg_theme, rogue.mode, rogue.squad)"
+      label="凹开局板子"
+    >
+      <n-input
+        v-model:value="start_foldartal_values"
+        placeholder="多个用逗号分隔，最多 3 个"
+        style="width: 260px"
+      />
+    </n-form-item>
+    <n-form-item
       v-if="
         collectible_start_visible(
           maa_rg_theme,
@@ -465,6 +542,21 @@ const start_reward_values = computed({
       label="刷开局期望奖励"
     >
       <n-select multiple :options="start_reward_options" v-model:value="start_reward_values" />
+    </n-form-item>
+    <n-form-item
+      v-if="is_field_enabled('blackflow_cultivation_target', maa_rg_theme, rogue.mode)"
+      label="目标襁褓动物"
+    >
+      <n-select
+        v-model:value="rogue.blackflow_cultivation_target"
+        :options="blackflow_target_options"
+      />
+    </n-form-item>
+    <n-form-item
+      v-if="is_field_enabled('find_playtime_target', maa_rg_theme, rogue.mode)"
+      label="目标常乐节点"
+    >
+      <n-select v-model:value="rogue.find_playtime_target" :options="find_playtime_options" />
     </n-form-item>
   </n-form>
 </template>

--- a/ui/src/components/MaaWeekly.vue
+++ b/ui/src/components/MaaWeekly.vue
@@ -23,6 +23,7 @@ const {
   expiring_medicine_on_weekend,
   maa_report_to_yituliu,
   maa_yituliu_id,
+  maa_penguin_id,
   ap_fallback
 } = storeToRefs(store)
 
@@ -293,6 +294,14 @@ function cancelCopyDialogLongPress() {
             </n-checkbox>
           </n-flex>
           <n-flex align="center">
+            <span>企鹅物流 id</span>
+            <n-input
+              v-model:value="maa_penguin_id"
+              placeholder="企鹅物流 id（可选）"
+              style="width: 200px"
+            />
+          </n-flex>
+          <n-flex align="center">
             <n-checkbox v-model:checked="maa_report_to_yituliu">上报至一图流</n-checkbox>
             <n-input
               v-model:value="maa_yituliu_id"
@@ -312,6 +321,7 @@ function cancelCopyDialogLongPress() {
                 </n-a>
                 。
               </div>
+              <div>两个上报站点均凭 id 关联个人账号；企鹅物流 id 选填，留空仍会匿名上报。</div>
             </help-text>
           </n-flex>
           <n-flex>

--- a/ui/src/stores/config.js
+++ b/ui/src/stores/config.js
@@ -22,6 +22,7 @@ export const useConfigStore = defineStore('config', () => {
   const medicine_expire_days = ref(0)
   const maa_report_to_yituliu = ref(false)
   const maa_yituliu_id = ref('')
+  const maa_penguin_id = ref('')
   const ap_fallback = ref(0)
   const maa_weekly_plan = ref([])
   const maa_weekly_plan_options = ref([])
@@ -373,6 +374,7 @@ export const useConfigStore = defineStore('config', () => {
     medicine_expire_days.value = response.data.medicine_expire_days
     maa_report_to_yituliu.value = response.data.maa_report_to_yituliu ?? false
     maa_yituliu_id.value = response.data.maa_yituliu_id ?? ''
+    maa_penguin_id.value = response.data.maa_penguin_id ?? ''
     ap_fallback.value = Number(response.data.ap_fallback) || 0
     maa_weekly_plan.value = normalizeWeeklyPlan(response.data.maa_weekly_plan)
     maa_weekly_plan_active.value = response.data.maa_weekly_plan_active || ''
@@ -494,6 +496,7 @@ export const useConfigStore = defineStore('config', () => {
       medicine_expire_days: medicine_expire_days.value,
       maa_report_to_yituliu: maa_report_to_yituliu.value,
       maa_yituliu_id: maa_yituliu_id.value,
+      maa_penguin_id: maa_penguin_id.value,
       ap_fallback: ap_fallback.value,
       maa_stage_inventory_enable: maa_stage_inventory_enable.value,
       maa_stage_limit_rules: normalizeStageLimitRules(maa_stage_limit_rules.value),
@@ -657,6 +660,7 @@ export const useConfigStore = defineStore('config', () => {
     medicine_expire_days,
     maa_report_to_yituliu,
     maa_yituliu_id,
+    maa_penguin_id,
     ap_fallback,
     maa_weekly_plan,
     maa_weekly_plan_options,

--- a/ui/src/utils/roguelike_options.js
+++ b/ui/src/utils/roguelike_options.js
@@ -66,7 +66,20 @@ export const field_conditions = {
   // 协议注明 refresh_trader_with_dice（指路鳞）仅支持主题 Mizuki
   refresh_trader_with_dice: (theme) => theme === 'Mizuki',
   // 协议注明 investment_with_more_score 仅在策略为 1（刷源石锭）且非黑流树海主题时生效
-  investment_with_more_score: (theme, mode) => mode === 1 && theme !== 'BlackFlow'
+  investment_with_more_score: (theme, mode) => mode === 1 && theme !== 'BlackFlow',
+  // 协议注明 monthly_squad_auto_iterate 与 monthly_squad_check_comms 仅模式 6（月度小队）下发
+  monthly_squad_auto_iterate: (theme, mode) => mode === 6,
+  monthly_squad_check_comms: (theme, mode) => mode === 6,
+  // 协议注明 deep_exploration_auto_iterate 仅模式 7（深入调查）下发
+  deep_exploration_auto_iterate: (theme, mode) => mode === 7,
+  // 协议注明 first_floor_foldartal 仅萨米刷开局模式有效（模型另限模式 4）
+  first_floor_foldartal: (theme, mode) => theme === 'Sami' && mode === 4,
+  // 协议注明 start_foldartal_list 仅萨米刷开局模式有效（模型另限生活至上分队）
+  start_foldartal_list: (theme, mode) => theme === 'Sami' && mode === 4,
+  // 协议注明 blackflow_cultivation_target 仅黑流树海刷襁褓动物模式使用
+  blackflow_cultivation_target: (theme, mode) => theme === 'BlackFlow' && mode === 30001,
+  // 协议注明 find_playTime_target 仅界园刷常乐节点模式下发
+  find_playtime_target: (theme, mode) => theme === 'JieGarden' && mode === 20001
 }
 
 // 当前主题/策略下某协议字段是否应展示（且应下发）。
@@ -104,6 +117,16 @@ export function collectible_start_visible(theme, mode, squad, only, start) {
 // only_start_with_elite_two=true 的组合，被 MAA 核心判定非法。
 export function only_elite_two_needs_reset(theme, mode, squad, start, only) {
   return only && (!start || !elite_two_visible(theme, mode, squad))
+}
+
+// 通信作为切换依据需先勾选月度小队自动切换（对照 XAML 的可视条件）。
+export function monthly_squad_check_comms_visible(theme, mode, auto) {
+  return is_field_enabled('monthly_squad_check_comms', theme, mode) && auto
+}
+
+// 凹开局板子仅生活至上分队可获得（对照 RoguelikeSquadIsFoldartal）。
+export function start_foldartal_visible(theme, mode, squad) {
+  return is_field_enabled('start_foldartal_list', theme, mode) && squad === '生活至上分队'
 }
 
 // 各主题肉鸽难度范围（对照：萨卡兹/水月/界园 0-18，其余 0-15）。

--- a/ui/src/utils/roguelike_options.test.js
+++ b/ui/src/utils/roguelike_options.test.js
@@ -8,10 +8,12 @@ import {
   is_field_enabled,
   mode_list,
   modes_for_theme,
+  monthly_squad_check_comms_visible,
   only_elite_two_needs_reset,
   only_elite_two_visible,
   professional_squads,
-  rogue_themes
+  rogue_themes,
+  start_foldartal_visible
 } from './roguelike_options'
 
 describe('roguelike_options', () => {
@@ -64,13 +66,20 @@ describe('roguelike_options', () => {
   it('字段条件覆盖协议注明的主题/模式限定字段', () => {
     expect(Object.keys(field_conditions).sort()).toEqual(
       [
+        'blackflow_cultivation_target',
         'collectible_mode_shopping',
         'collectible_mode_squad',
         'collectible_mode_start_list',
+        'deep_exploration_auto_iterate',
         'expected_collapsal_paradigms',
+        'find_playtime_target',
+        'first_floor_foldartal',
         'investment_with_more_score',
+        'monthly_squad_auto_iterate',
+        'monthly_squad_check_comms',
         'only_start_with_elite_two',
         'refresh_trader_with_dice',
+        'start_foldartal_list',
         'start_with_elite_two',
         'stop_at_final_boss',
         'stop_at_max_level',
@@ -149,6 +158,50 @@ describe('roguelike_options', () => {
     expect(is_field_enabled('investment_with_more_score', 'BlackFlow', 1)).toBe(false)
     expect(is_field_enabled('investment_with_more_score', 'Mizuki', 0)).toBe(false)
     expect(is_field_enabled('investment_with_more_score', 'Phantom', 4)).toBe(false)
+  })
+
+  it('月度小队字段仅策略 6 展示，通信检查需先勾自动切换', () => {
+    expect(is_field_enabled('monthly_squad_auto_iterate', 'Sami', 6)).toBe(true)
+    expect(is_field_enabled('monthly_squad_auto_iterate', 'Mizuki', 6)).toBe(true)
+    expect(is_field_enabled('monthly_squad_auto_iterate', 'Sami', 0)).toBe(false)
+    expect(is_field_enabled('monthly_squad_check_comms', 'Mizuki', 6)).toBe(true)
+    expect(is_field_enabled('monthly_squad_check_comms', 'Sami', 7)).toBe(false)
+    expect(monthly_squad_check_comms_visible('Mizuki', 6, true)).toBe(true)
+    expect(monthly_squad_check_comms_visible('Mizuki', 6, false)).toBe(false)
+    expect(monthly_squad_check_comms_visible('Sami', 0, true)).toBe(false)
+  })
+
+  it('deep_exploration_auto_iterate 仅策略 7 展示', () => {
+    expect(is_field_enabled('deep_exploration_auto_iterate', 'Sami', 7)).toBe(true)
+    expect(is_field_enabled('deep_exploration_auto_iterate', 'Mizuki', 7)).toBe(true)
+    expect(is_field_enabled('deep_exploration_auto_iterate', 'Sami', 6)).toBe(false)
+    expect(is_field_enabled('deep_exploration_auto_iterate', 'Sami', 0)).toBe(false)
+  })
+
+  it('first_floor_foldartal 仅萨米 + 策略 4 展示', () => {
+    expect(is_field_enabled('first_floor_foldartal', 'Sami', 4)).toBe(true)
+    expect(is_field_enabled('first_floor_foldartal', 'Sami', 0)).toBe(false)
+    expect(is_field_enabled('first_floor_foldartal', 'Mizuki', 4)).toBe(false)
+  })
+
+  it('start_foldartal_list 仅萨米 + 策略 4 + 生活至上分队展示', () => {
+    expect(is_field_enabled('start_foldartal_list', 'Sami', 4)).toBe(true)
+    expect(is_field_enabled('start_foldartal_list', 'Sarkaz', 4)).toBe(false)
+    expect(start_foldartal_visible('Sami', 4, '生活至上分队')).toBe(true)
+    expect(start_foldartal_visible('Sami', 4, '指挥分队')).toBe(false)
+    expect(start_foldartal_visible('Mizuki', 4, '生活至上分队')).toBe(false)
+  })
+
+  it('blackflow_cultivation_target 仅黑流树海刷襁褓动物展示', () => {
+    expect(is_field_enabled('blackflow_cultivation_target', 'BlackFlow', 30001)).toBe(true)
+    expect(is_field_enabled('blackflow_cultivation_target', 'BlackFlow', 0)).toBe(false)
+    expect(is_field_enabled('blackflow_cultivation_target', 'JieGarden', 20001)).toBe(false)
+  })
+
+  it('find_playtime_target 仅界园刷常乐节点展示', () => {
+    expect(is_field_enabled('find_playtime_target', 'JieGarden', 20001)).toBe(true)
+    expect(is_field_enabled('find_playtime_target', 'JieGarden', 0)).toBe(false)
+    expect(is_field_enabled('find_playtime_target', 'BlackFlow', 30001)).toBe(false)
   })
 
   it('professional_squads 为四支战术分队', () => {


### PR DESCRIPTION
## 变更

此前肉鸽界面可选月度小队、深入调查、刷常乐节点、黑流树海刷襁褓动物
等玩法，也能看到萨米板子相关设置，但这些玩法对应的 MAA 协议参数
从未下发，MAA 收不到就按默认值执行，选了也未必生效。本次按 MAA
当前协议的序列化顺序与界面可见条件补齐：

- 月度小队（策略 6）：monthly_squad_auto_iterate；
  monthly_squad_check_comms 需先勾选自动切换才下发
- 深入调查（策略 7）：deep_exploration_auto_iterate
- 萨米刷开局：first_floor_foldartal（板子名，非空才下发）、
  start_foldartal_list（另限生活至上分队）
- 黑流树海刷襁褓动物：策略由协议固定为 baby_animal，目标品种
  可选（swaddled_cat / swaddled_feathered_serpent / swaddled_dog /
  swaddled_cerberus）
- 界园刷常乐节点：find_playTime_target（1=令 / 2=黍 / 3=年），
  此前该策略可选却从不下发目标，MAA 核心按未知子类型处理，等于白选

界面按当前主题与策略只显示能生效的字段，可见条件集中在
ui/src/utils/roguelike_options.js 与后端共用，前端谓词与后端下发
条件均补正反例。

另外 Fight 的企鹅物流上报 id（penguin_id）由硬编码空串改为配置
下发（maa_penguin_id，默认空串行为与现状一致），MaaWeekly 增加
企鹅物流 id 输入框并补全上报说明；report_to_penguin 仍恒发 True，
默认匿名上报不受影响。

## 限制

- start_with_seed 本次未接：现版 MAA 界面仅在「界园」主题显示该
  字段，协议序列化则只要非空就下发，与 NiceAfternoon/arknights-mower#267
  票面写的「萨卡兹 + 投资策略 + 点刺成锭/后勤分队」不一致；三方说法
  尚未统一，等 MAA 侧明确后再做。
- use_foldartal、check_collapsal_paradigms、
  double_check_collapsal_paradigms 本次未接：MAA 参考客户端已不再下发
  这三个键，核心仍解析但默认值（检查模式 5 开启、其他模式关闭）即
  MAA 当前实际行为，接入只会增加参考客户端都不再暴露的配置面。

## 验证

- 后端 pytest：目标文件 66 通过；全量 1409 通过、18 跳过，
  4 个失败为环境预存（depot 资源 mimetype 探测、macOS ADB 清单），
  与本次改动无关
- 前端 vitest：129 通过（含新增谓词测试）
- eslint、prettier、ruff 检查均通过
- 无行为回归：所有新配置默认值与改动前硬编码行为等价
  （空串 / False / 默认品种 / 默认目标 1=令）
