### PR TITLE
fix(ci): 修复 MAA 回归测试进入真实休眠导致卡住

### DIFF
--- a/.github/workflows/format-check-and-test.yml
+++ b/.github/workflows/format-check-and-test.yml
@@ -101,6 +101,7 @@ jobs:
     needs: changes
     if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -115,7 +116,7 @@ jobs:
       - name: Compile all Python sources
         run: ./venv/bin/python3 -m compileall -q arknights_mower scripts
       - name: 自动发现全部 Python 回归测试（兼容 unittest 和 pytest）
-        run: ./venv/bin/python3 -m pytest -q
+        run: ./venv/bin/python3 -m pytest -v -o faulthandler_timeout=60
 
   # 运行依赖不含 scipy/scikit-image/scikit-learn，上面的 unittest 任务里等价性用例
   # 会整体跳过。这个任务装开发依赖把它们真正跑起来，避免识别算法被改坏时无人发现。

--- a/arknights_mower/tests/maa_error_no_exit_tests.py
+++ b/arknights_mower/tests/maa_error_no_exit_tests.py
@@ -19,6 +19,18 @@ class MaaErrorNoExitTests(unittest.TestCase):
     只释放 MAA（self.MAA = None）、记录错误、通知用户、本轮跳过，交给下个调度周期。
     """
 
+    def setUp(self):
+        # 未预期的异常必须使测试失败，不能进入真实休眠或被吞掉后假通过。
+        # 检查预期异常的用例在自己的 with 中覆盖这两个 mock。
+        self.unexpected_idle = self.enterContext(
+            patch.object(BaseSchedulerSolver, "_idle_sleep")
+        )
+        self.unexpected_error = self.enterContext(
+            patch.object(base_schedule, "save_exception")
+        )
+        self.addCleanup(self.unexpected_idle.assert_not_called)
+        self.addCleanup(self.unexpected_error.assert_not_called)
+
     @patch.object(BaseSchedulerSolver, "__init__", lambda self: None)
     def test_initialize_maa_failure_does_not_exit_game(self):
         # 初始化连不上 MAA（initialize_maa 抛错）→ 异常路径不得关闭游戏
@@ -184,6 +196,7 @@ class MaaErrorNoExitTests(unittest.TestCase):
                 "conf",
                 SimpleNamespace(
                     maa_gap=4,
+                    maa_restore_theme_enable=False,
                     RG=False,
                     SSS=False,
                     RCL=False,
@@ -197,7 +210,7 @@ class MaaErrorNoExitTests(unittest.TestCase):
             patch.object(solver, "initialize_maa", side_effect=_init_maa),
             patch.object(solver, "append_maa_task"),
             patch.object(solver, "sleep"),
-            patch.object(solver, "rest_until_next_task"),
+            patch.object(solver, "rest_until_next_task") as rest,
             patch.object(base_schedule, "get_server_weekday", return_value=1),
             patch.object(base_schedule, "send_message"),
         ):
@@ -205,6 +218,7 @@ class MaaErrorNoExitTests(unittest.TestCase):
 
         solver.device.exit.assert_not_called()
         solver.device.check_current_focus.assert_not_called()
+        rest.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
修复 #1009 合入后 `unittest` CI 长时间停住的问题。`test_normal_completion_does_not_exit_game` 使用的旧 `SimpleNamespace` 缺少新增的 `maa_restore_theme_enable` 字段，正常完成流程因此抛出 `AttributeError`，进入异常收尾；该用例将下一任务设在一天后，又没有模拟异常路径的 `_idle_sleep`，导致测试真实休眠约 24 小时。

- 补齐测试配置，将恢复主题显式设为关闭，并断言正常完成后确实调用预期的收尾方法。
- 在这组回归中统一模拟异常休眠和异常记录，断言它们没有被意外调用；预期异常的用例仍使用各自的局部模拟。以后出现缺失配置等问题时立即报错，不会长时间等待，也不会吞掉异常后假通过。
- `unittest` CI 增加 15 分钟总时限，输出每个测试名称，并在单个测试执行超过 60 秒时打印线程堆栈，便于直接定位卡点。

验证：先保留缺失字段验证保护措施，原用例在数秒内明确失败，报告缺少配置字段及意外休眠；补齐字段后，MAA 异常、主题恢复与控制权交接相关回归通过。全仓库 Ruff、格式检查、工作流 YAML 解析及 `git diff --check` 通过。

本地全量回归已越过原卡点并通过全部 MAA 测试，在约 57% 的资源测试阶段达到预设的 120 秒本地上限后停止，未发现失败；全量结果以本 PR 的 GitHub CI 为准。
