### PR TITLE
fix(mastery): 排除无法在训练室专精的机械师与电弧

### DIFF
--- a/arknights_mower/tests/mastery_untrainable_tests.py
+++ b/arknights_mower/tests/mastery_untrainable_tests.py
@@ -1,0 +1,68 @@
+"""Roguelike gift operators cannot be selected as training-room trainees."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from arknights_mower.utils import mastery_db as db
+from arknights_mower.utils import mastery_recommendation as rec
+
+
+def test_recommendations_exclude_gift_operators_but_keep_regular_trainees(
+    tmp_path, monkeypatch
+):
+    ids = ["char_4195_radian", "char_4230_mcnist", "char_103_angel"]
+    roster = tmp_path / "cultivate.json"
+    roster.write_text(
+        json.dumps(
+            {
+                "data": {
+                    "characters": [
+                        {"id": cid, "evolvePhase": 2, "skills": [{"level": 0}]}
+                        for cid in ids
+                    ]
+                }
+            }
+        )
+    )
+    skills = tmp_path / "skill_data.json"
+    skills.write_text(
+        json.dumps(
+            {
+                "characters": {
+                    cid: {
+                        "name": name,
+                        "skills": [
+                            {
+                                "name": "测试技能",
+                                "levels": [{"materials": [], "time": 28800}] * 3,
+                            }
+                        ],
+                    }
+                    for cid, name in zip(ids, ["电弧", "机械师", "能天使"])
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(rec, "get_path", lambda _: roster)
+    monkeypatch.setattr(rec, "_find_skill_data", lambda: skills)
+    result = rec.get_mastery_recommendations()
+    assert result["has_data"]
+    assert [op["name"] for op in result["operators"]] == ["能天使"]
+
+
+@pytest.mark.parametrize("char_id", ["char_4195_radian", "char_4230_mcnist"])
+@pytest.mark.parametrize("support_mode", ["auto", "route"])
+def test_plan_creation_rejects_gift_operators_before_reading_box(
+    monkeypatch, char_id, support_mode
+):
+    read_box = MagicMock(side_effect=AssertionError("Should reject before reading BOX"))
+    insert = MagicMock()
+    monkeypatch.setattr(rec, "get_current_mastery_level", read_box)
+    monkeypatch.setattr(db, "insert_plan", insert)
+    plan_id, error = db.add_plan_checked(char_id, 0, support_mode=support_mode)
+    assert plan_id == -1
+    assert "无法在训练室专精" in error
+    read_box.assert_not_called()
+    insert.assert_not_called()

--- a/arknights_mower/utils/mastery_db.py
+++ b/arknights_mower/utils/mastery_db.py
@@ -244,9 +244,12 @@ def add_plan_checked(
     ):
         return -1, f"目标专精等级无效: {target_level}（需 1/2/3）"
     from arknights_mower.utils.mastery_recommendation import (
+        UNTRAINABLE_CHAR_IDS,
         get_current_mastery_level,
     )
 
+    if char_id in UNTRAINABLE_CHAR_IDS:
+        return -1, "该干员为肉鸽赠送干员，无法在训练室专精技能"
     current_level = get_current_mastery_level(char_id, skill_index)
     if current_level is not None and current_level >= target_level:
         return -1, f"该干员技能已专{current_level}，无需再练到专{target_level}"

--- a/arknights_mower/utils/mastery_recommendation.py
+++ b/arknights_mower/utils/mastery_recommendation.py
@@ -9,6 +9,9 @@ from arknights_mower.utils.resource_pkg import (
 )
 from arknights_mower.utils.skill_label import format_skill_label
 
+# 肉鸽赠送干员不支持训练室专精，即使 BOX 包含精二和技能数据。
+UNTRAINABLE_CHAR_IDS = frozenset({"char_4195_radian", "char_4230_mcnist"})
+
 
 def _find_skill_data():
     candidates = [
@@ -200,7 +203,7 @@ def get_mastery_recommendations():
         char_id = char.get("id", "")
         evolve_phase = char.get("evolvePhase", 0)
 
-        if evolve_phase < 2:
+        if evolve_phase < 2 or char_id in UNTRAINABLE_CHAR_IDS:
             continue
 
         char_info = char_table.get(char_id)


### PR DESCRIPTION
机械师和电弧是无法在训练室专精技能的肉鸽赠送干员，但 BOX 中的精二与技能数据会让他们进入可专精列表。按干员 ID 从列表中排除这两位，并在共用计划创建入口拒绝添加，覆盖自动协助和手动路线模式，避免旧页面或接口绕过列表限制。

验证：专精列表、数据库、计划 API 和协助计划创建相关测试 94 项通过；应用本地后相关测试 47 项通过；Ruff、格式检查及前端生产构建通过。无需修改资源仓库。
