### PR TITLE
fix(window-shell): 修复无边框窗口丢失的最小化、最大化与还原动画

### DIFF
--- a/arknights_mower/tests/window_frameless_tests.py
+++ b/arknights_mower/tests/window_frameless_tests.py
@@ -1,0 +1,41 @@
+"""无边框窗口样式组合的回归用例。
+
+windows_frameless 在导入时就要 ctypes.wintypes，Linux 上不存在这个模块，所以按需在
+用例内部导入，整个文件在非 Windows 平台照常收集、不报错。
+"""
+
+import os
+import unittest
+
+
+@unittest.skipUnless(os.name == "nt", "WinForms 窗口样式只在 Windows 上组合")
+class TestFramelessWindowStyle(unittest.TestCase):
+    def test_keeps_the_caption_styles_the_shell_animates_on(self):
+        # 壳层只对同时带 WS_CAPTION 与最小化/最大化框样式的窗口播放最小化、最大化/
+        # 还原与吸附过渡；少了 WS_CAPTION 窗口就是硬切。这里把组合固定下来，避免以后
+        # 又把标题栏样式摘掉。真正的无边框由 WM_NCCALCSIZE 返回 0（客户区覆盖整个窗口）
+        # 保证，不靠摘样式。
+        from arknights_mower.utils import windows_frameless
+
+        style = windows_frameless.frameless_window_style(0)
+        for bit in (
+            windows_frameless._WS_CAPTION,
+            windows_frameless._WS_THICKFRAME,
+            windows_frameless._WS_MINIMIZEBOX,
+            windows_frameless._WS_MAXIMIZEBOX,
+            windows_frameless._WS_SYSMENU,
+        ):
+            self.assertTrue(style & bit)
+
+    def test_keeps_style_bits_the_window_already_had(self):
+        # 组合是「补上」不是「重写」：WinForms 自己加的 WS_CLIPSIBLINGS 等位不能被抹掉。
+        from arknights_mower.utils import windows_frameless
+
+        existing = 0x04000000  # WS_CLIPSIBLINGS
+        self.assertEqual(
+            windows_frameless.frameless_window_style(existing) & existing, existing
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/arknights_mower/utils/windows_frameless.py
+++ b/arknights_mower/utils/windows_frameless.py
@@ -1,10 +1,11 @@
-"""Small WinForms adaptation that restores OS-owned frameless resizing.
+"""Small WinForms adaptation that restores OS-owned frameless window behaviour.
 
 pywebview 5.1 sets ``FormBorderStyle.None`` for frameless windows, which removes
-the native resize frame. This module keeps the window border visually absent,
-but restores the standard sizing styles and returns native non-client hit-test
-codes at the window edges. Windows still owns the resize loop, DPI handling,
-cursor feedback, snapping, and multi-monitor interaction.
+the native resize frame and the caption styles. This module keeps the window
+border and caption visually absent, but restores the standard sizing and caption
+styles, and returns native non-client hit-test codes at the window edges.
+Windows still owns the resize loop, the minimize/maximize/snap transitions, DPI
+handling, cursor feedback, and multi-monitor interaction.
 """
 
 import ctypes
@@ -75,9 +76,16 @@ _RESIZE_EDGE_HIT_TEST = {
 
 
 def frameless_window_style(style: int) -> int:
-    """Keep native window operations without restoring the painted caption shell."""
-    return (style & ~_WS_CAPTION) | (
-        _WS_THICKFRAME | _WS_MINIMIZEBOX | _WS_MAXIMIZEBOX | _WS_SYSMENU
+    """Restore the caption styles the shell needs to animate window motion.
+
+    DWM plays the minimize, maximize/restore and snap transitions only for a
+    window that still carries ``WS_CAPTION`` next to the minimize/maximize box
+    styles; with the caption bit cleared the window just jumps. The painted
+    caption itself never appears, because ``WM_NCCALCSIZE`` returns 0 and leaves
+    the client area covering the whole window.
+    """
+    return style | (
+        _WS_CAPTION | _WS_THICKFRAME | _WS_MINIMIZEBOX | _WS_MAXIMIZEBOX | _WS_SYSMENU
     )
 
 
@@ -138,6 +146,13 @@ class _MINMAXINFO(ctypes.Structure):
         ("ptMaxPosition", _POINT),
         ("ptMinTrackSize", _POINT),
         ("ptMaxTrackSize", _POINT),
+    ]
+
+
+class _NCCALCSIZE_PARAMS(ctypes.Structure):
+    _fields_ = [
+        ("rgrc", _RECT * 3),
+        ("lppos", ctypes.c_void_p),
     ]
 
 
@@ -317,6 +332,13 @@ def _install_hook(
             return int(metric_for_dpi(metric, get_dpi_for_window(hwnd)))
         return int(user32.GetSystemMetrics(metric))
 
+    def frame_thickness() -> tuple[int, int]:
+        """Width and height of the resize frame the shell draws, per DPI."""
+        return (
+            system_metric(sm_cxsizeframe) + system_metric(sm_cxpaddedborder),
+            system_metric(sm_cysizeframe) + system_metric(sm_cxpaddedborder),
+        )
+
     def hit_test(l_param: int) -> int:
         rect = _RECT()
         if not user32.GetWindowRect(hwnd, ctypes.byref(rect)):
@@ -324,14 +346,13 @@ def _install_hook(
 
         x = ctypes.c_short(l_param & 0xFFFF).value
         y = ctypes.c_short((l_param >> 16) & 0xFFFF).value
-        border_x = system_metric(sm_cxsizeframe) + system_metric(sm_cxpaddedborder)
-        border_y = system_metric(sm_cysizeframe) + system_metric(sm_cxpaddedborder)
+        frame_x, frame_y = frame_thickness()
 
         maximized = bool(user32.IsZoomed(hwnd))
-        left = not maximized and rect.left <= x < rect.left + border_x
-        right = not maximized and rect.right - border_x <= x < rect.right
-        top = not maximized and rect.top <= y < rect.top + border_y
-        bottom = not maximized and rect.bottom - border_y <= y < rect.bottom
+        left = not maximized and rect.left <= x < rect.left + frame_x
+        right = not maximized and rect.right - frame_x <= x < rect.right
+        top = not maximized and rect.top <= y < rect.top + frame_y
+        bottom = not maximized and rect.bottom - frame_y <= y < rect.bottom
 
         if top and left:
             return _RESIZE_EDGE_HIT_TEST["top-left"]
@@ -358,6 +379,25 @@ def _install_hook(
         if in_titlebar and after_sidebar_control and before_controls:
             return htcaption
         return htclient
+
+    def inset_maximized_client(l_param: int) -> None:
+        """Keep the maximized client area on the work area.
+
+        The shell grows a maximized caption window by one resize frame on every
+        side, so that the frame itself hangs over the screen edges and the
+        taskbar and the client area lands on the work area. Here the client
+        normally covers the whole window, so that growth would push the WebView
+        over the taskbar instead; pull the client back in by the same frame.
+        """
+        if not user32.IsZoomed(hwnd):
+            return
+        params = ctypes.cast(l_param, ctypes.POINTER(_NCCALCSIZE_PARAMS)).contents
+        frame_x, frame_y = frame_thickness()
+        rect = params.rgrc[0]
+        rect.left += frame_x
+        rect.top += frame_y
+        rect.right -= frame_x
+        rect.bottom -= frame_y
 
     def constrain_maximized_bounds(l_param: int) -> None:
         minmax = ctypes.cast(l_param, ctypes.POINTER(_MINMAXINFO)).contents
@@ -406,9 +446,12 @@ def _install_hook(
                     )
                 restore_pending = False
                 return 0
-            # Keep the WebView client flush with the real outer window. DWM
-            # still owns clipping, shadow and the single outer corner.
+            # Keep the WebView client flush with the real outer window, except
+            # when maximized, where the shell's frame growth has to be taken
+            # back out. DWM still owns clipping, shadow and the outer corner.
             if message == wm_nccalcsize:
+                if w_param:  # TRUE: lParam is NCCALCSIZE_PARAMS, not a plain RECT
+                    inset_maximized_client(l_param)
                 return 0
             if message == wm_nchittest:
                 result = hit_test(l_param)

--- a/ui/src/theme/mower.css
+++ b/ui/src/theme/mower.css
@@ -25,7 +25,6 @@ html[data-mower-theme='dark'] .provider {
 }
 
 .provider .n-card:not(.n-card--embedded),
-.provider .n-checkbox-box,
 .provider .mower-surface-panel {
   box-shadow: none;
 }
@@ -52,6 +51,19 @@ html[data-mower-theme='dark']
   box-shadow:
     0 1px 2px 0 rgba(0, 0, 0, 0.4),
     0 0 0 3px rgba(99, 226, 183, 0.2);
+}
+
+/* 复选框盒体加一档极轻的投影，形状与实色按钮的阴影一致（暖墨色比黑色浅，所以透明度
+   调高一档，看上去才和按钮同重）：本主题里复选框填充是近乎白色的控件色，只有一圈最轻
+   的描边，单靠描边在卡片上还是偏平，加一层极轻的投影让方块立得住。
+   选择器刻意不带 .provider 前缀——naive-ui 把弹窗和气泡 teleport 到 body，那些位置的
+   复选框不在 .provider 里，加前缀会漏掉它们。 */
+.n-checkbox-box {
+  box-shadow: 0 1px 2px 0 rgba(55, 49, 43, 0.07);
+}
+
+html[data-mower-theme='dark'] .n-checkbox-box {
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.25);
 }
 
 .provider .n-data-table,

--- a/ui/src/theme/mower.js
+++ b/ui/src/theme/mower.js
@@ -125,11 +125,14 @@ function createMowerTheme(palette) {
       caretColor: palette.primary
     },
     Checkbox: {
-      border: transparentBorder,
-      borderChecked: transparentBorder,
-      borderDisabled: transparentBorder,
-      borderDisabledChecked: transparentBorder,
-      borderFocus: transparentBorder,
+      // 复选框填充是近乎白色的控件色，和卡片几乎没有对比，只有一档最轻的可见描边
+      // （与普通按钮同一档）才立得住边界。五个状态给同一圈描边：naive-ui 的悬停规则
+      // 取的是 borderChecked，勾选态若留透明描边，鼠标移上去描边会突然消失。
+      border: defaultBorder,
+      borderChecked: defaultBorder,
+      borderDisabled: defaultBorder,
+      borderDisabledChecked: defaultBorder,
+      borderFocus: defaultBorder,
       boxShadowFocus: palette.focusShadow,
       borderRadius: '3px',
       color: palette.control,


### PR DESCRIPTION
## 变更

- 恢复无边框窗口的最小化、最大化与还原动画：`frameless_window_style()` 不再摘掉 `WS_CAPTION`。壳层只对同时带标题栏样式与最小化/最大化框样式的窗口播放这几段过渡，而隐藏标题栏由 `WM_NCCALCSIZE` 返回 0 保证（客户区覆盖整个窗口），并不依赖摘样式。
- 最大化时把客户区收回到工作区：带标题栏样式的窗口最大化的时候，壳层会把外框每边撑大一个缩放边框（`SM_CXSIZEFRAME + SM_CXPADDEDBORDER`），客户区因此会压到任务栏上，所以在 `WM_NCCALCSIZE` 里按同一个边框把客户区收回来。
- 复选框补一档最轻的可见描边（与普通按钮同一档，五个状态统一，悬停或者聚焦的时候描边不会忽隐忽现）和极轻的投影；阴影的选择器不带 `.provider` 前缀，弹窗和气泡里 teleport 出去的复选框同样生效。
- 新增 `window_frameless_tests.py`，把样式位组合固定下来。

## 限制

- 只在 Windows 11、150% DPI、单显示器上实测。Windows 10 上 `DWMWA_BORDER_COLOR` 与 `DWMWA_WINDOW_CORNER_PREFERENCE` 不受支持（模块里已有降级日志），理论上可能重新出现一条 DWM 边框线，未验证。
- 吸附（Win+方向键、拖拽到屏幕边缘）没有单独测量，只是同一套样式位带来的预期收益。
- 新测试在 CI 上会被跳过（`skipUnless(os.name == "nt")`，CI 跑 ubuntu-latest），这类样式位回归只能靠 Windows 机器拦住。
- `WM_APP+1` 的还原 hack 实测已经冗余（开关 A/B 的还原动画与落点完全一致），本次保留未动。

## 验证

- 真窗口逐帧抓屏（探针复刻 `webview_ui.py` 的窗口配置）：修复前最小化没有中间帧，修复以后最小化与最大化都能看到连续的渐变；作为对照的原生有框窗口同样有渐变，证明探针能区分，且本机「最小化/最大化时播放动画」是开着的。
- 几何：不最大化的时候没有画出标题栏（客户区覆盖率 0.9999）；最大化以后客户区正好等于工作区 2560×1368。
- 复选框：浅色与深色、未选中/选中/半选/禁用，以及 teleport 到 body 的复选框，都实测到了描边与阴影。
- `npm test` 129 通过；`npm run build` 通过；`ruff check` 与 `ruff format --check` 干净；Python 全量 1386 个用例里有 3 个失败，是 Windows 上 `.webp` mimetype 的环境差异（`mimetypes.guess_type` 返回 `(None, None)`，CI 跑 Linux），与本次改动无关。
