### PR TITLE
test(ci): 放宽进程控制测试就绪等待至30秒

### DIFF
--- a/arknights_mower/tests/process_control_tests.py
+++ b/arknights_mower/tests/process_control_tests.py
@@ -167,7 +167,7 @@ class ProcessControlIntegrationTests(unittest.TestCase):
                 return process
 
             def wait_for_records(count):
-                deadline = time.monotonic() + 10
+                deadline = time.monotonic() + 30
                 while time.monotonic() < deadline:
                     records = runtime.instances(state)
                     if len(records) == count and all(


### PR DESCRIPTION
Windows CI 在 #1018 中出现过模拟进程未能在 10 秒内全部就绪的失败；相同提交重跑后通过。

将进程控制集成测试 `wait_for_records()` 的等待上限从 10 秒放宽至 30 秒，容纳 CI 环境下较慢的进程启动和登记。该辅助函数为各平台共用，每 50 毫秒检查一次，实例就绪后立即继续；保留原有实例数量、就绪状态及重启／停止隔离断言。

验证：

- 本地 `ProcessControlIntegrationTests` 通过（1 项）。
- Ruff 检查、格式检查及 `git diff --check` 通过。
- Windows 验证由本 PR 的 CI 执行。
