### PR TITLE
fix(window-shell): 修复窗口吸附失效与拖出最大化后多出的标题栏

### DIFF
--- a/arknights_mower/tests/window_frameless_tests.py
+++ b/arknights_mower/tests/window_frameless_tests.py
@@ -37,5 +37,115 @@ class TestFramelessWindowStyle(unittest.TestCase):
         )
 
 
+class _FakeEntryPoint:
+    """一个 user32 入口点：只记录调用，不真的打到壳层。
+
+    calls 记自己的入参；log 是共享的调用流水，用来固定几个入口之间的先后。
+    """
+
+    def __init__(self, log, name):
+        self.argtypes = None
+        self.restype = None
+        self.calls = []
+        self.log = log
+        self.name = name
+
+
+class _FakeFunction(_FakeEntryPoint):
+    def __init__(self, result, log, name):
+        super().__init__(log, name)
+        self._result = result
+
+    def __call__(self, *args):
+        self.calls.append(args)
+        self.log.append(self.name)
+        return self._result
+
+
+class _FakeCursorPos(_FakeEntryPoint):
+    def __init__(self, cursor, log):
+        super().__init__(log, "GetCursorPos")
+        self._cursor = cursor
+
+    def __call__(self, pointer):
+        self.calls.append(pointer)
+        self.log.append(self.name)
+        pointer._obj.x, pointer._obj.y = self._cursor
+        return True
+
+
+class _FakeUser32:
+    def __init__(self, cursor):
+        self.log = []
+        self.ReleaseCapture = _FakeFunction(True, self.log, "ReleaseCapture")
+        self.SendMessageW = _FakeFunction(0, self.log, "SendMessageW")
+        self.GetCursorPos = _FakeCursorPos(cursor, self.log)
+
+
+@unittest.skipUnless(os.name == "nt", "交回壳层的消息只在 Windows 上发送")
+class TestPressHandover(unittest.TestCase):
+    """标题栏拖拽与拉伸边共用「把按下交回壳层」这一步，这里固定它发出去的内容。"""
+
+    def setUp(self):
+        from arknights_mower.utils import windows_frameless
+
+        self.module = windows_frameless
+
+    def _patch(self, name, value):
+        original = getattr(self.module, name)
+        setattr(self.module, name, value)
+        self.addCleanup(setattr, self.module, name, original)
+
+    def _hand_over(self, cursor, hit_code):
+        fake = _FakeUser32(cursor)
+        self._patch("_user32", lambda: fake)
+        self.module._hand_press_to_shell(0x1234, hit_code)
+        return fake
+
+    def test_sends_the_press_as_a_non_client_button_down(self):
+        fake = self._hand_over((321, 654), self.module._HTCAPTION)
+
+        self.assertEqual(len(fake.SendMessageW.calls), 1)
+        hwnd, message, w_param, l_param = fake.SendMessageW.calls[0]
+        self.assertEqual(hwnd, 0x1234)
+        self.assertEqual(message, self.module._WM_NCLBUTTONDOWN)
+        self.assertEqual(w_param, self.module._HTCAPTION)
+        self.assertEqual(l_param, ((654 & 0xFFFF) << 16) | (321 & 0xFFFF))
+
+    def test_releases_the_capture_the_page_is_holding(self):
+        # 页面自己按下时已经拿到了鼠标捕获，不放开的话壳层的移动循环收不到任何移动。
+        fake = self._hand_over((10, 10), self.module._HTCAPTION)
+
+        self.assertEqual(len(fake.ReleaseCapture.calls), 1)
+
+    def test_asks_for_the_cursor_before_it_lets_go_of_the_capture(self):
+        # 三步的次序都是必要的：光标位置要填进 lParam，捕获要在发消息之前放开，
+        # 发消息必须在 UI 线程上（_run_on_ui_thread 的用例管这一段）。换了次序
+        # 移动循环就起不来，而这一点在测试里看不出来，所以固定下来。
+        fake = self._hand_over((11, 22), self.module._HTCAPTION)
+
+        self.assertEqual(fake.log, ["GetCursorPos", "ReleaseCapture", "SendMessageW"])
+
+    def test_packs_negative_coordinates_as_signed_words(self):
+        # 副屏在主屏左侧时窗口坐标是负的，lParam 的每个半字是 16 位有符号数。
+        fake = self._hand_over((-40, -7), self.module._HTCAPTION)
+
+        _, _, _, l_param = fake.SendMessageW.calls[0]
+        self.assertEqual(l_param, ((-7 & 0xFFFF) << 16) | (-40 & 0xFFFF))
+
+    def test_the_title_bar_hands_over_the_caption_hit_code(self):
+        # 入口自己挑命中码：标题栏交回 HTCAPTION，拉伸边交回 HTLEFT 一类。
+        fake = _FakeUser32((7, 8))
+        self._patch("_user32", lambda: fake)
+        self._patch("_winforms_window", lambda window: object())
+        self._patch("_winforms_hwnd", lambda window: 0x1234)
+        self._patch("_run_on_ui_thread", lambda form, action: action())
+
+        self.assertTrue(self.module.begin_windows_move(object()))
+
+        self.assertEqual(len(fake.SendMessageW.calls), 1)
+        self.assertEqual(fake.SendMessageW.calls[0][2], self.module._HTCAPTION)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/arknights_mower/utils/window_shell.py
+++ b/arknights_mower/utils/window_shell.py
@@ -204,6 +204,24 @@ class WindowShellBridge:
         self._window.confirm_close = False
         return self._call_window("destroy")
 
+    def start_move(self) -> bool:
+        """Hand a title bar press to the shell so it runs the drag itself.
+
+        The call returns only once the user lets go of the button, because the
+        shell's move loop owns the mouse for the whole drag.
+        """
+        if self._platform != "windows":
+            return False
+        try:
+            from arknights_mower.utils.windows_frameless import (
+                begin_windows_move,
+            )
+
+            return begin_windows_move(self._window)
+        except Exception:
+            logger.exception("Desktop window move could not start")
+            return False
+
     def start_resize(self, edge: str) -> bool:
         if self._platform != "windows":
             return False
@@ -288,6 +306,7 @@ def attach_window_shell(
         bridge.maximize,
         bridge.restore,
         bridge.close,
+        bridge.start_move,
         bridge.start_resize,
         bridge.get_window_state,
         bridge.get_platform,

--- a/arknights_mower/utils/windows_frameless.py
+++ b/arknights_mower/utils/windows_frameless.py
@@ -33,6 +33,8 @@ _WS_SYSMENU = 0x00080000
 _WS_CAPTION = 0x00C00000
 
 _WM_NCLBUTTONDOWN = 0x00A1
+_HTCLIENT = 1
+_HTCAPTION = 2
 
 _SWP_NOMOVE = 0x0002
 _SWP_NOZORDER = 0x0004
@@ -80,9 +82,16 @@ def frameless_window_style(style: int) -> int:
 
     DWM plays the minimize, maximize/restore and snap transitions only for a
     window that still carries ``WS_CAPTION`` next to the minimize/maximize box
-    styles; with the caption bit cleared the window just jumps. The painted
-    caption itself never appears, because ``WM_NCCALCSIZE`` returns 0 and leaves
-    the client area covering the whole window.
+    styles; with the caption bit cleared the window just jumps.
+
+    The caption those styles ask for is not free. This window has a non-client
+    area in exactly one place -- the resize frame ``inset_maximized_client`` takes
+    back out of a maximized window -- and while the window is maximized that band
+    hangs over the screen edge, which is why no caption is ever seen. Move a
+    maximized window without restoring it first and the band is dragged into view,
+    with a second title bar painted into it directly above the page's own; that is
+    the doubled title bar this module now avoids by handing the drag to the
+    shell's own move loop, which restores the window instead of moving it.
     """
     return style | (
         _WS_CAPTION | _WS_THICKFRAME | _WS_MINIMIZEBOX | _WS_MAXIMIZEBOX | _WS_SYSMENU
@@ -92,11 +101,50 @@ def frameless_window_style(style: int) -> int:
 def begin_windows_resize(window: Any, edge: str) -> bool:
     """Start the native sizing loop from an in-window HTML edge grip."""
     hit_test = _RESIZE_EDGE_HIT_TEST.get(edge)
-    if not is_windows() or hit_test is None:
+    if hit_test is None:
+        return False
+    return _begin_windows_drag(window, hit_test)
+
+
+def begin_windows_move(window: Any) -> bool:
+    """Start the native move loop from the in-window HTML title bar.
+
+    Dragging the title bar inside the page can only move the window with
+    ``SetWindowPos``, which never reaches the shell's own move handling: edge
+    snapping, restoring a maximized window by dragging it away from the screen
+    edge, shake, and the snap layout flyout all live in that loop. Handing the
+    press back with the caption hit code gives the drag back to the shell.
+
+    The loop owns the mouse until the button comes up, so callers must not wait
+    for this call to return.
+    """
+    return _begin_windows_drag(window, _HTCAPTION)
+
+
+def _begin_windows_drag(window: Any, hit_code: int) -> bool:
+    """Hand a press that landed inside the page back to the shell at *hit_code*."""
+    if not is_windows():
         return False
 
     form = _winforms_window(window)
-    hwnd = int(form.Handle.ToInt64())
+    hwnd = _winforms_hwnd(window)
+
+    def start_native_drag() -> bool:
+        return _hand_press_to_shell(hwnd, hit_code)
+
+    return _run_on_ui_thread(form, start_native_drag)
+
+
+def _hand_press_to_shell(hwnd: int, hit_code: int) -> bool:
+    """Replay the press at the cursor as the non-client message the shell tracks.
+
+    ``ReleaseCapture`` first, because the page already holds the capture from its
+    own mouse-down; without it the shell's loop never sees the movement.
+
+    The message only starts the loop for the active window; the shell activates
+    the window from the same press that armed the page, so by the time the page
+    hands the press over ``WM_ACTIVATE`` has already been through.
+    """
     user32 = _user32()
     user32.ReleaseCapture.argtypes = []
     user32.ReleaseCapture.restype = wintypes.BOOL
@@ -109,21 +157,22 @@ def begin_windows_resize(window: Any, edge: str) -> bool:
         wintypes.LPARAM,
     ]
     user32.SendMessageW.restype = ctypes.c_ssize_t
+    point = _POINT()
+    if not user32.GetCursorPos(ctypes.byref(point)):
+        raise ctypes.WinError(ctypes.get_last_error())
+    user32.ReleaseCapture()
+    position = ((point.y & 0xFFFF) << 16) | (point.x & 0xFFFF)
+    user32.SendMessageW(hwnd, _WM_NCLBUTTONDOWN, hit_code, position)
+    return True
 
-    def start_native_resize() -> bool:
-        point = _POINT()
-        if not user32.GetCursorPos(ctypes.byref(point)):
-            raise ctypes.WinError(ctypes.get_last_error())
-        user32.ReleaseCapture()
-        position = ((point.y & 0xFFFF) << 16) | (point.x & 0xFFFF)
-        user32.SendMessageW(hwnd, _WM_NCLBUTTONDOWN, hit_test, position)
-        return True
 
+def _run_on_ui_thread(form: Any, action: Any) -> bool:
+    """Run *action* on the WinForms UI thread; that thread owns the window."""
     if form.InvokeRequired:
         from System import Boolean, Func
 
-        return bool(form.Invoke(Func[Boolean](start_native_resize)))
-    return start_native_resize()
+        return bool(form.Invoke(Func[Boolean](action)))
+    return action()
 
 
 class _POINT(ctypes.Structure):
@@ -309,13 +358,16 @@ def _install_hook(
     wm_ncdestroy = 0x0082
     wm_size = 0x0005
     wm_windowposchanged = 0x0047
+    wm_cancelmode = 0x001F
+    wm_entersizemove = 0x0231
+    wm_exitsizemove = 0x0232
     wm_restore_normal_rect = 0x8001  # WM_APP + 1
 
     size_restored = 0
     size_maximized = 2
 
-    htclient = 1
-    htcaption = 2
+    htclient = _HTCLIENT
+    htcaption = _HTCAPTION
 
     sm_cxsizeframe = 32
     sm_cysizeframe = 33
@@ -421,6 +473,7 @@ def _install_hook(
     normal_rect: _RECT | None = None
     was_maximized = False
     restore_pending = False
+    shell_owns_modal_loop = False
 
     @wnd_proc_type
     def window_proc(
@@ -429,7 +482,7 @@ def _install_hook(
         w_param: int,
         l_param: int,
     ) -> int:
-        nonlocal normal_rect, restore_pending, was_maximized
+        nonlocal normal_rect, restore_pending, was_maximized, shell_owns_modal_loop
         try:
             if message == wm_restore_normal_rect:
                 if normal_rect is not None:
@@ -468,10 +521,24 @@ def _install_hook(
                 if w_param == size_maximized:
                     was_maximized = True
                 elif w_param == size_restored and was_maximized:
-                    restore_pending = True
                     was_maximized = False
-                    user32.PostMessageW(hwnd, wm_restore_normal_rect, 0, 0)
+                    # Dragging a maximized window away from the screen edge
+                    # restores it from inside the shell's move loop, and the
+                    # restore arrives after WM_ENTERSIZEMOVE (the order the loop
+                    # itself uses, read off the message journal). Forcing the
+                    # remembered rect would fight the drag, so while the shell
+                    # owns the loop let it keep the geometry it picked and let
+                    # that position become the remembered one.
+                    if not shell_owns_modal_loop:
+                        restore_pending = True
+                        user32.PostMessageW(hwnd, wm_restore_normal_rect, 0, 0)
                 return result
+            if message == wm_entersizemove:
+                shell_owns_modal_loop = True
+            elif message in (wm_exitsizemove, wm_cancelmode):
+                # WM_CANCELMODE is the loop's own way out when it is cancelled
+                # instead of finished, so the latch cannot outlive its loop.
+                shell_owns_modal_loop = False
             if message == wm_windowposchanged:
                 result = call_window_proc(
                     original_proc, message_hwnd, message, w_param, l_param

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -33,6 +33,7 @@
       :on-toggle-maximize="windowShell.toggleMaximize"
       :resizable="windowShellPlatform === 'windows' && !windowShellState.maximized"
       :on-resize="windowShell.startResize"
+      :on-move="windowShell.startMove"
     />
     <n-dialog-provider>
       <n-message-provider>

--- a/ui/src/components/WindowTitlebar.vue
+++ b/ui/src/components/WindowTitlebar.vue
@@ -12,17 +12,19 @@
     data-window-shell
   >
     <div
-      class="window-titlebar__brand pywebview-drag-region"
+      class="window-titlebar__brand"
       data-window-drag-region
       aria-hidden="true"
+      @mousedown.left="onDragStart"
       @dblclick.stop="onToggleMaximize"
     >
       <img class="window-titlebar__brand-mark" :src="'/favicon.ico'" alt="" />
     </div>
 
     <div
-      class="window-titlebar__drag-region pywebview-drag-region"
+      class="window-titlebar__drag-region"
       data-window-drag-region
+      @mousedown.left="onDragStart"
       @dblclick.stop="onToggleMaximize"
     >
       <span class="window-titlebar__identity" :title="title">
@@ -83,11 +85,12 @@
 </template>
 
 <script setup>
+import { onBeforeUnmount } from 'vue'
 import { WINDOW_RESIZE_EDGES } from '@/window-shell/adapter.js'
 
 const resizeEdges = WINDOW_RESIZE_EDGES
 
-defineProps({
+const props = defineProps({
   active: { type: Boolean, required: true },
   title: { type: String, required: true },
   version: { type: String, required: true },
@@ -103,8 +106,52 @@ defineProps({
   onControl: { type: Function, required: true },
   onToggleMaximize: { type: Function, required: true },
   resizable: { type: Boolean, required: true },
-  onResize: { type: Function, required: true }
+  onResize: { type: Function, required: true },
+  onMove: { type: Function, required: true }
 })
+
+// A press on the title bar is handed to the shell only once the pointer actually
+// moves. The shell's move loop then owns the mouse until the button comes up, so
+// starting it on the press itself would swallow the second click of a double
+// click and take maximise-on-double-click away with it.
+const DRAG_THRESHOLD = 4
+let dragOriginX = 0
+let dragOriginY = 0
+let dragArmed = false
+
+function stopWatchingDrag() {
+  dragArmed = false
+  window.removeEventListener('mousemove', watchDrag)
+  window.removeEventListener('mouseup', stopWatchingDrag)
+  window.removeEventListener('blur', stopWatchingDrag)
+}
+
+function watchDrag(event) {
+  if (!dragArmed) return
+  if (!(event.buttons & 1)) {
+    // The button is already up: the press this move belongs to is over, so drop
+    // the arming instead of handing a hover over to the shell as a caption drag.
+    stopWatchingDrag()
+    return
+  }
+  const moved =
+    Math.abs(event.screenX - dragOriginX) >= DRAG_THRESHOLD ||
+    Math.abs(event.screenY - dragOriginY) >= DRAG_THRESHOLD
+  if (!moved) return
+  stopWatchingDrag()
+  props.onMove()
+}
+
+function onDragStart(event) {
+  dragOriginX = event.screenX
+  dragOriginY = event.screenY
+  dragArmed = true
+  window.addEventListener('mousemove', watchDrag)
+  window.addEventListener('mouseup', stopWatchingDrag)
+  window.addEventListener('blur', stopWatchingDrag)
+}
+
+onBeforeUnmount(stopWatchingDrag)
 </script>
 
 <style scoped>

--- a/ui/src/window-shell/adapter.js
+++ b/ui/src/window-shell/adapter.js
@@ -21,6 +21,11 @@ const REQUIRED_METHODS = [
   'get_window_state',
   'get_platform'
 ]
+// start_move is deliberately absent from that list. It is the one capability the
+// shell can do without: the controls and the resize grips still work, only the
+// drag is gone. Requiring it would reject the whole shell instead, and on a
+// frameless window that leaves no title bar, no controls and no drag at all.
+// initialize() warns when it is missing, so the gap is not silent.
 const CONTROL_METHODS = new Set(['minimize', 'maximize', 'restore', 'close'])
 const RESIZE_EDGES = new Set(WINDOW_RESIZE_EDGES)
 
@@ -175,6 +180,9 @@ export function createWindowShellAdapter({
       bridge = candidate
       platform.value = platformResult.platform
       state.value = { ...stateResult }
+      if (typeof candidate.start_move !== 'function') {
+        console.warn('window shell cannot drag the window: start_move is missing')
+      }
       active.value = true
       windowObject?.addEventListener?.(event, onNativeState)
       listeningEvent = event
@@ -207,6 +215,29 @@ export function createWindowShellAdapter({
   const restore = () => runControl('restore')
   const close = () => runControl('close')
   const toggleMaximize = () => (state.value.maximized ? restore() : maximize())
+
+  async function startMove() {
+    if (!active.value || !bridge) return false
+    let handover
+    try {
+      handover = bridge.start_move()
+    } catch (error) {
+      // The call never reached the shell, so nothing owns the drag.
+      console.warn('window shell drag handover failed', error)
+      return false
+    }
+    // The shell's move loop owns the mouse until the button comes up, so this
+    // settles only after the drag has already ended. Report the handover straight
+    // away, but do not let a late refusal disappear either: a title bar that hands
+    // the drag to nobody leaves the window unable to move at all.
+    Promise.resolve(handover).then(
+      (started) => {
+        if (started !== true) console.warn('window shell refused the drag handover')
+      },
+      (error) => console.warn('window shell drag handover failed', error)
+    )
+    return true
+  }
 
   async function startResize(edge) {
     if (!active.value || !bridge || !RESIZE_EDGES.has(edge) || state.value.maximized) {
@@ -247,6 +278,7 @@ export function createWindowShellAdapter({
     restore,
     close,
     toggleMaximize,
+    startMove,
     startResize,
     dispose
   }

--- a/ui/src/window-shell/adapter.test.js
+++ b/ui/src/window-shell/adapter.test.js
@@ -12,6 +12,7 @@ function makeBridge(platform = 'windows') {
     maximize: vi.fn(async () => true),
     restore: vi.fn(async () => true),
     close: vi.fn(async () => true),
+    start_move: vi.fn(async () => true),
     start_resize: vi.fn(async () => true),
     get_platform: vi.fn(async () => ({ protocol: PROTOCOL, event: EVENT, platform })),
     get_window_state: vi.fn(async () => ({
@@ -146,5 +147,82 @@ describe('window shell adapter', () => {
     await expect(adapter.startResize('unexpected')).resolves.toBe(false)
     expect(bridge.start_resize).toHaveBeenCalledOnce()
     expect(bridge.start_resize).toHaveBeenCalledWith('bottom-right')
+  })
+
+  it('reports a title bar drag as started without waiting for the drag to end', async () => {
+    const desktopWindow = makeWindow()
+    const bridge = makeBridge()
+    // The shell's move loop holds the mouse until the button comes up, so the
+    // bridge call settles only after the user lets go.
+    let finishDrag
+    bridge.start_move = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          finishDrag = resolve
+        })
+    )
+    desktopWindow.pywebview = { api: bridge }
+    const adapter = createWindowShellAdapter({ windowObject: desktopWindow })
+    await adapter.initialize()
+
+    await expect(adapter.startMove()).resolves.toBe(true)
+    expect(bridge.start_move).toHaveBeenCalledOnce()
+    finishDrag(true)
+  })
+
+  it('still reports the handover when the shell refuses the drag', async () => {
+    // A refused handover must not turn into an unhandled rejection: the drag is
+    // already gone at that point, so the only thing left to do is say so.
+    const desktopWindow = makeWindow()
+    const bridge = makeBridge()
+    bridge.start_move = vi.fn(async () => {
+      throw new Error('no move loop here')
+    })
+    desktopWindow.pywebview = { api: bridge }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const adapter = createWindowShellAdapter({ windowObject: desktopWindow })
+    await adapter.initialize()
+
+    await expect(adapter.startMove()).resolves.toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('reports a drag the bridge could not even start', async () => {
+    // A synchronous throw means nothing owns the drag, so this is a refusal and
+    // not a handover -- and it must not escape as an unhandled rejection.
+    const desktopWindow = makeWindow()
+    const bridge = makeBridge()
+    bridge.start_move = vi.fn(() => {
+      throw new Error('bridge is gone')
+    })
+    desktopWindow.pywebview = { api: bridge }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const adapter = createWindowShellAdapter({ windowObject: desktopWindow })
+    await adapter.initialize()
+
+    await expect(adapter.startMove()).resolves.toBe(false)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('keeps the shell usable when the backend cannot drag the window', async () => {
+    // A missing start_move costs the drag and nothing else. Rejecting the whole
+    // contract instead would leave a frameless window with no title bar, no
+    // controls and no way to move it, so the shell comes up and names the gap.
+    const desktopWindow = makeWindow()
+    const bridge = makeBridge()
+    delete bridge.start_move
+    desktopWindow.pywebview = { api: bridge }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const adapter = createWindowShellAdapter({ windowObject: desktopWindow })
+
+    await expect(adapter.initialize()).resolves.toBe(true)
+    expect(adapter.active.value).toBe(true)
+    expect(adapter.controls.value).toHaveLength(3)
+    await expect(adapter.startMove()).resolves.toBe(false)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
   })
 })


### PR DESCRIPTION
## 变更

标题栏拖动由 pywebview 注入的拖拽区脚本完成，最终落到 `SetWindowPos`。系统的吸附与「从最大化拖出来」只在处理标题栏按下的移动循环里发生，`SetWindowPos` 不进入那个循环，拖到屏幕边缘不触发最大化；它也不解除最大化状态，窗口被搬走而客户区仍按工作区大小留着，客户区顶边上方的非客户区带随之进入视野，多出一条标题栏。

改为在指针移动超过 4px 后把按下交回壳层（`HTCAPTION`），与拉伸握把共用 `_begin_windows_drag()` 和 `_hand_press_to_shell()`；桥接层新增 `start_move`，页面侧移除 `pywebview-drag-region`。壳层持有移动循环期间跳过 `WM_APP+1` 按记忆矩形做的强制还原，并给这个标志补上 `WM_CANCELMODE` 出口。

## 限制

- 只覆盖 Windows，其他平台 `frameless` 为假，窗口保留原生标题栏。
- `start_move` 未列入前端必需方法清单：后端缺它时壳层照常出现，标题栏、控制按钮和拉伸握把都能用，只丢拖动，初始化时打一条警告。
- 悬停最大化按钮不弹贴边布局浮层，需要窗口回答 `HTMAXBUTTON`，命中测试没走到那里（未实测，按代码推断）。
- 最大化时收回客户区的 11px 非客户区带仍在，只是不再有把仍是最大化状态的窗口搬走这条路径。它与多出的标题栏的对应关系按几何和截图判断，未追 DWM 的绘制过程。
- 新增的 `window_frameless_tests.py` 用例在 CI 上会被跳过（CI 跑 ubuntu-latest）。

## 验证

Windows 11、150% 缩放、2560×1440，真窗口驱动鼠标：拖动跟随指针；拖到屏幕顶边触发最大化；从最大化往下拖动还原成 1536×1050 并落到屏幕之内；双击仍然切换最大化。同一次运行的消息顺序是 `WM_NCLBUTTONDOWN(HTCAPTION)`、`WM_SYSCOMMAND(SC_DRAGMOVE)`、`WM_ENTERSIZEMOVE`、`WM_SIZE(SIZE_RESTORED)`，交回这一步阻塞约 1.0 秒。pytest 7 条通过，vitest 227 条通过，ruff、prettier、eslint 均干净。
