### PR TITLE
fix(schedule): 纠错优先安排替班，无可用替班时保留叫回

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -1046,6 +1046,13 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             # （受保护时发节流提醒邮件）。fix_plan 拿 op_data 缓存比对静态计划，专精
             # 活跃/受保护时缓存与计划必然错位，不弹会每轮生成训练室纠错（反复进出）。
             self._suppress_train_correction(fix_plan)
+            # Prefer replacements after all correction passes; if none are available,
+            # retain the original correction's recall instead of blocking it.
+            from arknights_mower.utils.resting_correction import (
+                prefer_resting_replacements,
+            )
+
+            prefer_resting_replacements(self.op_data, fix_plan, _is_mastery_busy)
             if len(fix_plan.keys()) > 0:
                 # 如果5分钟之内有任务则跳过心情读取
                 next_task = self.find_next_task()

--- a/arknights_mower/tests/resting_correction_tests.py
+++ b/arknights_mower/tests/resting_correction_tests.py
@@ -1,0 +1,242 @@
+"""Correction prefers replacements and recalls operators when none are available."""
+
+import sys
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault("arknights_mower.utils.skland", MagicMock())
+
+from arknights_mower.solvers.base_schedule import BaseSchedulerSolver  # noqa: E402
+from arknights_mower.utils.operators import Dormitory, Operator, Operators  # noqa: E402
+from arknights_mower.utils.plan import Room  # noqa: E402
+from arknights_mower.utils.resting_correction import (  # noqa: E402
+    prefer_resting_replacements,
+)
+
+
+@pytest.fixture
+def solver():
+    data = object.__new__(Operators)
+    data.plan = {
+        "central": [Room("歌蕾蒂娅", "深海", ["薇薇安娜"])],
+        "room_2_2": [Room("引星棘刺", "自动化", ["淬羽赫默"])],
+        "room_3_2": [Room("清流", "", ["砾"]), Room("温蒂", "自动化", ["多萝西"])],
+        "room_3_3": [
+            Room("斯卡蒂", "深海", ["多萝西"]),
+            Room("幽灵鲨", "深海", ["淬羽赫默"]),
+        ],
+        "dormitory_1": [Room("Free", "", [])],
+        "train": [Room("逻各斯", "", ["赫默"])],
+    }
+    data.groups = {
+        "深海": ["歌蕾蒂娅", "斯卡蒂", "幽灵鲨"],
+        "自动化": ["引星棘刺", "温蒂"],
+    }
+    data.operators = {}
+    for room, slots in data.plan.items():
+        for index, slot in enumerate(slots):
+            if slot.agent == "Free":
+                continue
+            data.operators[slot.agent] = Operator(
+                slot.agent,
+                room,
+                index=index,
+                group=slot.group,
+                replacement=slot.replacement,
+                operator_type="high",
+                time_stamp=datetime.now(),
+            )
+    for name in ("薇薇安娜", "淬羽赫默", "多萝西", "归溟幽灵鲨", "砾", "赫默"):
+        data.operators[name] = Operator(name, "", time_stamp=datetime.now())
+    actual = {
+        "central": ["薇薇安娜"],
+        "room_3_3": ["引星棘刺", "温蒂"],
+        "room_3_2": ["多萝西", "淬羽赫默"],
+        "dormitory_1": ["歌蕾蒂娅"],
+        "train": ["归溟幽灵鲨"],
+    }
+    for room, names in actual.items():
+        for index, name in enumerate(names):
+            data.operators[name].current_room = room
+            data.operators[name].current_index = index
+    data.operators["歌蕾蒂娅"].mood = 0
+    data.dorm = [
+        Dormitory(("dormitory_1", 0), "歌蕾蒂娅", datetime.now() + timedelta(hours=7))
+    ]
+    instance = object.__new__(BaseSchedulerSolver)
+    instance.op_data, instance.tasks = data, []
+    instance.find_next_task = MagicMock(return_value=None)
+    instance.enter_room = MagicMock(
+        side_effect=AssertionError("unexpected device read")
+    )
+    instance._suppress_train_correction = lambda plan: plan.pop("train", None)
+    return instance
+
+
+def apply_plan(solver, plan):
+    """Apply confirmed placements to the cache without operating a device."""
+    for room, names in plan.items():
+        for index, name in enumerate(names):
+            if name in ("Current", "Free"):
+                continue
+            for op in solver.op_data.operators.values():
+                if op.current_room == room and op.current_index == index:
+                    op.current_room, op.current_index = "", -1
+            op = solver.op_data.operators[name]
+            op.current_room, op.current_index = room, index
+
+
+def test_backup_room_change_converges_using_replacements(solver, monkeypatch):
+    monkeypatch.setattr(
+        "arknights_mower.solvers.base_schedule._is_mastery_busy", lambda name: False
+    )
+    assert solver.agent_get_mood() == "self_correction"
+    plan = solver.tasks.pop().plan
+    assert plan["room_3_3"] == ["多萝西", "淬羽赫默"]
+    assert plan["room_3_2"] == ["清流", "温蒂"]
+    assert plan["room_2_2"] == ["引星棘刺"]
+    assert "central" not in plan
+    apply_plan(solver, plan)
+    for _ in range(3):
+        assert solver.agent_get_mood() is None
+        assert solver.tasks == []
+    assert solver.op_data.operators["歌蕾蒂娅"].current_room == "dormitory_1"
+    solver.enter_room.assert_not_called()
+
+
+def test_partial_group_at_work_does_not_wake_resting_member(solver):
+    apply_plan(
+        solver,
+        {
+            "room_2_2": ["引星棘刺"],
+            "room_3_2": ["清流", "温蒂"],
+            "room_3_3": ["斯卡蒂", "幽灵鲨"],
+        },
+    )
+    # The protected training room still seeds the legacy group-synchronization pass.
+    assert solver.agent_get_mood() is None
+    assert solver.tasks == []
+    assert solver.op_data.operators["歌蕾蒂娅"].mood == 0
+    assert solver.op_data.operators["歌蕾蒂娅"].is_resting()
+
+
+def test_completed_rest_allows_normal_group_return(solver):
+    solver.op_data.dorm[0].time = datetime.now() - timedelta(seconds=1)
+    solver.op_data.operators["歌蕾蒂娅"].mood = 24
+    solver.agent_get_mood()
+    first = solver.tasks.pop().plan
+    apply_plan(solver, first)
+    if "central" not in first:
+        solver.agent_get_mood()
+        first = solver.tasks.pop().plan
+    assert first["central"] == ["歌蕾蒂娅"]
+
+
+def test_replacements_in_other_working_rooms_are_not_taken(solver):
+    plan = {"room_3_3": ["斯卡蒂", "幽灵鲨"]}
+    busy = MagicMock(return_value=False)
+    prefer_resting_replacements(solver.op_data, plan, busy)
+    assert plan == {"room_3_3": ["斯卡蒂", "幽灵鲨"]}
+    busy.assert_not_called()
+
+
+def test_shared_replacement_is_assigned_only_once(solver):
+    data = solver.op_data
+    data.operators["多萝西"].current_room = ""
+    data.operators["幽灵鲨"].replacement = ["多萝西"]
+    plan = {"room_3_3": ["斯卡蒂", "幽灵鲨"]}
+    busy = MagicMock(return_value=False)
+    prefer_resting_replacements(data, plan, busy)
+    assert plan == {"room_3_3": ["多萝西", "幽灵鲨"]}
+    busy.assert_called_once_with("多萝西")
+
+
+def test_mastery_busy_replacement_is_not_used_and_checked_once(solver):
+    data = solver.op_data
+    data.operators["多萝西"].current_room = ""
+    data.operators["幽灵鲨"].replacement = ["多萝西"]
+    plan = {"room_3_3": ["斯卡蒂", "幽灵鲨"]}
+    busy = MagicMock(return_value=True)
+    prefer_resting_replacements(data, plan, busy)
+    assert plan == {"room_3_3": ["斯卡蒂", "幽灵鲨"]}
+    busy.assert_called_once_with("多萝西")
+
+
+def test_replacement_reserved_by_another_correction_is_not_reused(solver):
+    data = solver.op_data
+    data.operators["多萝西"].current_room = ""
+    plan = {"room_3_2": ["Current", "多萝西"], "room_3_3": ["斯卡蒂", "幽灵鲨"]}
+    prefer_resting_replacements(data, plan, MagicMock(return_value=False))
+    assert plan == {
+        "room_3_2": ["Current", "多萝西"],
+        "room_3_3": ["斯卡蒂", "淬羽赫默"],
+    }
+
+
+def test_correctly_placed_replacement_is_not_stolen_for_another_slot(solver):
+    data = solver.op_data
+    apply_plan(solver, {"room_3_3": ["多萝西", "Current"]})
+    data.operators["幽灵鲨"].replacement = ["多萝西"]
+    plan = {"room_3_3": ["Current", "幽灵鲨"]}
+    prefer_resting_replacements(data, plan, MagicMock(return_value=False))
+    assert plan == {"room_3_3": ["Current", "幽灵鲨"]}
+
+
+@pytest.mark.parametrize("end", [None, "future"])
+def test_individual_rest_is_also_protected(solver, end):
+    data = solver.op_data
+    data.operators["歌蕾蒂娅"].group = ""
+    data.dorm[0].time = None if end is None else datetime.now() + timedelta(hours=1)
+    # A missing bed deadline still has valid cached mood and an actual dorm slot.
+    plan = {"central": ["歌蕾蒂娅"]}
+    prefer_resting_replacements(data, plan, MagicMock(return_value=False))
+    assert plan == {}
+
+
+def test_zero_mood_workaholic_does_not_block_group_correction(solver):
+    data = solver.op_data
+    data.operators["歌蕾蒂娅"].workaholic = True
+    plan = {"room_3_3": ["斯卡蒂", "幽灵鲨"]}
+    prefer_resting_replacements(data, plan, MagicMock(return_value=False))
+    assert plan == {"room_3_3": ["斯卡蒂", "幽灵鲨"]}
+
+
+def test_temporary_trade_operator_is_replaced_by_regular_cover(solver):
+    data = solver.op_data
+    data.operators["但书"] = Operator("但书", "", time_stamp=datetime.now())
+    data.operators["斯卡蒂"].replacement = ["但书", "多萝西"]
+    data.operators["多萝西"].current_room = ""
+    apply_plan(solver, {"room_3_3": ["但书", "Current"]})
+    plan = {"room_3_3": ["斯卡蒂", "Current"]}
+    prefer_resting_replacements(data, plan, MagicMock(return_value=False))
+    assert plan == {"room_3_3": ["多萝西", "Current"]}
+
+
+def test_no_available_replacement_allows_group_correction_to_recall(solver):
+    apply_plan(
+        solver,
+        {
+            "room_2_2": ["引星棘刺"],
+            "room_3_2": ["清流", "温蒂"],
+            "room_3_3": ["斯卡蒂", "幽灵鲨"],
+        },
+    )
+    # The only cover is working elsewhere and this correction does not free her.
+    solver.op_data.operators["薇薇安娜"].current_room = "contact"
+    assert solver.agent_get_mood() == "self_correction"
+    plan = solver.tasks.pop().plan
+    assert plan == {"central": ["歌蕾蒂娅"]}
+    assert solver.op_data.operators["歌蕾蒂娅"].mood == 0
+    apply_plan(solver, plan)
+    assert solver.agent_get_mood(skip_dorm=True) is None
+    assert solver.tasks == []
+    solver.enter_room.assert_not_called()
+
+
+def test_correction_outside_planned_slot_is_not_silently_removed(solver):
+    apply_plan(solver, {"room_3_2": ["清流", "温蒂"]})
+    plan = {"room_3_2": ["斯卡蒂", "Current"]}
+    prefer_resting_replacements(solver.op_data, plan, MagicMock(return_value=False))
+    assert plan == {"room_3_2": ["斯卡蒂", "Current"]}

--- a/arknights_mower/utils/resting_correction.py
+++ b/arknights_mower/utils/resting_correction.py
@@ -1,0 +1,122 @@
+"""Prefer available replacements before recalling resting operators in correction."""
+
+from datetime import datetime
+from functools import cache
+
+from arknights_mower.utils.log import logger
+from arknights_mower.utils.operators import TRADE_ORDER_AGENTS
+
+PLACEHOLDERS = {"", "Current", "Free"}
+
+
+def _resting_members(op_data):
+    ends = {d.name: d.time for d in op_data.dorm if d.name}
+    resting, groups = set(), set()
+    now = datetime.now()
+    for name, op in op_data.operators.items():
+        if (
+            not op.is_high()
+            or op.workaholic
+            or op.room.startswith("dorm")
+            or not op.is_resting()
+        ):
+            continue
+        end = ends.get(name)
+        unfinished = end > now if end is not None else 0 <= op.mood < op.upper_limit
+        if unfinished:
+            resting.add(name)
+            if op.group:
+                groups.add(op.group)
+    for group in groups:
+        resting.update(
+            name
+            for name in op_data.groups[group]
+            if not op_data.operators[name].workaholic
+        )
+    return resting
+
+
+def _requested(plan, room, index):
+    slots = plan.get(room, [])
+    return slots[index] if 0 <= index < len(slots) else "Current"
+
+
+def _reserved_names(op_data, plan, resting):
+    reserved = {
+        name
+        for slots in plan.values()
+        for name in slots
+        if name not in PLACEHOLDERS and name not in resting
+    }
+    for name, op in op_data.operators.items():
+        if not op.current_room or op.is_resting():
+            continue
+        requested = _requested(plan, op.current_room, op.current_index)
+        # Preserve occupants of unchanged slots, including an already valid cover.
+        cover = (
+            requested in resting and name in op_data.operators[requested].replacement
+        )
+        if requested in ("Current", name) or cover:
+            reserved.add(name)
+    return reserved
+
+
+def _can_move(op, room, plan, resting):
+    if not op.current_room or op.is_resting() or op.current_room == room:
+        return True
+    replacement = _requested(plan, op.current_room, op.current_index)
+    # A replacement in another workplace is available only when this correction
+    # explicitly vacates its slot. Never take it from an unrelated working group.
+    return replacement not in PLACEHOLDERS | resting | {op.name}
+
+
+def prefer_resting_replacements(op_data, fix_plan, is_busy):
+    """Try replacements; otherwise retain the original correction's recall."""
+    if not fix_plan:
+        return
+    resting = _resting_members(op_data)
+    if not resting:
+        return
+    requested = {room: slots.copy() for room, slots in fix_plan.items()}
+    reserved = _reserved_names(op_data, requested, resting)
+    is_busy = cache(is_busy)
+    current = {room: op_data.get_current_room(room, True) for room in fix_plan}
+    for room, slots in fix_plan.items():
+        if room.startswith("dorm"):
+            continue
+        for index, name in enumerate(slots):
+            if name not in resting:
+                continue
+            op = op_data.operators[name]
+            if (room, index) != (op.room, op.index):
+                continue
+            actual = current[room][index]
+            if actual == name or (
+                actual in op.replacement and actual not in TRADE_ORDER_AGENTS
+            ):
+                slots[index] = "Current"
+                continue
+            for candidate in op.replacement:
+                cover = op_data.operators.get(candidate)
+                if (
+                    cover is None
+                    or cover.is_high()
+                    or candidate in reserved | resting
+                    or candidate in TRADE_ORDER_AGENTS
+                    or not _can_move(cover, room, requested, resting)
+                    or is_busy(candidate)
+                ):
+                    continue
+                slots[index] = candidate
+                reserved.add(candidate)
+                break
+            else:
+                logger.debug(
+                    f"{name}所在组正在休息，{room}暂无可用替班，保留原纠错叫回安排"
+                )
+    for room, slots in list(fix_plan.items()):
+        for index, name in enumerate(slots):
+            if name not in PLACEHOLDERS and name == current[room][index]:
+                slots[index] = "Current"
+        if all(name == "Current" for name in slots):
+            del fix_plan[room]


### PR DESCRIPTION
副表切换改变工作房间或替班顺序后，纠错会直接安排主力回岗，并可能通过同组检查连带叫回尚未休息完的干员。例如深海组休息期间，即使多萝西、淬羽赫默能随本轮纠错调整到正确位置，旧逻辑仍会先叫回斯卡蒂、幽灵鲨，再叫回歌蕾蒂娅。

本次在全部纠错方案生成后、任务执行前，优先为正在休息的干员及其同组成员安排替班：

- 保留已经正确在岗的替班，复用空闲、宿舍内或本轮纠错明确会释放的替班。
- 避免重复分配同一替班，避开其他正常工作房间、专精占用干员和跑单专用干员。
- 确实没有可用替班时，保留原纠错方案中的叫回安排。

改动仅作用于纠错方案；副表触发时机及显式上下班任务沿用现有规则。计算使用已有位置和休息记录，专精占用检查在单次计算中缓存。

验证：

- 在最新 `alpha` 基线上运行纠错、基建调度、干员房间和任务调度回归：115 项测试、7 项子测试通过。
- 覆盖切表后跨房间复用替班，并连续三轮确认不再生成重复纠错；覆盖无替班时叫回、替班重复占用和专精占用。
- 全仓库 `ruff check .`、`ruff format --check .` 通过，`git diff --check` 通过。
