### PR TITLE
fix(mastery): 兼容排班表未配置训练室的自动专精

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -3116,7 +3116,9 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         if fast_mode:
             current_room = self.op_data.get_current_room(room, True)
             # 如果空位置进房间会被向前挤
-            current_room = sorted(current_room, key=lambda x: x == "")
+            # 训练室的协助位和训练位固定，空协助位不能让训练位前移。
+            if room != "train":
+                current_room = sorted(current_room, key=lambda x: x == "")
             differences = []
             for i in range(len(current_room)):
                 if current_room[i] not in agents:
@@ -3399,7 +3401,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
             logger.info("检测到产物收取提示")
             self.sleep(1)
         if room == "train":
-            length = len(self.op_data.plan.get(room, [None, None]))
+            length = 2
         else:
             length = len(self.op_data.plan[room])
         if length > 3:

--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -935,7 +935,8 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         for key in plan:
             need_fix = False
             _current_room = self.op_data.get_current_room(key, True)
-            for idx, name in enumerate(_current_room):
+            # 训练室读取固定两格；纠错只管理排班中明确配置的槽位。
+            for idx, name in enumerate(_current_room[: len(plan[key])]):
                 # 如果是空房间
                 if name == "":
                     if not need_fix:

--- a/arknights_mower/tests/mastery_choose_train_tests.py
+++ b/arknights_mower/tests/mastery_choose_train_tests.py
@@ -9,9 +9,92 @@ from unittest.mock import MagicMock
 sys.modules.setdefault("arknights_mower.utils.skland", MagicMock())
 
 from arknights_mower.solvers.base_schedule import BaseSchedulerSolver  # noqa: E402
+from arknights_mower.utils.operators import Operators  # noqa: E402
 from arknights_mower.utils.scene import Scene  # noqa: E402
 
 choose_train = BaseSchedulerSolver.choose_train
+
+
+class TestUnscheduledTrainingRoom(unittest.TestCase):
+    def make_operators(self, support="", trainee="号角", plan=None):
+        data = object.__new__(Operators)
+        data.plan = {} if plan is None else plan
+        data.operators = {
+            name: types.SimpleNamespace(
+                name=name, current_room="train", current_index=index
+            )
+            for index, name in enumerate([support, trainee])
+            if name
+        }
+        return data
+
+    def test_room_slots_do_not_depend_on_schedule(self):
+        for plan in (
+            {},
+            {"train": []},
+            {"train": [types.SimpleNamespace(agent="暴雨")]},
+        ):
+            with self.subTest(plan=plan):
+                data = self.make_operators(plan=plan)
+                self.assertEqual(data.get_current_room("train", True), ["", "号角"])
+                self.assertIsNone(data.get_current_room("train"))
+                self.assertEqual(
+                    data.get_current_room("train", current_index=[1]), ["", "号角"]
+                )
+                self.assertEqual(data.plan, plan)
+
+    def test_empty_and_occupied_room_keep_both_slots(self):
+        self.assertEqual(
+            self.make_operators(trainee="").get_current_room("train", True), ["", ""]
+        )
+        self.assertEqual(
+            self.make_operators(support="暴雨").get_current_room("train"),
+            ["暴雨", "号角"],
+        )
+
+    def test_other_rooms_still_use_schedule_size(self):
+        data = self.make_operators(
+            plan={"central": [types.SimpleNamespace(agent="阿米娅")]}
+        )
+        self.assertEqual(data.get_current_room("central", True), [""])
+        with self.assertRaises(KeyError):
+            data.get_current_room("missing", True)
+
+    def test_real_assistant_selection_without_train_schedule(self):
+        for old_support in ("", "褐果"):
+            with self.subTest(old_support=old_support):
+                solver = make_solver(
+                    [
+                        Scene.INFRA_DETAILS,
+                        Scene.INFRA_ARRANGE_ORDER,
+                        Scene.INFRA_DETAILS,
+                    ],
+                    [
+                        [{"agent": old_support}, {"agent": "号角"}],
+                        [{"agent": "暴雨"}, {"agent": "号角"}],
+                    ],
+                )
+                solver.op_data = self.make_operators(support=old_support)
+                solver.choose_agent = types.MethodType(
+                    BaseSchedulerSolver.choose_agent, solver
+                )
+                solver.detect_arrange_order.return_value = ("技能", False)
+                solver.verify_agent.return_value = True
+
+                def scan(agents, **kwargs):
+                    self.assertEqual(agents, ["暴雨"])
+                    agents.remove("暴雨")
+                    return ["暴雨"], []
+
+                solver.scan_agent.side_effect = scan
+                choose_train(solver, ["暴雨", "Current"])
+                solver.verify_agent.assert_called_once_with(["暴雨"], "train")
+                solver.tap_confirm.assert_called_once_with("train")
+                solver.choose_train_ope.assert_not_called()
+                self.assertEqual(solver.op_data.plan, {})
+                if not old_support:
+                    # 协助位为空时不得把训练位当成原协助者点击取消。
+                    solver.tap.assert_not_called()
 
 
 def make_solver(scenes, scan_results):

--- a/arknights_mower/tests/resting_correction_tests.py
+++ b/arknights_mower/tests/resting_correction_tests.py
@@ -122,6 +122,30 @@ def test_partial_group_at_work_does_not_wake_resting_member(solver):
     assert solver.op_data.operators["歌蕾蒂娅"].is_resting()
 
 
+@pytest.mark.parametrize("configured_slots", [0, 1])
+@pytest.mark.parametrize("trainee_present", [False, True])
+def test_correction_leaves_unconfigured_training_slot_alone(
+    solver, configured_slots, trainee_present
+):
+    solver.op_data.plan["train"] = solver.op_data.plan["train"][:configured_slots]
+    if not configured_slots:
+        del solver.op_data.operators["逻各斯"]
+    if trainee_present:
+        trainee = Operator("号角", "", time_stamp=datetime.now())
+        trainee.current_room, trainee.current_index = "train", 1
+        solver.op_data.operators[trainee.name] = trainee
+    # 不依赖专精保护抑制纠错，也不得为用户未配置的训练位生成安排。
+    solver._suppress_train_correction = lambda plan: None
+    solver.agent_get_mood()
+    for task in solver.tasks:
+        if configured_slots:
+            assert task.plan.get("train", ["逻各斯"]) == ["逻各斯"]
+        else:
+            assert "train" not in task.plan
+    if trainee_present:
+        assert solver.op_data.operators["号角"].current_room == "train"
+
+
 def test_completed_rest_allows_normal_group_return(solver):
     solver.op_data.dorm[0].time = datetime.now() - timedelta(seconds=1)
     solver.op_data.operators["歌蕾蒂娅"].mood = 24

--- a/arknights_mower/utils/operators.py
+++ b/arknights_mower/utils/operators.py
@@ -425,7 +425,9 @@ class Operators:
             for k, v in self.operators.items()
             if v.current_room == room
         }
-        res = [obj.agent for obj in self.plan[room]]
+        # 训练室的两个槽位由设施决定，自动专精不要求静态排班配置该房间。
+        # 只读取缓存，不向排班表补人，避免常规排班接管自动专精。
+        res = [""] * 2 if room == "train" else [obj.agent for obj in self.plan[room]]
         not_found = False
         for idx, op in enumerate(res):
             if idx in room_data:


### PR DESCRIPTION
排班表未填写训练室时，自动专精在开训后安排协助者会因读取 `self.plan["train"]` 抛出 `KeyError: 'train'`，导致训练已开始而协助者未能入驻。

本次将训练室的缓存读取与现场扫描统一按两个固定槽位处理，使未配置、空配置或只配置一个干员时仍能读取完整的协助位和训练位。选人时跳过通用的空位前移排序，保持索引 0 为协助位、索引 1 为训练位。常规排班纠错只检查用户明确配置的槽位，避免只填写协助位时越界，也不会为未配置的训练位生成纠错安排。不会向用户排班表写入干员或 `Current`。

验证：
- 本地完整 Python 测试：2187 passed、11 skipped、431 subtests passed；更新后 GitHub CI 所有适用检查通过。
- 新增未配置训练室时调用真实 `choose_train`、`choose_agent` 和缓存读取的回归用例，设备交互使用 mock。
- Ruff 检查、格式检查及 `git diff --check` 通过。
- 尚未实机验证。
