### PR TITLE
fix(device): 隐藏 Windows ADB 探测时的 MuMu 控制台窗口

### DIFF
--- a/arknights_mower/tests/simulator_tests.py
+++ b/arknights_mower/tests/simulator_tests.py
@@ -1,8 +1,10 @@
+import json
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from arknights_mower.utils import config, simulator
+from arknights_mower.utils.device.adb_client import core as adb_core
 
 
 class TestSimulatorReady(unittest.TestCase):
@@ -25,7 +27,7 @@ class TestSimulatorReady(unittest.TestCase):
         self.popen = self.enterContext(patch.object(simulator.subprocess, "Popen"))
         self.popen.return_value.poll.return_value = 0
         self.popen.return_value.returncode = 0
-        self.enterContext(patch.object(simulator, "csleep"))
+        self.sleep = self.enterContext(patch.object(simulator, "csleep"))
 
     def test_only_device_state_is_ready(self):
         for target in (self.old_target, ""):
@@ -62,6 +64,59 @@ class TestSimulatorReady(unittest.TestCase):
         )
         self.popen.assert_called_once()
         self.assertIn("launch_player", self.popen.call_args.args[0])
+
+    def test_cold_start_hides_every_windows_port_discovery_process(self):
+        # 使用真实端口查询：启动前和首轮探测未就绪，第二轮才发现新端口。
+        # 设置 120 秒仍可在就绪后提前继续，隐藏窗口不改变等待/重发现规则。
+        self.conf.simulator.wait_time = 120
+        self.discover.side_effect = adb_core.query_mumu_adb_port
+        self.session.return_value.devices_list.side_effect = [
+            [],
+            [(self.new_target, "device")],
+        ]
+        no_window = 0x08000000
+        with (
+            patch.object(adb_core, "__system__", "windows"),
+            patch.object(simulator, "__system__", "windows"),
+            patch.object(adb_core.os.path, "isfile", return_value=True),
+            patch.object(
+                adb_core.subprocess, "CREATE_NO_WINDOW", no_window, create=True
+            ),
+            patch.object(adb_core.subprocess, "run") as run,
+        ):
+            run.side_effect = [
+                SimpleNamespace(stdout="{}"),
+                SimpleNamespace(stdout="{}"),
+                SimpleNamespace(stdout=json.dumps({"0": {"adb_port": 16416}})),
+            ]
+            self.assertTrue(simulator.restart_simulator(stop=False, start=True))
+        self.assertEqual(run.call_count, 3)
+        for invocation in run.call_args_list:
+            self.assertEqual(
+                invocation.args[0], ["MuMuManager.exe", "info", "-v", "all"]
+            )
+            self.assertEqual(invocation.kwargs["creationflags"], no_window)
+            self.assertTrue(invocation.kwargs["capture_output"])
+        self.popen.assert_called_once()
+        self.assertEqual(self.popen.call_args.kwargs["creationflags"], no_window)
+        self.assertEqual(self.conf.adb, self.new_target)
+        self.sleep.assert_has_calls([call(3), call(1)])
+        self.assertEqual(self.sleep.call_count, 2)
+
+    def test_non_windows_port_discovery_does_not_use_windows_creation_flags(self):
+        for platform in ("linux", "darwin"):
+            with (
+                self.subTest(platform=platform),
+                patch.object(adb_core, "__system__", platform),
+                patch.object(adb_core.os.path, "isfile", return_value=True),
+                patch.object(adb_core.subprocess, "run") as run,
+            ):
+                run.return_value.stdout = json.dumps({"0": {"adb_port": 16416}})
+                self.assertEqual(
+                    adb_core.query_mumu_adb_port(self.conf.simulator), self.new_target
+                )
+                run.assert_called_once()
+                self.assertEqual(run.call_args.kwargs["creationflags"], 0)
 
     def test_discovery_failure_keeps_configured_target(self):
         self.session.return_value.devices_list.return_value = [

--- a/arknights_mower/utils/device/adb_client/core.py
+++ b/arknights_mower/utils/device/adb_client/core.py
@@ -35,6 +35,8 @@ def query_mumu_adb_port(simulator) -> Optional[str]:
     try:
         out = subprocess.run(
             [manager, "info", "-v", "all"],
+            # 端口发现会反复执行；仅重定向输出不会隐藏 Windows 控制台。
+            creationflags=subprocess.CREATE_NO_WINDOW if __system__ == "windows" else 0,
             capture_output=True,
             text=True,
             encoding="utf-8",


### PR DESCRIPTION
Windows 下使用 MuMu12 时，模拟器启动等待和 ADB 重连会反复执行 `MuMuManager.exe info -v all` 查询实例端口。该调用只捕获输出，没有隐藏控制台窗口，探测期间可能反复闪出黑框；其他 ADB 命令已使用隐藏窗口标志。

为这条端口查询调用补上 Windows 的 `CREATE_NO_WINDOW`，与现有 ADB 进程启动方式保持一致。采用隐藏窗口方案，继续保留配置的模拟器启动等待窗口、ADB 就绪后提前继续及 MuMu 端口重新发现；不改动此前确定的首次启动和三次重连策略，也不修改 IPC 专属逻辑。

验证：

- 新增回归测试，模拟 Windows 下启动前、首次未就绪、端口漂移后上线的连续探测，确认每次管理器进程都带隐藏窗口标志；配置 120 秒时仍能在 ADB 就绪后继续。
- 验证 Linux/macOS 不传入 Windows 专用创建标志。
- 设备、ADB、模拟器及调度相关 157 项测试通过；修改文件的 Ruff lint/格式、Python 编译、`git diff --check` 均通过。

进程与 ADB I/O 使用 mock；尚未进行 Windows 模拟器实机验证。
