### PR TITLE
feat(mastery): 增加专精材料预算与原料保留设置

### DIFF
--- a/arknights_mower/tests/mastery_materials_tests.py
+++ b/arknights_mower/tests/mastery_materials_tests.py
@@ -261,3 +261,38 @@ def test_lower_tier_direct_and_crafting_consumption_are_both_displayed():
     result = budget({"t3": 1, "t2": 2}, {"t2": 7})
     assert result["craftable"]
     assert [(row["id"], row["required"]) for row in result["crafting"]] == [("t2", 7)]
+
+
+def test_craftable_materials_are_distinguished_from_unrelated_missing_materials():
+    result = budget({"t4": 1, "3303": 2}, {"t3": 3, "3302": 3})
+    assert not result["craftable"]
+    assert {row["id"]: row["craftable"] for row in result["materials"]} == {
+        "t4": True,
+        "3303": False,
+    }
+
+
+def test_lower_tier_crafting_marks_blue_and_high_materials_craftable():
+    result = budget({"t5": 1}, {"t4": 1, "t3": 2, "t2": 5})
+    assert result["craftable"]
+    assert all(row["craftable"] for row in result["materials"] + result["crafting"])
+    result = budget({"t5": 1}, {"t4": 1, "t3": 2, "t2": 4})
+    assert not result["materials"][0]["craftable"]
+    assert {row["id"]: row["craftable"] for row in result["crafting"]} == {
+        "t4": False,
+        "t3": False,
+    }
+
+
+def test_shared_ingredient_shortage_is_not_claimed_as_craftable_by_each_parent():
+    data = resources()
+    data["items"]["other_t4"] = {"name": "另一紫材料", "rarity": 4}
+    data["composite"]["other_t4"] = {"pathway": [{"id": "t3", "count": 3}]}
+    result = MaterialBudget(data, {"t3": 3}).calculate(
+        [
+            {"id": "t4", "count": 1},
+            {"id": "other_t4", "count": 1},
+        ]
+    )
+    assert all(not row["craftable"] for row in result["materials"])
+    assert result["missing"][0]["count"] == 3

--- a/arknights_mower/tests/mastery_materials_tests.py
+++ b/arknights_mower/tests/mastery_materials_tests.py
@@ -179,7 +179,7 @@ def test_lower_tiers_are_shown_when_they_can_complete_crafting():
     result = budget({"t3": 1}, {"t2": 4, "t1": 3})
     assert result["craftable"]
     assert [(r["id"], r["required"]) for r in result["crafting"]] == [
-        ("t2", 5),
+        ("t2", 4),
         ("t1", 3),
     ]
 
@@ -194,3 +194,70 @@ def test_chip_conversion_recipes_do_not_break_mastery_budgeting():
 
 def test_empty_plan_does_not_require_box_data():
     assert plan_material_summary([])["materials"] == []
+
+
+def test_missing_skills_follow_plan_order_and_share_inventory():
+    calculator = MaterialBudget(resources(), {"t3": 5, "t5": 1})
+    entries = [
+        ("first", [{"id": "t3", "count": 4}]),
+        ("second", [{"id": "t3", "count": 4}]),
+        ("stocked", [{"id": "t5", "count": 1}]),
+    ]
+    result = calculator.calculate_plan(entries)
+    assert result["missing_skills"] == ["second"]
+    assert result["missing"][0]["count"] == 3
+    assert {row["id"] for row in result["materials"]} == {"t3", "t5"}
+    assert calculator.calculate_plan([entries[1], entries[0], entries[2]])[
+        "missing_skills"
+    ] == ["first"]
+
+
+def test_book_shortages_are_displayed_without_listing_skills():
+    result = MaterialBudget(resources(), {}).calculate_plan(
+        [("books_only", [{"id": "3303", "count": 2}])]
+    )
+    assert result["missing_skills"] == []
+    assert not result["craftable"]
+    assert [(row["id"], row["count"]) for row in result["missing"]] == [("3303", 2)]
+
+
+def test_mixed_shortages_only_list_skills_lacking_elite_materials():
+    result = MaterialBudget(resources(), {"t3": 3}).calculate_plan(
+        [
+            ("craftable", [{"id": "t4", "count": 1}]),
+            ("books_only", [{"id": "3303", "count": 2}]),
+            ("elite_missing", [{"id": "t4", "count": 1}]),
+        ]
+    )
+    assert result["missing_skills"] == ["elite_missing"]
+    assert {row["id"]: row["count"] for row in result["missing"]} == {
+        "3303": 2,
+        "t3": 3,
+    }
+
+
+@pytest.mark.parametrize(
+    "stock,expected_missing,expected_spent",
+    [
+        ({"t2": 4, "t1": 3}, 2, {"t2": 4, "t1": 3}),
+        ({"t2": 8, "t1": 3}, 2, {"t2": 5}),
+        ({"t2": 10, "t1": 0}, 1, {"t2": 10}),
+        ({"t2": 4, "t1": 2}, 3, {}),
+    ],
+)
+def test_lower_tier_consumption_is_capped_and_remaining_shortage_stays_blue(
+    stock, expected_missing, expected_spent
+):
+    result = budget({"t3": 3}, stock)
+    assert [(row["id"], row["count"]) for row in result["missing"]] == [
+        ("t3", expected_missing)
+    ]
+    spent = {row["id"]: row["required"] for row in result["crafting"]}
+    assert spent == expected_spent
+    assert all(count <= stock.get(item, 0) for item, count in spent.items())
+
+
+def test_lower_tier_direct_and_crafting_consumption_are_both_displayed():
+    result = budget({"t3": 1, "t2": 2}, {"t2": 7})
+    assert result["craftable"]
+    assert [(row["id"], row["required"]) for row in result["crafting"]] == [("t2", 7)]

--- a/arknights_mower/tests/mastery_materials_tests.py
+++ b/arknights_mower/tests/mastery_materials_tests.py
@@ -1,0 +1,196 @@
+"""Inventory is shared across all requirements, including intermediate crafts."""
+
+import copy
+import json
+
+import pytest
+
+from arknights_mower.utils.mastery_materials import (
+    MaterialBudget,
+    plan_material_summary,
+)
+
+
+def resources():
+    return {
+        "items": {
+            "t5": {"name": "金材料", "rarity": 5},
+            "t4": {"name": "紫材料", "rarity": 4},
+            "t3": {"name": "蓝材料", "rarity": 3},
+            "t2": {"name": "绿材料", "rarity": 2},
+            "t1": {"name": "白材料", "rarity": 1},
+            "3303": {"name": "技巧概要·卷3", "rarity": 4},
+            "3302": {"name": "技巧概要·卷2", "rarity": 3},
+        },
+        "composite": {
+            "t5": {"pathway": [{"id": "t4", "count": 2}]},
+            "t4": {"pathway": [{"id": "t3", "count": 3}]},
+        },
+    }
+
+
+def lower_recipes():
+    return {
+        "蓝材料": {"costs": {"绿材料": 5}},
+        "绿材料": {"costs": {"白材料": 3}},
+        "技巧概要·卷3": {"costs": {"技巧概要·卷2": 3}},
+    }
+
+
+def budget(demand, stock):
+    return MaterialBudget(resources(), stock, lower_recipes()).calculate(
+        [{"id": key, "count": value} for key, value in demand.items()]
+    )
+
+
+def test_intermediate_stock_is_used_before_decomposition():
+    result = budget({"t5": 1}, {"t4": 1, "t3": 3})
+    assert not result["available"]
+    assert result["craftable"]
+    assert [(r["id"], r["required"]) for r in result["crafting"]] == [
+        ("t4", 2),
+        ("t3", 3),
+    ]
+    assert result["missing"] == []
+
+
+def test_direct_and_indirect_needs_share_inventory_once():
+    result = budget({"t5": 1, "t4": 1, "t3": 2}, {"t4": 1, "t3": 4})
+    assert [(r["id"], r["count"]) for r in result["missing"]] == [("t3", 4)]
+    assert result["missing"][0]["required"] == 8
+
+
+def test_multiple_skills_do_not_each_spend_the_same_stock():
+    result = MaterialBudget(resources(), {"t3": 5}).calculate(
+        [{"id": "t3", "count": 4}, {"id": "t3", "count": 4}]
+    )
+    assert result["missing"][0]["count"] == 3
+
+
+def test_lower_stock_makes_whole_blue_materials_only():
+    result = budget({"t3": 3}, {"t2": 9, "t1": 3})
+    assert result["missing"][0]["count"] == 1
+    assert result["missing"][0]["blue"]
+    assert result["missing"][0]["craftable_count"] == 2
+    result = budget({"t3": 1}, {"t2": 4})
+    assert result["missing"][0]["count"] == 1
+
+
+def test_books_are_craftable_but_missing_books_are_not_blue_elite_materials():
+    assert budget({"3303": 2}, {"3302": 6})["craftable"]
+    result = budget({"3303": 2}, {"3302": 5})
+    assert result["missing"][0]["count"] == 1
+    assert not result["missing"][0]["blue"]
+
+
+def test_owned_high_materials_do_not_consume_lower_stock():
+    result = budget({"t5": 1, "t3": 2}, {"t5": 1, "t3": 2})
+    assert result["available"] and result["craftable"]
+    assert not result["crafting"]
+
+
+def test_missing_recipe_does_not_silently_mark_materials_craftable():
+    result = budget({"unknown": 1}, {})
+    assert not result["craftable"]
+    assert result["missing"][0]["count"] == 1
+
+
+def test_inputs_are_not_mutated_and_repeated_calculations_are_independent():
+    data, stock = resources(), {"t3": 3}
+    saved = copy.deepcopy((data, stock))
+    calculator = MaterialBudget(data, stock)
+    assert calculator.calculate([{"id": "t4", "count": 1}]) == calculator.calculate(
+        [{"id": "t4", "count": 1}]
+    )
+    assert (data, stock) == saved
+
+
+def test_recipe_cycles_are_rejected():
+    data = resources()
+    data["composite"]["t3"] = {"pathway": [{"id": "t5", "count": 1}]}
+    with pytest.raises(ValueError, match="循环"):
+        MaterialBudget(data, {})
+
+
+@pytest.mark.parametrize(
+    "status,target,current,runtime_level,expected",
+    [
+        ("idle", 2, 0, None, 3),
+        ("training", 3, 0, 1, 6),
+        ("waiting_collect", 3, 1, 1, 6),
+        ("idle", 3, 2, None, 4),
+    ],
+)
+def test_plan_summary_uses_remaining_target_levels_and_excludes_paid_training(
+    tmp_path, monkeypatch, status, target, current, runtime_level, expected
+):
+    from arknights_mower.utils import mastery_db, mastery_recommendation, path
+
+    data = resources()
+    data["characters"] = {
+        "char_test": {
+            "skills": [
+                {
+                    "levels": [
+                        {"materials": [{"id": "t3", "count": count}]}
+                        for count in (1, 2, 4)
+                    ]
+                }
+            ]
+        }
+    }
+    box = tmp_path / "box.json"
+    box.write_text(
+        json.dumps(
+            {
+                "data": {
+                    "characters": [{"id": "char_test", "skills": [{"level": current}]}],
+                    "items": [],
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(path, "get_path", lambda _: box)
+    monkeypatch.setattr(mastery_recommendation, "get_skill_data", lambda: data)
+    monkeypatch.setattr(
+        mastery_db,
+        "get_all_plans",
+        lambda: [
+            {
+                "char_id": "char_test",
+                "skill_index": 0,
+                "target_level": target,
+                "status": status,
+                "support_runtime": json.dumps({"level": runtime_level}),
+            }
+        ],
+    )
+    monkeypatch.setattr(mastery_db, "get_failed_plans", lambda: [])
+    result = plan_material_summary(["char_test_0", "char_test_0"])
+    assert result["materials"][0]["required"] == expected
+
+
+def test_low_materials_reserved_for_direct_needs_are_not_spent_twice():
+    result = budget({"t3": 1, "t2": 5}, {"t2": 5})
+    assert [(row["id"], row["count"]) for row in result["missing"]] == [("t3", 1)]
+
+
+def test_lower_tiers_are_shown_when_they_can_complete_crafting():
+    result = budget({"t3": 1}, {"t2": 4, "t1": 3})
+    assert result["craftable"]
+    assert [(r["id"], r["required"]) for r in result["crafting"]] == [
+        ("t2", 5),
+        ("t1", 3),
+    ]
+
+
+def test_chip_conversion_recipes_do_not_break_mastery_budgeting():
+    recipes = lower_recipes()
+    recipes["金材料"] = {"tab": "芯片", "costs": {"紫材料": 1}}
+    recipes["紫材料"] = {"tab": "芯片", "costs": {"金材料": 1}}
+    calculator = MaterialBudget(resources(), {"t3": 6}, recipes)
+    assert calculator.calculate([{"id": "t5", "count": 1}])["craftable"]
+
+
+def test_empty_plan_does_not_require_box_data():
+    assert plan_material_summary([])["materials"] == []

--- a/arknights_mower/tests/mastery_recommendation_tests.py
+++ b/arknights_mower/tests/mastery_recommendation_tests.py
@@ -187,6 +187,19 @@ class TestComputeWorkshopConfigReadsDb(unittest.TestCase):
     def test_db_plan_drives_book_demand(self):
         # DB 计划 (char_A, 1) → 推荐链材料 技巧概要·卷3×5 → 合成配置 book 上限=5
         mats = [{"name": "技巧概要·卷3", "count": 5}]
+        cultivate_path, skill_path = _write_inventory_files(self.tmp.name, "3303", 0)
+        with open(skill_path, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "items": {
+                        "3303": {"name": "技巧概要·卷3"},
+                        "3302": {"name": "技巧概要·卷2"},
+                    }
+                },
+                f,
+            )
+        with open(cultivate_path, "w", encoding="utf-8") as f:
+            json.dump({"data": {"items": [{"id": "3302", "count": 15}]}}, f)
         with (
             patch(
                 "arknights_mower.utils.mastery_db.get_all_plans",
@@ -200,7 +213,7 @@ class TestComputeWorkshopConfigReadsDb(unittest.TestCase):
             patch.object(
                 rec,
                 "get_path",
-                return_value=os.path.join(self.tmp.name, "no_cultivate.json"),
+                return_value=cultivate_path,
             ),
         ):
             config = rec.compute_workshop_config()
@@ -240,7 +253,7 @@ class TestComputeWorkshopConfigReadsDb(unittest.TestCase):
             config = rec.compute_workshop_config()
         self.assertIsNotNone(config)
         book = [c for c in config if c["operator"] == "司霆惊蛰"]
-        self.assertEqual(book[0]["items"], [])
+        self.assertEqual(book, [])
 
     def test_no_db_plans_clears_automatic_config(self):
         # 无 DB 计划 → 空配置，避免继续合成旧计划或全量默认材料。

--- a/arknights_mower/tests/workshop_auto_plan_tests.py
+++ b/arknights_mower/tests/workshop_auto_plan_tests.py
@@ -32,7 +32,7 @@ def test_box_completed_head_is_skipped_before_selecting_next_skill(next_skill):
             {
                 "data": {
                     "characters": [{"id": "char_b", "skills": [{"level": 3}]}],
-                    "items": [],
+                    "items": [{"id": "3302", "count": 300}],
                 }
             }
         )

--- a/arknights_mower/tests/workshop_material_policy_tests.py
+++ b/arknights_mower/tests/workshop_material_policy_tests.py
@@ -1,0 +1,110 @@
+"""The T2 preservation switch applies to plans, saved tasks and batch execution."""
+
+import copy
+
+import pytest
+
+from arknights_mower.data import workshop_formula
+from arknights_mower.utils import config
+from arknights_mower.utils.config.conf import RIICPart, WorkShopItem
+from arknights_mower.utils.mastery_materials import MaterialBudget
+from arknights_mower.utils.workshop_limits import batch_limit
+from arknights_mower.utils.workshop_material_policy import (
+    PROTECTED_T2_MATERIALS,
+    protected_workshop_materials,
+)
+from arknights_mower.utils.workshop_recommendation import (
+    allocate_workshop_items,
+    prioritize_workshop_settings,
+)
+
+
+def test_switch_defaults_off_and_round_trips():
+    assert not RIICPart().workshop_protect_t2_device_rock
+    enabled = RIICPart(workshop_protect_t2_device_rock=True)
+    assert RIICPart(**enabled.model_dump()).workshop_protect_t2_device_rock
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_only_exact_t2_ingredients_are_blocked_at_execution(monkeypatch, enabled):
+    monkeypatch.setattr(config.conf, "workshop_protect_t2_device_rock", enabled)
+    setting = WorkShopItem(self_upper_limit=1, children_lower_limit=0)
+    for name in (
+        "固源岩组",
+        "全新装置",
+        "提纯源岩",
+        "改量装置",
+        "固源岩",
+        "装置",
+        "技巧概要·卷3",
+    ):
+        recipe = workshop_formula[name]
+        inventory = {ingredient: 99 for ingredient in recipe["items"]}
+        inventory[recipe["output_name"]] = 0
+        protected = bool(PROTECTED_T2_MATERIALS.intersection(recipe["items"]))
+        assert batch_limit(name, recipe, setting, inventory) == (
+            0 if enabled and protected else 1
+        ), name
+
+
+def test_saved_and_generated_tasks_preserve_other_materials_and_user_settings(
+    monkeypatch,
+):
+    monkeypatch.setattr(config.conf, "workshop_protect_t2_device_rock", True)
+    items = [
+        {
+            "item_names": ["固源岩组", "全新装置", "提纯源岩"],
+            "self_upper_limit": 5,
+            "children_lower_limit": 0,
+        }
+    ]
+    settings = [{"operator": "测试干员", "enabled": True, "items": items}]
+    before = copy.deepcopy(settings)
+    scoped = prioritize_workshop_settings(settings, available={})
+    assert scoped[0]["items"][0]["item_names"] == ["提纯源岩"]
+    assert settings == before
+    generated = allocate_workshop_items(
+        [("fodder_operators", ["测试干员"], items)], available={}
+    )
+    assert [
+        name
+        for entry in generated
+        for item in entry["items"]
+        for name in item["item_names"]
+    ] == ["提纯源岩"]
+    monkeypatch.setattr(config.conf, "workshop_protect_t2_device_rock", False)
+    assert prioritize_workshop_settings(settings, available={}) == before
+
+
+@pytest.mark.parametrize("name", ["固源岩", "装置"])
+@pytest.mark.parametrize("enabled", [False, True])
+def test_budget_excludes_protected_t2_and_t1_routes_but_uses_t3_stock(
+    monkeypatch, name, enabled
+):
+    monkeypatch.setattr(config.conf, "workshop_protect_t2_device_rock", enabled)
+    data = {
+        "items": {
+            "t1": {"name": "低阶原料", "rarity": 1},
+            "t2": {"name": name, "rarity": 2},
+            "t3": {"name": "蓝材料", "rarity": 3},
+            "t4": {"name": "紫材料", "rarity": 4},
+        },
+        "composite": {
+            "t2": {"pathway": [{"id": "t1", "count": 3}]},
+            "t3": {"pathway": [{"id": "t2", "count": 5}]},
+            "t4": {"pathway": [{"id": "t3", "count": 3}]},
+        },
+    }
+    calculator = MaterialBudget(
+        data,
+        {"t1": 300, "t2": 100, "t3": 1},
+        blocked_materials=protected_workshop_materials(),
+    )
+    result = calculator.calculate_plan([("skill", [{"id": "t4", "count": 1}])])
+    assert result["craftable"] is not enabled
+    if enabled:
+        assert [(row["id"], row["count"]) for row in result["missing"]] == [("t3", 2)]
+        assert all(row["id"] not in {"t1", "t2"} for row in result["crafting"])
+        assert result["missing_skills"] == ["skill"]
+    else:
+        assert result["missing"] == []

--- a/arknights_mower/tests/workshop_materials_tests.py
+++ b/arknights_mower/tests/workshop_materials_tests.py
@@ -116,7 +116,12 @@ def test_plan_specialties_include_direct_and_indirect_t3_with_counts_and_stock(
     skill_path.write_text(json.dumps(data))
     iron_id = next(i for i, v in data["items"].items() if v["name"] == "异铁块")
     path = tmp_path / "cultivate.json"
-    path.write_text(json.dumps({"data": {"items": [{"id": iron_id, "count": 1}]}}))
+    stock = [{"id": iron_id, "count": 1}] + [
+        {"id": key, "count": 300}
+        for key, item in data["items"].items()
+        if item.get("rarity") == 2
+    ]
+    path.write_text(json.dumps({"data": {"items": stock}}))
     recommendations = {
         "operators": [
             {

--- a/arknights_mower/tests/workshop_plan_fixtures.py
+++ b/arknights_mower/tests/workshop_plan_fixtures.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -32,9 +33,15 @@ def next_skill(monkeypatch, tmp_path):
     config.conf.workshop_generation = 0
     config.conf.workshop_deer_fodder = config.Conf().workshop_deer_fodder
     cultivate = tmp_path / "cultivate.json"
-    cultivate.write_text(json.dumps({"data": {"characters": [], "items": []}}))
+    data = json.loads((Path(__file__).parents[1] / "data/skill_data.json").read_text())
+    stock = [
+        {"id": key, "count": 300}
+        for key, item in data["items"].items()
+        if item.get("rarity") == 3 or key == "3302"
+    ]
+    cultivate.write_text(json.dumps({"data": {"characters": [], "items": stock}}))
     skills = tmp_path / "skill_data.json"
-    skills.write_text(json.dumps({"items": {"3303": {"name": "技巧概要·卷3"}}}))
+    skills.write_text(json.dumps({"items": data["items"]}))
     monkeypatch.setattr(rec, "get_path", lambda _: cultivate)
     monkeypatch.setattr(rec, "_find_skill_data", lambda: skills)
     plans = [
@@ -68,9 +75,12 @@ def next_skill(monkeypatch, tmp_path):
             "operators": [
                 {
                     "char_id": cid,
+                    "name": cid,
+                    "profession": "CASTER",
                     "recommendations": [
                         {
                             "skill_index": 0,
+                            "skill_name": "一技能",
                             "current_level": 0,
                             "chain_needed_materials": [
                                 {"name": "技巧概要·卷3", "count": count}

--- a/arknights_mower/tests/workshop_readiness_tests.py
+++ b/arknights_mower/tests/workshop_readiness_tests.py
@@ -1,0 +1,155 @@
+"""Uncraftable skills wait without starting partial automatic preparation."""
+
+import copy
+import json
+
+from arknights_mower.tests.workshop_plan_fixtures import book_limit
+from arknights_mower.tests.workshop_plan_fixtures import next_skill as next_skill
+from arknights_mower.utils import config
+from arknights_mower.utils import mastery_recommendation as rec
+from arknights_mower.utils import workshop_automation as auto
+from arknights_mower.utils.config.conf import RIICPart
+
+
+def set_stock(fixture, stock):
+    fixture.cultivate.write_text(
+        json.dumps(
+            {
+                "data": {
+                    "characters": [],
+                    "items": [
+                        {"id": key, "count": value} for key, value in stock.items()
+                    ],
+                }
+            }
+        )
+    )
+
+
+def test_books_short_after_crafting_wait_then_resume_without_changing_plan(next_skill):
+    plans = copy.deepcopy(next_skill.plans)
+    set_stock(next_skill, {"3302": 20})  # Six books can be made; the head needs seven.
+    assert rec.compute_workshop_config([], [], ["赫拉格"]) == []
+    assert rec.auto_schedule_mastery_tasks()["scheduled"] == []
+    assert next_skill.plans == plans
+    set_stock(next_skill, {"3302": 21})
+    assert book_limit(rec.compute_workshop_config([], [], ["赫拉格"])) == 7
+    assert rec.auto_schedule_mastery_tasks()["scheduled"] == []  # Not crafted yet.
+    set_stock(next_skill, {"3303": 7})
+    assert any(
+        item["char_id"] == "char_b"
+        for item in rec.auto_schedule_mastery_tasks()["scheduled"]
+    )
+    assert next_skill.plans == plans
+
+
+def test_elite_shortage_stops_all_preparation_including_other_available_materials(
+    next_skill, monkeypatch
+):
+    data = rec.get_mastery_recommendations()
+    data["operators"][1]["recommendations"][0]["chain_needed_materials"].append(
+        {"name": "糖聚块", "count": 1}
+    )
+    monkeypatch.setattr(rec, "get_mastery_recommendations", lambda: data)
+    set_stock(next_skill, {"3302": 300})
+    assert rec.compute_workshop_config(["空爆"], [], ["赫拉格"]) == []
+    assert rec.auto_schedule_mastery_tasks()["scheduled"] == []
+
+
+def test_protected_ingredients_do_not_unlock_automatic_preparation(
+    next_skill, monkeypatch
+):
+    data = rec.get_mastery_recommendations()
+    data["operators"][1]["recommendations"][0]["chain_needed_materials"] = [
+        {"name": "提纯源岩", "count": 1}
+    ]
+    monkeypatch.setattr(rec, "get_mastery_recommendations", lambda: data)
+    set_stock(next_skill, {"30012": 20})
+    assert any(item["items"] for item in rec.compute_workshop_config(["空爆"], [], []))
+    config.conf.workshop_protect_t2_device_rock = True
+    assert rec.compute_workshop_config(["空爆"], [], []) == []
+    set_stock(next_skill, {"30013": 4})
+    assert any(item["items"] for item in rec.compute_workshop_config(["空爆"], [], []))
+
+
+def test_new_shortage_invalidates_old_automatic_tasks_but_keeps_backup_and_plan(
+    next_skill,
+):
+    manual = RIICPart.WorkShopSetting(operator="空爆")
+    config.conf.workshop_settings = [manual]
+    auto.update_workshop_config()
+    generation = config.conf.workshop_generation
+    plans = copy.deepcopy(next_skill.plans)
+    set_stock(next_skill, {})
+    result = auto.update_workshop_config()
+    assert result["workshop_settings"] == []
+    assert config.conf.workshop_auto_active
+    assert config.conf.workshop_generation > generation
+    assert config.conf.workshop_manual_backup == [manual]
+    assert next_skill.plans == plans
+    set_stock(next_skill, {"3302": 21})
+    assert book_limit(auto.update_workshop_config()["workshop_settings"]) == 7
+
+
+def test_readiness_uses_target_level_for_both_crafting_and_training(
+    next_skill, monkeypatch
+):
+    next_skill.plans[1]["target_level"] = 1
+    data = rec.get_mastery_recommendations()
+    data["operators"][1]["recommendations"][0]["stages"] = [
+        {
+            "to_level": level + 7,
+            "needed_materials": [{"name": "技巧概要·卷3", "count": count}],
+        }
+        for level, count in [(1, 1), (2, 2), (3, 4)]
+    ]
+    monkeypatch.setattr(rec, "get_mastery_recommendations", lambda: data)
+    set_stock(next_skill, {"3302": 3})
+    assert book_limit(rec.compute_workshop_config([], [], ["赫拉格"])) == 1
+    set_stock(next_skill, {"3303": 1})
+    assert [
+        item["char_id"] for item in rec.auto_schedule_mastery_tasks()["scheduled"]
+    ] == ["char_b"]
+
+
+def test_lookahead_checks_current_remaining_costs_as_well_as_next_skill(
+    next_skill, monkeypatch
+):
+    next_skill.plans[1].update(status="training", expires_at="2999-01-01 00:00:00")
+    data = rec.get_mastery_recommendations()
+    data["operators"][1]["recommendations"][0]["stages"] = [
+        {
+            "to_level": level + 7,
+            "needed_materials": [{"name": "技巧概要·卷3", "count": count}],
+        }
+        for level, count in [(1, 1), (2, 2), (3, 4)]
+    ]
+    monkeypatch.setattr(rec, "get_mastery_recommendations", lambda: data)
+    set_stock(next_skill, {"3302": 15})  # Enough for next skill, not current + next.
+    assert rec.compute_workshop_config([], [], ["赫拉格"]) == []
+    set_stock(next_skill, {"3302": 33})
+    assert book_limit(rec.compute_workshop_config([], [], ["赫拉格"])) == 11
+
+
+def test_training_start_sums_repeated_materials_across_remaining_levels(
+    next_skill, monkeypatch
+):
+    next_skill.plans[1]["target_level"] = 2
+    data = rec.get_mastery_recommendations()
+    skill = data["operators"][1]["recommendations"][0]
+    skill["stages"] = [
+        {
+            "to_level": level + 7,
+            "needed_materials": [{"name": "技巧概要·卷3", "count": 1}],
+        }
+        for level in (1, 2, 3)
+    ]
+    monkeypatch.setattr(rec, "get_mastery_recommendations", lambda: data)
+    set_stock(next_skill, {"3303": 1})
+    assert rec.auto_schedule_mastery_tasks()["scheduled"] == []
+    set_stock(next_skill, {"3303": 2})
+    assert [
+        item["char_id"] for item in rec.auto_schedule_mastery_tasks()["scheduled"]
+    ] == ["char_b"]
+    skill["current_level"] = 2
+    assert rec.auto_schedule_mastery_tasks()["scheduled"] == []

--- a/arknights_mower/utils/config/conf.py
+++ b/arknights_mower/utils/config/conf.py
@@ -474,6 +474,8 @@ class RIICPart(ConfModel):
     "九色鹿垫刀素材，独立于自动生成的配置"
     workshop_min_bonus: int = Field(default=80, ge=0, le=1000)
     "加工站一键设置的副产品概率加成下限（百分比）"
+    workshop_protect_t2_device_rock: bool = False
+    "禁止加工消耗装置、固源岩（仅 T2），材料预算也排除对应合成配方"
     workshop_low_priority_rest: bool = True
     "加工干员使用最低宿舍恢复优先级，覆盖床位分配与实际选人"
     t5_operators: list[str] = ["年"]

--- a/arknights_mower/utils/mastery_materials.py
+++ b/arknights_mower/utils/mastery_materials.py
@@ -154,12 +154,28 @@ class MaterialBudget:
                     "direct": 0,
                 }
             )
+        # Propagate unresolved ingredient shortages upward through the shared
+        # budget, so unrelated craftable materials remain distinguishable.
+        missing_ids = {row["id"] for row in missing}
+        supply = {}
+        for row in sorted(rows, key=lambda row: self.depths.get(row["id"], 0)):
+            key = row["id"]
+            needs_crafting = row.get("to_craft", 0) > 0
+            row["craftable"] = not needs_crafting or (
+                key not in missing_ids
+                and all(
+                    supply.get(child, True)
+                    for child in self.recipes.get(key, ({}, 1))[0]
+                )
+            )
+            supply[key] = row["craftable"]
         direct_rows = [
             {
                 "id": key,
                 "name": self.items.get(key, {}).get("name", key),
                 "required": count,
                 "owned": self.inventory.get(key, 0),
+                "craftable": supply[key],
             }
             for key, count in direct.items()
             if count > 0

--- a/arknights_mower/utils/mastery_materials.py
+++ b/arknights_mower/utils/mastery_materials.py
@@ -41,9 +41,10 @@ class MaterialBudget:
         return self.depths[key]
 
     def _consume(self, key, count, stock, trace=None):
-        if trace is not None:
-            trace[key] += count
         used = min(stock.get(key, 0), count)
+        if trace is not None and used:
+            # Show inventory actually spent, not intermediates made during crafting.
+            trace[key] += used
         stock[key] = stock.get(key, 0) - used
         count -= used
         if not count:
@@ -132,6 +133,7 @@ class MaterialBudget:
         known_rows = {row["id"]: row for row in rows}
         for key, count in lower_demand.items():
             if key in known_rows:
+                known_rows[key]["required"] += count
                 continue
             item = self.items.get(key, {})
             rows.append(
@@ -162,10 +164,36 @@ class MaterialBudget:
             "craftable": not missing,
         }
 
+    def calculate_plan(self, entries):
+        """Attribute new elite-material shortages in plan order using shared stock."""
+        demand = Counter()
+        previous_missing = {}
+        missing_skills = []
+        summary = self.calculate([])
+        for key, materials in entries:
+            for material in materials:
+                demand[material["id"]] += material["count"]
+            # Aggregate first: each pass is bounded by material types, not plan length.
+            summary = self.calculate(
+                [{"id": item, "count": count} for item, count in demand.items()]
+            )
+            missing = {
+                row["id"]: row["count"]
+                for row in summary["missing"]
+                if not row["id"].startswith("330")
+            }
+            if any(
+                count > previous_missing.get(item, 0) for item, count in missing.items()
+            ):
+                missing_skills.append(key)
+            previous_missing = missing
+        summary["missing_skills"] = missing_skills
+        return summary
+
 
 def plan_material_summary(planned_keys):
     if not planned_keys:
-        return MaterialBudget({}, {}).calculate([])
+        return MaterialBudget({}, {}).calculate_plan([])
 
     import json
 
@@ -183,8 +211,8 @@ def plan_material_summary(planned_keys):
         key = f"{plan['char_id']}_{plan['skill_index']}"
         if key not in saved or plan["target_level"] > saved[key]["target_level"]:
             saved[key] = plan
-    materials = []
-    for key in set(planned_keys):
+    entries = []
+    for key in dict.fromkeys(planned_keys):
         char_id, skill_index = key.rsplit("_", 1)
         skill_index = int(skill_index)
         char = characters.get(char_id)
@@ -201,7 +229,9 @@ def plan_material_summary(planned_keys):
             if isinstance(runtime, str):
                 runtime = json.loads(runtime)
             current = max(current, runtime.get("level") or current + 1)
+        materials = []
         for level in definitions[skill_index].get("levels", [])[current:target]:
             materials.extend(level.get("materials", []))
+        entries.append((key, materials))
     inventory = {item["id"]: int(item.get("count", 0)) for item in box.get("items", [])}
-    return MaterialBudget(skills, inventory, workshop_formula).calculate(materials)
+    return MaterialBudget(skills, inventory, workshop_formula).calculate_plan(entries)

--- a/arknights_mower/utils/mastery_materials.py
+++ b/arknights_mower/utils/mastery_materials.py
@@ -5,7 +5,9 @@ from math import ceil
 
 
 class MaterialBudget:
-    def __init__(self, skill_data, inventory, workshop_formula=None):
+    def __init__(
+        self, skill_data, inventory, workshop_formula=None, *, blocked_materials=()
+    ):
         self.items = skill_data.get("items", {})
         self.inventory = {key: max(0, int(value)) for key, value in inventory.items()}
         ids = {item["name"]: key for key, item in self.items.items()}
@@ -26,6 +28,12 @@ class MaterialBudget:
                     {ids[child]: count for child, count in costs.items()},
                     max(1, int(recipe.get("output_count", 1))),
                 )
+        blocked_ids = {ids[name] for name in blocked_materials if name in ids}
+        self.recipes = {
+            key: recipe
+            for key, recipe in self.recipes.items()
+            if not blocked_ids.intersection(recipe[0])
+        }
         self.depths = {}
         for key in self.recipes:
             self._depth(key, set())
@@ -201,6 +209,9 @@ def plan_material_summary(planned_keys):
     from arknights_mower.utils.mastery_db import get_all_plans, get_failed_plans
     from arknights_mower.utils.mastery_recommendation import get_skill_data
     from arknights_mower.utils.path import get_path
+    from arknights_mower.utils.workshop_material_policy import (
+        protected_workshop_materials,
+    )
 
     with open(get_path("@app/tmp/cultivate.json"), encoding="utf-8") as stream:
         box = json.load(stream).get("data", {})
@@ -234,4 +245,9 @@ def plan_material_summary(planned_keys):
             materials.extend(level.get("materials", []))
         entries.append((key, materials))
     inventory = {item["id"]: int(item.get("count", 0)) for item in box.get("items", [])}
-    return MaterialBudget(skills, inventory, workshop_formula).calculate_plan(entries)
+    return MaterialBudget(
+        skills,
+        inventory,
+        workshop_formula,
+        blocked_materials=protected_workshop_materials(),
+    ).calculate_plan(entries)

--- a/arknights_mower/utils/mastery_materials.py
+++ b/arknights_mower/utils/mastery_materials.py
@@ -1,0 +1,207 @@
+"""Read-only material budgeting for mastery previews; never changes workshop tasks."""
+
+from collections import Counter
+from math import ceil
+
+
+class MaterialBudget:
+    def __init__(self, skill_data, inventory, workshop_formula=None):
+        self.items = skill_data.get("items", {})
+        self.inventory = {key: max(0, int(value)) for key, value in inventory.items()}
+        ids = {item["name"]: key for key, item in self.items.items()}
+        self.recipes = {}
+        for key, recipe in skill_data.get("composite", {}).items():
+            costs = Counter()
+            for child in recipe.get("pathway", []):
+                costs[child["id"]] += child["count"]
+            if costs:
+                self.recipes[key] = (dict(costs), 1)
+        for name, recipe in (workshop_formula or {}).items():
+            if recipe.get("tab", "精英材料") not in ("精英材料", "技巧概要"):
+                continue
+            output = ids.get(recipe.get("output_name", name))
+            costs = recipe.get("costs") or dict(Counter(recipe.get("items", [])))
+            if output and costs and all(child in ids for child in costs):
+                self.recipes[output] = (
+                    {ids[child]: count for child, count in costs.items()},
+                    max(1, int(recipe.get("output_count", 1))),
+                )
+        self.depths = {}
+        for key in self.recipes:
+            self._depth(key, set())
+
+    def _depth(self, key, visiting):
+        if key in visiting:
+            raise ValueError("材料合成配方存在循环")
+        if key not in self.depths:
+            children = self.recipes.get(key, ({}, 1))[0]
+            self.depths[key] = 1 + max(
+                (self._depth(child, visiting | {key}) for child in children), default=-1
+            )
+        return self.depths[key]
+
+    def _consume(self, key, count, stock, trace=None):
+        if trace is not None:
+            trace[key] += count
+        used = min(stock.get(key, 0), count)
+        stock[key] = stock.get(key, 0) - used
+        count -= used
+        if not count:
+            return True
+        recipe = self.recipes.get(key)
+        if not recipe:
+            return False
+        costs, output = recipe
+        batches = ceil(count / output)
+        for child, cost in costs.items():
+            if not self._consume(child, cost * batches, stock, trace):
+                return False
+        stock[key] += batches * output - count
+        return True
+
+    def _craft_available(self, key, count, stock, trace):
+        # Whole batches only. Failed probes must not consume shared ingredients.
+        low, high = 0, count
+        while low < high:
+            middle = (low + high + 1) // 2
+            if self._consume(key, middle, dict(stock)):
+                low = middle
+            else:
+                high = middle - 1
+        if low:
+            self._consume(key, low, stock, trace)
+        return low
+
+    def calculate(self, materials):
+        direct = Counter()
+        for material in materials:
+            direct[material["id"]] += material["count"]
+        demand = Counter(direct)
+        stock = dict(self.inventory)
+        reserved = {key: min(count, stock.get(key, 0)) for key, count in direct.items()}
+        for key, count in reserved.items():
+            stock[key] = stock.get(key, 0) - count
+        rows, missing = [], []
+        lower_demand = Counter()
+        pending = set(demand)
+        while pending:
+            key = max(pending, key=lambda k: (self.depths.get(k, 0), k))
+            pending.remove(key)
+            count = demand[key]
+            if count <= 0:
+                continue
+            item = self.items.get(key, {})
+            owned = stock.get(key, 0)
+            extra_used = min(count - reserved.get(key, 0), owned)
+            stock[key] = owned - extra_used
+            used = extra_used + reserved.get(key, 0)
+            shortage = count - used
+            row = {
+                "id": key,
+                "name": item.get("name", key),
+                "rarity": item.get("rarity", 0),
+                "required": count,
+                "owned": self.inventory.get(key, 0),
+                "used": used,
+                "direct": direct[key],
+                "to_craft": shortage,
+            }
+            rows.append(row)
+            if not shortage:
+                continue
+            # Stop the shopping list at blue elite materials. Lower-tier stock
+            # may still make whole blue materials; books are reported separately.
+            blue = item.get("rarity") == 3 and not key.startswith("330")
+            book = key.startswith("330")
+            recipe = self.recipes.get(key)
+            if recipe and not blue and not book:
+                costs, output = recipe
+                batches = ceil(shortage / output)
+                for child, cost in costs.items():
+                    demand[child] += cost * batches
+                    pending.add(child)
+            else:
+                crafted = (
+                    self._craft_available(key, shortage, stock, lower_demand)
+                    if recipe
+                    else 0
+                )
+                row["craftable_count"] = crafted
+                if shortage > crafted:
+                    missing.append({**row, "count": shortage - crafted, "blue": blue})
+        known_rows = {row["id"]: row for row in rows}
+        for key, count in lower_demand.items():
+            if key in known_rows:
+                continue
+            item = self.items.get(key, {})
+            rows.append(
+                {
+                    "id": key,
+                    "name": item.get("name", key),
+                    "rarity": item.get("rarity", 0),
+                    "required": count,
+                    "owned": self.inventory.get(key, 0),
+                    "direct": 0,
+                }
+            )
+        direct_rows = [
+            {
+                "id": key,
+                "name": self.items.get(key, {}).get("name", key),
+                "required": count,
+                "owned": self.inventory.get(key, 0),
+            }
+            for key, count in direct.items()
+            if count > 0
+        ]
+        return {
+            "materials": direct_rows,
+            "crafting": [row for row in rows if row["required"] > row["direct"]],
+            "missing": missing,
+            "available": all(row["owned"] >= row["required"] for row in direct_rows),
+            "craftable": not missing,
+        }
+
+
+def plan_material_summary(planned_keys):
+    if not planned_keys:
+        return MaterialBudget({}, {}).calculate([])
+
+    import json
+
+    from arknights_mower.data import workshop_formula
+    from arknights_mower.utils.mastery_db import get_all_plans, get_failed_plans
+    from arknights_mower.utils.mastery_recommendation import get_skill_data
+    from arknights_mower.utils.path import get_path
+
+    with open(get_path("@app/tmp/cultivate.json"), encoding="utf-8") as stream:
+        box = json.load(stream).get("data", {})
+    skills = get_skill_data()
+    characters = {char["id"]: char for char in box.get("characters", [])}
+    saved = {}
+    for plan in get_all_plans() + get_failed_plans():
+        key = f"{plan['char_id']}_{plan['skill_index']}"
+        if key not in saved or plan["target_level"] > saved[key]["target_level"]:
+            saved[key] = plan
+    materials = []
+    for key in set(planned_keys):
+        char_id, skill_index = key.rsplit("_", 1)
+        skill_index = int(skill_index)
+        char = characters.get(char_id)
+        definitions = skills.get("characters", {}).get(char_id, {}).get("skills", [])
+        if not char or not 0 <= skill_index < min(
+            len(char.get("skills", [])), len(definitions)
+        ):
+            raise ValueError("部分计划缺少干员技能数据，请刷新干员数据")
+        current = char["skills"][skill_index].get("level") or 0
+        plan = saved.get(key, {})
+        target = plan.get("target_level", 3)
+        if plan.get("status") in ("training", "waiting_collect"):
+            runtime = plan.get("support_runtime") or {}
+            if isinstance(runtime, str):
+                runtime = json.loads(runtime)
+            current = max(current, runtime.get("level") or current + 1)
+        for level in definitions[skill_index].get("levels", [])[current:target]:
+            materials.extend(level.get("materials", []))
+    inventory = {item["id"]: int(item.get("count", 0)) for item in box.get("items", [])}
+    return MaterialBudget(skills, inventory, workshop_formula).calculate(materials)

--- a/arknights_mower/utils/mastery_recommendation.py
+++ b/arknights_mower/utils/mastery_recommendation.py
@@ -188,6 +188,10 @@ def get_mastery_recommendations():
         if count > 0:
             inventory[item_id] = count
 
+    from arknights_mower.data import workshop_formula
+    from arknights_mower.utils.mastery_materials import MaterialBudget
+
+    material_budget = MaterialBudget(skill_data, inventory, workshop_formula)
     operators = []
     skill_name_cache = {}
 
@@ -320,6 +324,7 @@ def get_mastery_recommendations():
                     "remaining_levels": end_stage - start_stage,
                     "total_time": total_time,
                     "full_chain_achievable": full_chain_achievable,
+                    "material_summary": material_budget.calculate(chain_needed_list),
                     "chain_needed_materials": chain_needed_list,
                     "chain_missing_materials": chain_missing_list,
                     "chain_missing_t3": chain_missing_t3,

--- a/arknights_mower/utils/mastery_recommendation.py
+++ b/arknights_mower/utils/mastery_recommendation.py
@@ -376,23 +376,30 @@ def _workshop_lookahead_active(plan):
         return False
 
 
+def _remaining_mastery_materials(plan, recommendation):
+    """Remaining costs through the plan target, excluding an already-paid step."""
+    stages = recommendation.get("stages")
+    if stages is None:
+        return recommendation.get("chain_needed_materials", [])
+    paid_level = 0
+    if plan.get("status") in ("training", "waiting_collect"):
+        runtime = plan.get("support_runtime") or {}
+        if isinstance(runtime, str):
+            runtime = json.loads(runtime)
+        paid_level = runtime.get("level") or recommendation.get("current_level", 0) + 1
+    return [
+        material
+        for stage in stages
+        if paid_level < stage["to_level"] - 7 <= plan.get("target_level", 3)
+        for material in stage.get("needed_materials", [])
+    ]
+
+
 def _workshop_training_reserve(plan, recommendation):
-    """The current training step is already paid; retain subsequent steps' inputs."""
     from collections import defaultdict
 
-    stages = recommendation.get("stages")
-    materials = (
-        [
-            material
-            for stage in stages[1:]
-            if stage["to_level"] - 7 <= plan.get("target_level", 3)
-            for material in stage.get("needed_materials", [])
-        ]
-        if stages
-        else recommendation.get("chain_needed_materials", [])
-    )
     reserved = defaultdict(int)
-    for material in materials:
+    for material in _remaining_mastery_materials(plan, recommendation):
         reserved[material["name"]] += material["count"]
     return reserved
 
@@ -506,7 +513,10 @@ def compute_workshop_config(
         reserved = _workshop_training_reserve(current, current_rec)
 
     raw_demand = defaultdict(int)
-    for mat in recommendations.get(plan_key, {}).get("chain_needed_materials", []):
+    selected_rec = recommendations.get(plan_key)
+    if selected_rec is None:
+        return []
+    for mat in _remaining_mastery_materials(selected, selected_rec):
         raw_demand[mat["name"]] += mat["count"]
 
     demand_t5_raw = {n: c for n, c in raw_demand.items() if n in t5_names}
@@ -533,6 +543,35 @@ def compute_workshop_config(
         return max(
             0, inventory.get(id_by_name.get(name, ""), 0) - reserved.get(name, 0)
         )
+
+    from arknights_mower.utils.mastery_materials import MaterialBudget
+    from arknights_mower.utils.workshop_material_policy import (
+        protected_workshop_materials,
+    )
+
+    budget = MaterialBudget(
+        skill_data,
+        inventory,
+        workshop_formula,
+        blocked_materials=protected_workshop_materials(),
+    )
+    summary = budget.calculate(
+        [
+            {
+                "id": id_by_name.get(name, name),
+                "count": raw_demand.get(name, 0) + reserved.get(name, 0),
+            }
+            for name in raw_demand.keys() | reserved.keys()
+        ]
+    )
+    if not summary["craftable"]:
+        from arknights_mower.utils.log import logger
+
+        logger.info(
+            f"专精计划 {selected['char_id']} 技能{selected['skill_index'] + 1} "
+            "材料仍不足，暂不合成，等待后续仓库扫描"
+        )
+        return []
 
     t4_indirect = defaultdict(int)
     for t5_name, t5_demand in demand_t5_raw.items():
@@ -705,7 +744,7 @@ def auto_schedule_mastery_tasks():
     # 的孤儿文件，只靠它的话新装/绕过前端新增的计划永远不在 plan_set，扫描自动开始失效。
     from arknights_mower.utils.mastery_db import get_all_plans
 
-    plan_set = {(p["char_id"], p["skill_index"]) for p in get_all_plans()}
+    plan_set = {(p["char_id"], p["skill_index"]): p for p in get_all_plans()}
     if not plan_set:
         return result
 
@@ -743,14 +782,20 @@ def auto_schedule_mastery_tasks():
         for rec in op.get("recommendations", []):
             if (op["char_id"], rec["skill_index"]) not in plan_set:
                 continue
-            if rec.get("current_level", 0) >= 3:
+            plan = plan_set[(op["char_id"], rec["skill_index"])]
+            if rec.get("current_level", 0) >= plan.get("target_level", 3):
                 continue
 
+            from collections import Counter
+
+            needed = Counter()
+            for mat in _remaining_mastery_materials(plan, rec):
+                needed[mat["name"]] += mat["count"]
             all_materials_sufficient = True
-            for mat in rec.get("chain_needed_materials", []):
-                mat_id = name_to_id.get(mat["name"], "")
+            for name, count in needed.items():
+                mat_id = name_to_id.get(name, "")
                 owned = inventory.get(mat_id, 0)
-                if owned < mat["count"]:
+                if owned < count:
                     all_materials_sufficient = False
                     break
 

--- a/arknights_mower/utils/mastery_recommendation.py
+++ b/arknights_mower/utils/mastery_recommendation.py
@@ -190,8 +190,16 @@ def get_mastery_recommendations():
 
     from arknights_mower.data import workshop_formula
     from arknights_mower.utils.mastery_materials import MaterialBudget
+    from arknights_mower.utils.workshop_material_policy import (
+        protected_workshop_materials,
+    )
 
-    material_budget = MaterialBudget(skill_data, inventory, workshop_formula)
+    material_budget = MaterialBudget(
+        skill_data,
+        inventory,
+        workshop_formula,
+        blocked_materials=protected_workshop_materials(),
+    )
     operators = []
     skill_name_cache = {}
 

--- a/arknights_mower/utils/workshop_allocation.py
+++ b/arknights_mower/utils/workshop_allocation.py
@@ -1,5 +1,6 @@
 """Allocate recipe tasks and sort scoped copies of saved workshop settings."""
 
+from arknights_mower.utils.workshop_material_policy import protected_workshop_materials
 from arknights_mower.utils.workshop_recipes import (
     T4_PREFERRED,
     exclusive_specialists,
@@ -37,7 +38,7 @@ def setting_priority(entry, available, formulas):
 
 def scope_setting(entry, formulas):
     name = entry.operator if hasattr(entry, "model_dump") else entry["operator"]
-    if name not in (*T4_PREFERRED, "莱伊"):
+    if not protected_workshop_materials() and name not in (*T4_PREFERRED, "莱伊"):
         return entry
     items = scope_workshop_items(
         name, entry.items if hasattr(entry, "model_dump") else entry["items"], formulas

--- a/arknights_mower/utils/workshop_limits.py
+++ b/arknights_mower/utils/workshop_limits.py
@@ -4,6 +4,8 @@ import json
 from functools import lru_cache
 from pathlib import Path
 
+from arknights_mower.utils.workshop_material_policy import workshop_recipe_allowed
+
 
 @lru_cache(maxsize=1)
 def _bundled_recipes():
@@ -33,6 +35,8 @@ def recipe_quantities(name, metadata):
 
 
 def batch_limit(name, metadata, setting, inventory):
+    if not workshop_recipe_allowed(metadata):
+        return 0
     quantities = recipe_quantities(name, metadata)
     if quantities is None:
         return 0

--- a/arknights_mower/utils/workshop_material_policy.py
+++ b/arknights_mower/utils/workshop_material_policy.py
@@ -1,0 +1,18 @@
+"""User-selected ingredients that workshop crafting must preserve."""
+
+PROTECTED_T2_MATERIALS = frozenset({"装置", "固源岩"})
+
+
+def protected_workshop_materials():
+    from arknights_mower.utils import config
+
+    if getattr(config.conf, "workshop_protect_t2_device_rock", False):
+        return PROTECTED_T2_MATERIALS
+    return frozenset()
+
+
+def workshop_recipe_allowed(recipe, protected=None):
+    if protected is None:
+        protected = protected_workshop_materials()
+    ingredients = set(recipe.get("items", [])) | set(recipe.get("costs", {}))
+    return not protected.intersection(ingredients)

--- a/arknights_mower/utils/workshop_recipes.py
+++ b/arknights_mower/utils/workshop_recipes.py
@@ -5,6 +5,10 @@ from functools import lru_cache
 from pathlib import Path
 
 from arknights_mower.utils.workshop_data import unlocked
+from arknights_mower.utils.workshop_material_policy import (
+    protected_workshop_materials,
+    workshop_recipe_allowed,
+)
 
 T4_PREFERRED = ("九色鹿", "蚀清")
 
@@ -27,7 +31,8 @@ def operator_recipe_allowed(name, recipe, *, fodder=False):
 
 def scope_workshop_items(name, items, formulas=None):
     """Filter saved tasks too; copy changed items without altering user settings."""
-    if name not in (*T4_PREFERRED, "莱伊"):
+    protected = protected_workshop_materials()
+    if not protected and name not in (*T4_PREFERRED, "莱伊"):
         return list(items)
     if formulas is None:
         from arknights_mower.data import workshop_formula
@@ -40,6 +45,7 @@ def scope_workshop_items(name, items, formulas=None):
             material
             for material in data["item_names"]
             if operator_recipe_allowed(name, formulas.get(material, {}), fodder=True)
+            and workshop_recipe_allowed(formulas.get(material, {}), protected)
         ]
         if materials:
             result.append(

--- a/server.py
+++ b/server.py
@@ -2176,141 +2176,17 @@ def workshop_auto_config():
 
 @app.route("/mastery-t3-summary", methods=["POST"])
 def mastery_t3_summary():
-    import json as _json
-    from collections import defaultdict
-
-    from arknights_mower.data import workshop_formula
-    from arknights_mower.utils.mastery_recommendation import (
-        _find_skill_data,
-        get_mastery_recommendations,
-    )
+    from arknights_mower.utils.mastery_materials import plan_material_summary
 
     req = request.json or {}
-    planned_keys = req.get("planned_skills", [])
-    if not planned_keys:
-        return {"t3_summary": []}
-
-    skill_data_path = _find_skill_data()
-    with open(skill_data_path, "r", encoding="utf-8") as f:
-        skill_data = _json.load(f)
-    items = skill_data.get("items", {})
-
-    t4_names = {
-        n
-        for n, e in workshop_formula.items()
-        if e.get("tab") == "精英材料" and e.get("apCost") == 4.0
-    }
-    t5_names = {
-        n: e
-        for n, e in workshop_formula.items()
-        if e.get("tab") == "精英材料" and e.get("apCost") == 8.0
-    }
-
-    result = get_mastery_recommendations()
-    operators = result.get("operators", [])
-
-    plan_set = set()
-    for key in planned_keys:
-        parts = key.rsplit("_", 1)
-        if len(parts) == 2:
-            try:
-                plan_set.add((parts[0], int(parts[1])))
-            except ValueError:
-                pass
-
-    # 步骤1: 读取计划内所有需求材料
-    raw_demand = defaultdict(int)
-    for op in operators:
-        for rec in op.get("recommendations", []):
-            if (op["char_id"], rec["skill_index"]) not in plan_set:
-                continue
-            for mat in rec.get("chain_needed_materials", []):
-                raw_demand[mat["name"]] += mat["count"]
-
-    # 加载仓库库存
-    cultivate_path = get_path("@app/tmp/cultivate.json")
-    inventory = defaultdict(int)
-    if os.path.exists(cultivate_path):
-        with open(cultivate_path, "r", encoding="utf-8") as f:
-            cdata = _json.load(f)
-        for item in cdata.get("data", {}).get("items", []):
-            cnt = int(item.get("count", 0))
-            if cnt > 0:
-                inventory[item.get("id", "")] = cnt
-
-    id_by_name = {}
-    for iid, info in items.items():
-        id_by_name[info.get("name", "")] = iid
-
-    def inv_of(name):
-        return inventory.get(id_by_name.get(name, ""), 0)
-
-    # 步骤2: 分类 T5 / T4 / T3+
-    demand_t5 = {n: c for n, c in raw_demand.items() if n in t5_names}
-    demand_t4 = {n: c for n, c in raw_demand.items() if n in t4_names}
-    demand_t3 = {
-        n: c for n, c in raw_demand.items() if n not in t4_names and n not in t5_names
-    }
-
-    # 步骤3: T5缺失 → 拆解为T4间接缺失
-    t4_indirect = defaultdict(int)
-    for t5_name, t5_demand in demand_t5.items():
-        t5_missing = max(0, t5_demand - inv_of(t5_name))
-        formula = t5_names.get(t5_name, {})
-        for child in formula.get("items", []):
-            if child in t4_names:
-                t4_indirect[child] += t5_missing
-
-    # 步骤4: T4总需 = T4直接 + T4间接; T4缺失 = T4总需 - T4库存
-    t4_total = defaultdict(int)
-    for name in set(list(demand_t4.keys()) + list(t4_indirect.keys())):
-        t4_total[name] = demand_t4.get(name, 0) + t4_indirect.get(name, 0)
-
-    t4_missing_entries = []
-    for name, demand in t4_total.items():
-        missing = max(0, demand - inv_of(name))
-        if missing > 0:
-            t4_missing_entries.append((name, missing))
-
-    # 步骤5: T4缺失 → 拆解为T3间接缺失（只拆到T3层级）
-    t3_indirect = defaultdict(int)
-    queue = list(t4_missing_entries)
-    while queue:
-        name, cnt = queue.pop(0)
-        formula = workshop_formula.get(name)
-        if not formula or not formula.get("items"):
-            t3_indirect[name] += cnt
-            continue
-        is_high = name in t4_names or name in t5_names
-        if not is_high:
-            t3_indirect[name] += cnt
-            continue
-        for child in formula["items"]:
-            queue.append((child, cnt))
-
-    # 步骤6: T3总需 = T3直接 + T3间接; T3缺失 = T3总需 - T3库存
-    t3_total = defaultdict(int)
-    for name, count in demand_t3.items():
-        t3_total[name] += count
-    for name, count in t3_indirect.items():
-        t3_total[name] += count
-
-    t3_summary = []
-    for name, need in sorted(t3_total.items(), key=lambda x: -x[1]):
-        owned = inv_of(name)
-        shortage = max(0, need - owned)
-        if shortage > 0:
-            t3_summary.append(
-                {
-                    "id": id_by_name.get(name, name),
-                    "name": name,
-                    "count": shortage,
-                    "total": need,
-                    "owned": owned,
-                }
-            )
-
-    return {"t3_summary": t3_summary}
+    keys = req.get("planned_skills", [])
+    if not isinstance(keys, list) or any(not isinstance(key, str) for key in keys):
+        return {"error": "计划格式错误"}, 400
+    try:
+        summary = plan_material_summary(keys)
+    except (OSError, ValueError, TypeError, KeyError) as exc:
+        return {"error": f"无法计算材料，请刷新干员数据：{exc}"}, 400
+    return {"material_summary": summary, "t3_summary": summary["missing"]}
 
 
 @app.route("/mastery-t3-debug", methods=["POST"])

--- a/ui/src/components/MasteryMaterials.vue
+++ b/ui/src/components/MasteryMaterials.vue
@@ -2,7 +2,7 @@
   <div v-if="summary" class="mastery-materials">
     <n-space align="center" justify="space-between" :size="8">
       <n-text strong>{{ title }}</n-text>
-      <n-tag :type="summary.craftable ? 'success' : 'error'" size="small" :bordered="false">
+      <n-tag :type="materialStatusType(summary)" size="small" :bordered="false">
         {{ materialStatus(summary) }}
       </n-tag>
     </n-space>
@@ -22,7 +22,7 @@
           <n-avatar :src="'/depot/' + material.name + '.webp'" :size="28" :bordered="false" />
           <div>
             <div>{{ material.name }}</div>
-            <n-text :type="material.owned < material.required ? 'error' : undefined">
+            <n-text :type="materialQuantityType(material)">
               {{ material.owned }} / {{ material.required }}
             </n-text>
           </div>
@@ -41,7 +41,7 @@
                 <n-avatar :src="'/depot/' + material.name + '.webp'" :size="24" :bordered="false" />
                 <div>
                   <div>{{ material.name }}</div>
-                  <n-text :type="material.owned < material.required ? 'error' : undefined">
+                  <n-text :type="materialQuantityType(material)">
                     {{ material.owned }} / {{ material.required }}
                   </n-text>
                 </div>
@@ -72,7 +72,7 @@
 
 <script setup>
 import { computed } from 'vue'
-import { materialStatus } from '@/utils/masteryMaterials'
+import { materialStatus, materialStatusType, materialQuantityType } from '@/utils/masteryMaterials'
 
 const props = defineProps({
   summary: Object,

--- a/ui/src/components/MasteryMaterials.vue
+++ b/ui/src/components/MasteryMaterials.vue
@@ -1,0 +1,115 @@
+<template>
+  <div v-if="summary" class="mastery-materials">
+    <n-space align="center" justify="space-between" :size="8">
+      <n-text strong>{{ title }}</n-text>
+      <n-tag :type="summary.craftable ? 'success' : 'warning'" size="small" :bordered="false">
+        {{ materialStatus(summary) }}
+      </n-tag>
+    </n-space>
+    <n-text v-if="!summary.materials.length" depth="3">无需继续准备材料</n-text>
+    <template v-else>
+      <n-text depth="3" class="inventory-hint">数量：库存 / 需要</n-text>
+      <div class="material-grid">
+        <div v-for="material in summary.materials" :key="material.id" class="material-row">
+          <n-avatar :src="'/depot/' + material.name + '.webp'" :size="28" :bordered="false" />
+          <div>
+            <div>{{ material.name }}</div>
+            <n-text :type="material.owned >= material.required ? 'success' : 'warning'">
+              {{ material.owned }} / {{ material.required }}
+            </n-text>
+          </div>
+        </div>
+      </div>
+      <n-collapse
+        v-if="expandCrafting && summary.crafting.length"
+        :default-expanded-names="['materials']"
+        class="crafting-details"
+      >
+        <n-collapse-item title="逐级合成材料" name="materials">
+          <section v-for="group in craftingGroups" :key="group.label" class="crafting-tier">
+            <n-text depth="3" class="inventory-hint">{{ group.label }}</n-text>
+            <div class="material-grid">
+              <div v-for="material in group.materials" :key="material.id" class="material-row">
+                <n-avatar :src="'/depot/' + material.name + '.webp'" :size="24" :bordered="false" />
+                <div>
+                  <div>{{ material.name }}</div>
+                  <n-text :type="material.owned >= material.required ? 'success' : 'warning'">
+                    {{ material.owned }} / {{ material.required }}
+                  </n-text>
+                </div>
+              </div>
+            </div>
+          </section>
+        </n-collapse-item>
+      </n-collapse>
+      <div v-if="blueMissing.length" class="missing-materials">
+        <n-text type="warning">仍缺蓝材料（T3）</n-text>
+        <n-space :size="4" wrap>
+          <n-tag v-for="material in blueMissing" :key="material.id" size="small" type="warning">
+            {{ material.name }} ×{{ material.count }}
+          </n-tag>
+        </n-space>
+      </div>
+      <div v-if="otherMissing.length" class="missing-materials">
+        <n-text type="warning">其他缺少材料</n-text>
+        <n-space :size="4" wrap>
+          <n-tag v-for="material in otherMissing" :key="material.id" size="small" type="warning">
+            {{ material.name }} ×{{ material.count }}
+          </n-tag>
+        </n-space>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { materialStatus } from '@/utils/masteryMaterials'
+
+const props = defineProps({
+  summary: Object,
+  expandCrafting: Boolean,
+  title: { type: String, default: '材料消耗与库存' }
+})
+const craftingGroups = computed(() => {
+  const groups = new Map()
+  for (const material of props.summary?.crafting || []) {
+    const label = material.id.startsWith('330') ? '技巧概要' : `T${material.rarity} 材料`
+    if (!groups.has(label)) groups.set(label, { label, rarity: material.rarity, materials: [] })
+    groups.get(label).materials.push(material)
+  }
+  return [...groups.values()].sort((a, b) => b.rarity - a.rarity)
+})
+const blueMissing = computed(() => props.summary?.missing.filter((item) => item.blue) || [])
+const otherMissing = computed(() => props.summary?.missing.filter((item) => !item.blue) || [])
+</script>
+
+<style scoped>
+.mastery-materials {
+  font-variant-numeric: tabular-nums;
+}
+.inventory-hint {
+  display: block;
+  margin: 8px 0;
+  font-size: 12px;
+}
+.material-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px 16px;
+}
+.material-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+.crafting-details,
+.missing-materials {
+  margin-top: 12px;
+}
+.missing-materials > :first-child {
+  display: block;
+  margin-bottom: 6px;
+}
+</style>

--- a/ui/src/components/MasteryMaterials.vue
+++ b/ui/src/components/MasteryMaterials.vue
@@ -2,19 +2,27 @@
   <div v-if="summary" class="mastery-materials">
     <n-space align="center" justify="space-between" :size="8">
       <n-text strong>{{ title }}</n-text>
-      <n-tag :type="summary.craftable ? 'success' : 'warning'" size="small" :bordered="false">
+      <n-tag :type="summary.craftable ? 'success' : 'error'" size="small" :bordered="false">
         {{ materialStatus(summary) }}
       </n-tag>
     </n-space>
     <n-text v-if="!summary.materials.length" depth="3">无需继续准备材料</n-text>
     <template v-else>
+      <div v-if="missingSkills.length" class="missing-materials">
+        <n-text type="error">缺料技能</n-text>
+        <n-space :size="4" wrap>
+          <n-tag v-for="skill in missingSkills" :key="skill.key" size="small" type="error">
+            {{ skill.name }} {{ skill.skill_name }}
+          </n-tag>
+        </n-space>
+      </div>
       <n-text depth="3" class="inventory-hint">数量：库存 / 需要</n-text>
       <div class="material-grid">
         <div v-for="material in summary.materials" :key="material.id" class="material-row">
           <n-avatar :src="'/depot/' + material.name + '.webp'" :size="28" :bordered="false" />
           <div>
             <div>{{ material.name }}</div>
-            <n-text :type="material.owned >= material.required ? 'success' : 'warning'">
+            <n-text :type="material.owned < material.required ? 'error' : undefined">
               {{ material.owned }} / {{ material.required }}
             </n-text>
           </div>
@@ -33,7 +41,7 @@
                 <n-avatar :src="'/depot/' + material.name + '.webp'" :size="24" :bordered="false" />
                 <div>
                   <div>{{ material.name }}</div>
-                  <n-text :type="material.owned >= material.required ? 'success' : 'warning'">
+                  <n-text :type="material.owned < material.required ? 'error' : undefined">
                     {{ material.owned }} / {{ material.required }}
                   </n-text>
                 </div>
@@ -43,17 +51,17 @@
         </n-collapse-item>
       </n-collapse>
       <div v-if="blueMissing.length" class="missing-materials">
-        <n-text type="warning">仍缺蓝材料（T3）</n-text>
+        <n-text type="error">仍缺蓝材料（T3）</n-text>
         <n-space :size="4" wrap>
-          <n-tag v-for="material in blueMissing" :key="material.id" size="small" type="warning">
+          <n-tag v-for="material in blueMissing" :key="material.id" size="small" type="error">
             {{ material.name }} ×{{ material.count }}
           </n-tag>
         </n-space>
       </div>
       <div v-if="otherMissing.length" class="missing-materials">
-        <n-text type="warning">其他缺少材料</n-text>
+        <n-text type="error">其他缺少材料</n-text>
         <n-space :size="4" wrap>
-          <n-tag v-for="material in otherMissing" :key="material.id" size="small" type="warning">
+          <n-tag v-for="material in otherMissing" :key="material.id" size="small" type="error">
             {{ material.name }} ×{{ material.count }}
           </n-tag>
         </n-space>
@@ -69,6 +77,7 @@ import { materialStatus } from '@/utils/masteryMaterials'
 const props = defineProps({
   summary: Object,
   expandCrafting: Boolean,
+  missingSkills: { type: Array, default: () => [] },
   title: { type: String, default: '材料消耗与库存' }
 })
 const craftingGroups = computed(() => {

--- a/ui/src/pages/MasteryRecommendation.vue
+++ b/ui/src/pages/MasteryRecommendation.vue
@@ -503,6 +503,19 @@
             </help-text>
           </n-space>
         </n-space>
+        <n-space align="center" :size="6">
+          <n-switch
+            :value="workshopProtectT2"
+            :disabled="workshopPolicySaving"
+            @update:value="setWorkshopMaterialPolicy"
+            size="small"
+            aria-label="不使用装置/固源岩进行合成"
+          />
+          <n-text>不使用装置/固源岩进行合成</n-text>
+          <help-text>
+            仅保留 T2 装置、固源岩，其他等级照常合成。开启后，材料预算也不使用这两种原料。
+          </help-text>
+        </n-space>
         <div>
           <n-text depth="3">非 T5 材料加工干员</n-text>
           <help-text>九色鹿使用下方独立设置中的垫刀素材。</help-text>
@@ -675,11 +688,26 @@ const idleFilterOptions = [
 const {
   workshop_min_bonus: workshopMinBonus,
   workshop_low_priority_rest: workshopLowPriorityRest,
+  workshop_protect_t2_device_rock: workshopProtectT2,
   workshop_deer_fodder: deerFodder,
   fodder_operators: fodderOps,
   t5_operators: t5Ops,
   book_operators: bookOps
 } = storeToRefs(configStore)
+const workshopPolicySaving = ref(false)
+async function setWorkshopMaterialPolicy(value) {
+  workshopProtectT2.value = value
+  workshopPolicySaving.value = true
+  try {
+    await configStore.save_config()
+    await store.fetchRecommendations()
+    await refreshT3Summary()
+  } catch (error) {
+    message.error(`合成设置保存失败：${error.message || error}`)
+  } finally {
+    workshopPolicySaving.value = false
+  }
+}
 const workshopLoading = ref(false)
 const showWorkshopSettings = ref(false)
 const workshopRecommendations = ref(null)

--- a/ui/src/pages/MasteryRecommendation.vue
+++ b/ui/src/pages/MasteryRecommendation.vue
@@ -81,8 +81,7 @@
         style="min-width: 100px"
       />
       <n-checkbox v-model:checked="showOnlyPlanned">只看计划</n-checkbox>
-      <n-checkbox v-model:checked="filterAchievable">材料充足</n-checkbox>
-      <n-checkbox v-model:checked="decomposeT3">缺料拆解为T3</n-checkbox>
+      <n-checkbox v-model:checked="filterAchievable">材料充足或可合成</n-checkbox>
     </n-space>
 
     <n-divider />
@@ -112,18 +111,16 @@
     <n-empty v-else-if="displayList.length === 0" :description="emptyText" />
 
     <div v-else class="mastery-list">
-      <!-- 计划内 T3 缺料汇总 -->
-      <n-card
-        v-if="plannedT3Summary.length"
-        size="small"
-        title="计划缺料汇总（T3）"
-        style="margin-bottom: 8px"
-      >
-        <n-space :size="4" wrap>
-          <n-tag v-for="m in plannedT3Summary" :key="m.id" type="warning" size="small">
-            {{ m.name }} x{{ m.count }}
-          </n-tag>
-        </n-space>
+      <n-card v-if="planEntries.length" size="small" style="margin-bottom: 12px">
+        <n-spin :show="materialsLoading">
+          <n-alert v-if="materialsError" type="warning">{{ materialsError }}</n-alert>
+          <MasteryMaterials
+            v-else
+            :summary="planMaterials"
+            expand-crafting
+            title="计划剩余总材料消耗"
+          />
+        </n-spin>
       </n-card>
 
       <n-collapse accordion>
@@ -169,8 +166,11 @@
                     >
                   </n-space>
                   <n-space :size="4">
-                    <n-tag :type="rec.full_chain_achievable ? 'success' : 'warning'" size="small">
-                      {{ rec.full_chain_achievable ? '材料充足' : '材料不足' }}
+                    <n-tag
+                      :type="rec.material_summary?.craftable ? 'success' : 'warning'"
+                      size="small"
+                    >
+                      {{ materialStatus(rec.material_summary) }}
                     </n-tag>
                     <n-button
                       size="tiny"
@@ -196,48 +196,7 @@
                   >总训练时间: {{ formatTime(rec.total_time) }} |
                   {{ rec.remaining_levels }}级专精</n-text
                 >
-                <n-text depth="3" class="section-label">所需材料:</n-text>
-                <n-grid :x-gap="8" :y-gap="4" cols="3 m:4 l:5 xl:6" responsive="screen">
-                  <n-gi v-for="mat in rec.chain_needed_materials" :key="mat.id">
-                    <n-thing>
-                      <template #avatar>
-                        <n-avatar
-                          :src="'/depot/' + mat.name + '.webp'"
-                          :size="24"
-                          fallback-src="/depot/源岩.webp"
-                        />
-                      </template>
-                      <template #header>
-                        <n-text :depth="chainHas(rec, mat.id) ? 1 : 3" style="font-size: 11px">{{
-                          mat.name
-                        }}</n-text>
-                      </template>
-                      <template #description>
-                        <n-text
-                          :type="chainHas(rec, mat.id) ? 'success' : 'error'"
-                          style="font-size: 11px"
-                          >x{{ mat.count }}</n-text
-                        >
-                      </template>
-                    </n-thing>
-                  </n-gi>
-                </n-grid>
-                <div v-if="currentMissing(rec).length" class="missing-section">
-                  <n-text depth="3" type="error" style="font-size: 11px"
-                    >缺少{{ decomposeT3 ? '(T3拆解)' : '' }}:</n-text
-                  >
-                  <n-space :size="2">
-                    <n-tag v-for="m in currentMissing(rec)" :key="m.id" type="error" size="small">
-                      {{ m.name }}x{{ decomposeT3 ? m.count : m.count }}
-                      <n-text
-                        v-if="decomposeT3 && m.total"
-                        depth="3"
-                        style="font-size: 10px; margin-left: 2px"
-                        >(需{{ m.total }}有{{ m.owned }})</n-text
-                      >
-                    </n-tag>
-                  </n-space>
-                </div>
+                <MasteryMaterials :summary="rec.material_summary" />
               </n-space>
             </n-card>
           </div>
@@ -273,20 +232,7 @@
           trainingWarning(cd.op?.name)
         }}</n-text>
         <n-divider />
-        <n-text :type="cd.rec?.full_chain_achievable ? 'success' : 'warning'"
-          >材料: {{ cd.rec?.full_chain_achievable ? '充足 ✓' : '不足 ✗' }}</n-text
-        >
-        <n-text v-if="currentMissing(cd.rec).length" style="margin-top: 4px">
-          缺少:
-          <n-tag
-            v-for="m in currentMissing(cd.rec)"
-            :key="m.id"
-            type="error"
-            size="small"
-            style="margin-left: 4px"
-            >{{ m.name }}x{{ m.count }}</n-tag
-          >
-        </n-text>
+        <MasteryMaterials :summary="cd.rec?.material_summary" />
       </n-space>
       <template #footer>
         <n-space justify="end">
@@ -440,6 +386,7 @@
       preset="card"
       title="专精计划"
       style="width: min(600px, 95vw)"
+      content-style="max-height: 75vh; overflow-y: auto"
       :mask-closable="false"
       @update:show="onPlanModalShow"
     >
@@ -468,6 +415,17 @@
           </template>
         </draggable>
         <n-text v-if="!planEntries.length" depth="3">未添加计划</n-text>
+        <n-card v-if="planEntries.length" size="small">
+          <n-spin :show="materialsLoading">
+            <n-alert v-if="materialsError" type="warning">{{ materialsError }}</n-alert>
+            <MasteryMaterials
+              v-else
+              :summary="planMaterials"
+              expand-crafting
+              title="计划剩余总材料消耗"
+            />
+          </n-spin>
+        </n-card>
         <n-divider />
         <n-scrollbar style="max-height: 50vh">
           <div v-for="op in filteredPlanOperators" :key="op.char_id" class="plan-op-row">
@@ -630,7 +588,9 @@ import {
   workshopTraineeWarning
 } from '@/utils/workshopOperators'
 import { masteryScheduleContext, masteryTraineeWarning } from '@/utils/masterySupport'
-import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
+import MasteryMaterials from '@/components/MasteryMaterials.vue'
+import { materialStatus } from '@/utils/masteryMaterials'
 import {
   NAlert,
   NAvatar,
@@ -715,7 +675,6 @@ const filterRarity = ref([])
 const filterProfession = ref([])
 const filterAchievable = ref(false)
 const showOnlyPlanned = ref(false)
-const decomposeT3 = ref(false)
 // 空闲状态三态：all=全部 idle=空闲 busy=非空闲
 const idleFilter = ref('all')
 const idleFilterOptions = [
@@ -848,8 +807,35 @@ function getStatusType(status) {
   return map[status] || 'default'
 }
 
+async function warnMaterialShortage(additions) {
+  const keys = [
+    ...new Set([...Object.keys(plan.value).filter((key) => plan.value[key]), ...additions])
+  ]
+  try {
+    const response = await axios.post(
+      `${import.meta.env.VITE_HTTP_URL}/mastery-t3-summary`,
+      {
+        planned_skills: keys
+      },
+      { timeout: 5000 }
+    )
+    const summary = response.data?.material_summary
+    if (!summary) throw new Error('材料数据不可用')
+    if (!summary.available) {
+      message.warning(
+        summary.craftable
+          ? '计划总需求超出成品库存，可由现有材料合成；仍可加入计划。'
+          : '计划总材料不足（含技巧概要），缺口可在专精计划中查看；仍可加入计划。'
+      )
+    }
+  } catch {
+    message.warning('暂时无法核对总材料库存，仍可加入计划，请稍后刷新查看。')
+  }
+}
+
 async function toggleSkillPlan(op, rec, draft = false) {
   const k = planKey(op.char_id, rec.skill_index)
+  if (!plan.value[k]) await warnMaterialShortage([k])
   if (!plan.value[k] && workshopTrainingWarning(op.name)) {
     message.warning(workshopTrainingWarning(op.name))
   }
@@ -907,6 +893,10 @@ async function addAllToPlan(op, draft = false) {
     message.warning(trainingWarning(op.name))
   }
   const recs = op.recommendations
+  const additions = recs
+    .map((rec) => planKey(op.char_id, rec.skill_index))
+    .filter((key) => !plan.value[key])
+  if (additions.length) await warnMaterialShortage(additions)
   if (
     recs.some((rec) => !plan.value[planKey(op.char_id, rec.skill_index)]) &&
     workshopTrainingWarning(op.name)
@@ -1466,7 +1456,7 @@ const displayList = computed(() => {
     list = list
       .map((op) => ({
         ...op,
-        recommendations: op.recommendations.filter((r) => r.full_chain_achievable)
+        recommendations: op.recommendations.filter((r) => r.material_summary?.craftable)
       }))
       .filter((op) => op.recommendations.length > 0)
   return list
@@ -1478,39 +1468,55 @@ function visibleRecs(op) {
   return op.recommendations
 }
 
-const plannedT3Summary = ref([])
+const planMaterials = ref(null)
+const materialsLoading = ref(false)
+const materialsError = ref('')
+let materialRequest = 0
+let materialTimer
 
 async function refreshT3Summary() {
-  const keys = Object.keys(plan.value).filter((k) => plan.value[k])
+  const request = ++materialRequest
+  const keys = Object.keys(plan.value).filter((key) => plan.value[key])
   if (!keys.length) {
-    plannedT3Summary.value = []
+    planMaterials.value = null
+    materialsLoading.value = false
     return
   }
+  materialsLoading.value = true
+  materialsError.value = ''
   try {
-    const r = await axios.post(`${import.meta.env.VITE_HTTP_URL}/mastery-t3-summary`, {
+    const response = await axios.post(`${import.meta.env.VITE_HTTP_URL}/mastery-t3-summary`, {
       planned_skills: keys
     })
-    plannedT3Summary.value = r.data?.t3_summary || []
-  } catch {
-    plannedT3Summary.value = []
+    if (request !== materialRequest) return
+    if (response.data.error) throw new Error(response.data.error)
+    planMaterials.value = response.data.material_summary
+  } catch (error) {
+    if (request === materialRequest) {
+      planMaterials.value = null
+      materialsError.value = error.response?.data?.error || '材料计算失败，请刷新后重试'
+    }
+  } finally {
+    if (request === materialRequest) materialsLoading.value = false
   }
 }
 
 watch(
-  plan,
+  [plan, planStatus, () => store.recommendations],
   () => {
-    if (store.recommendations.length) refreshT3Summary()
+    ++materialRequest
+    clearTimeout(materialTimer)
+    materialsLoading.value = !!Object.values(plan.value).some(Boolean)
+    materialTimer = setTimeout(refreshT3Summary, 200)
   },
   { deep: true }
 )
+onUnmounted(() => {
+  ++materialRequest
+  clearTimeout(materialTimer)
+})
 
 // ─── 工具函数 ───
-function chainHas(rec, matId) {
-  return !rec.chain_missing_materials?.some((m) => m.id === matId)
-}
-function currentMissing(rec) {
-  return decomposeT3.value ? rec.chain_missing_t3 || [] : rec.chain_missing_materials || []
-}
 function formatTime(s) {
   const h = Math.floor(s / 3600),
     m = Math.floor((s % 3600) / 60)
@@ -1541,6 +1547,7 @@ function confirmSkill(op, rec) {
 async function doAddTask() {
   showConfirm.value = false
   const { op, rec } = cd
+  await warnMaterialShortage([planKey(op.char_id, rec.skill_index)])
   if (workshopTrainingWarning(op.name)) message.warning(workshopTrainingWarning(op.name))
   if (trainingWarning(op.name)) message.warning(trainingWarning(op.name))
   try {

--- a/ui/src/pages/MasteryRecommendation.vue
+++ b/ui/src/pages/MasteryRecommendation.vue
@@ -415,17 +415,6 @@
           </template>
         </draggable>
         <n-text v-if="!planEntries.length" depth="3">未添加计划</n-text>
-        <n-card v-if="planEntries.length" size="small">
-          <n-spin :show="materialsLoading">
-            <n-alert v-if="materialsError" type="warning">{{ materialsError }}</n-alert>
-            <MasteryMaterials
-              v-else
-              :summary="planMaterials"
-              expand-crafting
-              title="计划剩余总材料消耗"
-            />
-          </n-spin>
-        </n-card>
         <n-divider />
         <n-scrollbar style="max-height: 50vh">
           <div v-for="op in filteredPlanOperators" :key="op.char_id" class="plan-op-row">
@@ -825,7 +814,7 @@ async function warnMaterialShortage(additions) {
       message.warning(
         summary.craftable
           ? '计划总需求超出成品库存，可由现有材料合成；仍可加入计划。'
-          : '计划总材料不足（含技巧概要），缺口可在专精计划中查看；仍可加入计划。'
+          : '计划总材料不足（含技巧概要），缺口可在主页查看；仍可加入计划。'
       )
     }
   } catch {

--- a/ui/src/pages/MasteryRecommendation.vue
+++ b/ui/src/pages/MasteryRecommendation.vue
@@ -167,10 +167,7 @@
                     >
                   </n-space>
                   <n-space :size="4">
-                    <n-tag
-                      :type="rec.material_summary?.craftable ? 'success' : 'error'"
-                      size="small"
-                    >
+                    <n-tag :type="materialStatusType(rec.material_summary)" size="small">
                       {{ materialStatus(rec.material_summary) }}
                     </n-tag>
                     <n-button
@@ -593,7 +590,7 @@ import {
 import { masteryScheduleContext, masteryTraineeWarning } from '@/utils/masterySupport'
 import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import MasteryMaterials from '@/components/MasteryMaterials.vue'
-import { materialStatus } from '@/utils/masteryMaterials'
+import { materialStatus, materialStatusType } from '@/utils/masteryMaterials'
 import {
   NAlert,
   NAvatar,

--- a/ui/src/pages/MasteryRecommendation.vue
+++ b/ui/src/pages/MasteryRecommendation.vue
@@ -117,6 +117,7 @@
           <MasteryMaterials
             v-else
             :summary="planMaterials"
+            :missing-skills="missingPlanSkills"
             expand-crafting
             title="计划剩余总材料消耗"
           />
@@ -167,7 +168,7 @@
                   </n-space>
                   <n-space :size="4">
                     <n-tag
-                      :type="rec.material_summary?.craftable ? 'success' : 'warning'"
+                      :type="rec.material_summary?.craftable ? 'success' : 'error'"
                       size="small"
                     >
                       {{ materialStatus(rec.material_summary) }}
@@ -1458,6 +1459,10 @@ function visibleRecs(op) {
 }
 
 const planMaterials = ref(null)
+const missingPlanSkills = computed(() => {
+  const keys = new Set(planMaterials.value?.missing_skills || [])
+  return planEntries.value.filter((entry) => keys.has(entry.key))
+})
 const materialsLoading = ref(false)
 const materialsError = ref('')
 let materialRequest = 0
@@ -1465,7 +1470,7 @@ let materialTimer
 
 async function refreshT3Summary() {
   const request = ++materialRequest
-  const keys = Object.keys(plan.value).filter((key) => plan.value[key])
+  const keys = planEntries.value.map((entry) => entry.key)
   if (!keys.length) {
     planMaterials.value = null
     materialsLoading.value = false

--- a/ui/src/stores/config.js
+++ b/ui/src/stores/config.js
@@ -77,6 +77,7 @@ export const useConfigStore = defineStore('config', () => {
   ]
   const workshop_deer_fodder = ref(defaultDeerFodder())
   const workshop_min_bonus = ref(80)
+  const workshop_protect_t2_device_rock = ref(false)
   const workshop_low_priority_rest = ref(true)
   const fodder_operators = ref(['九色鹿'])
   const t5_operators = ref(['年'])
@@ -513,6 +514,7 @@ export const useConfigStore = defineStore('config', () => {
     load_workshop_config(response.data)
     workshop_deer_fodder.value = response.data.workshop_deer_fodder ?? defaultDeerFodder()
     workshop_min_bonus.value = response.data.workshop_min_bonus ?? 80
+    workshop_protect_t2_device_rock.value = response.data.workshop_protect_t2_device_rock ?? false
     workshop_low_priority_rest.value = response.data.workshop_low_priority_rest ?? true
     fodder_operators.value = response.data.fodder_operators || ['九色鹿']
     t5_operators.value = response.data.t5_operators || ['年']
@@ -646,6 +648,7 @@ export const useConfigStore = defineStore('config', () => {
       workshop_manual_settings_revision: workshop_manual_settings_revision.value,
       workshop_deer_fodder: workshop_deer_fodder.value,
       workshop_min_bonus: workshop_min_bonus.value,
+      workshop_protect_t2_device_rock: workshop_protect_t2_device_rock.value,
       workshop_low_priority_rest: workshop_low_priority_rest.value,
       fodder_operators: fodder_operators.value,
       t5_operators: t5_operators.value,
@@ -774,6 +777,7 @@ export const useConfigStore = defineStore('config', () => {
     apply_workshop_response,
     workshop_deer_fodder,
     workshop_min_bonus,
+    workshop_protect_t2_device_rock,
     workshop_low_priority_rest,
     fodder_operators,
     t5_operators,

--- a/ui/src/stores/config.test.js
+++ b/ui/src/stores/config.test.js
@@ -13,6 +13,30 @@ afterEach(() => {
 })
 
 describe('workshop config autosave', () => {
+  it('defaults T2 protection off and saves it without changing manual materials', async () => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    const loaded = ref(false)
+    const app = createApp({})
+    app.use(pinia)
+    app.provide('loaded', loaded)
+    store = app.runWithContext(() => useConfigStore())
+    for (const name of ['reload_room', 'maa_mall_buy', 'maa_mall_blacklist']) store[name] = []
+    expect(store.workshop_protect_t2_device_rock).toBe(false)
+    const manual = [{ operator: '空爆', items: [{ item_names: ['固源岩组', '异铁组'] }] }]
+    store.workshop_manual_settings = manual
+    axios.post.mockResolvedValue({ data: {} })
+    loaded.value = true
+    await vi.waitFor(() => expect(axios.post).toHaveBeenCalledTimes(1))
+    store.workshop_protect_t2_device_rock = true
+    await vi.waitFor(() => expect(axios.post).toHaveBeenCalledTimes(2))
+    expect(axios.post.mock.calls[1][1]).toMatchObject({
+      workshop_protect_t2_device_rock: true,
+      workshop_manual_settings: manual
+    })
+    loaded.value = false
+  })
+
   it('saves turning off crafter recovery priority without changing workshop selections', async () => {
     pinia = createPinia()
     setActivePinia(pinia)

--- a/ui/src/utils/masteryMaterials.js
+++ b/ui/src/utils/masteryMaterials.js
@@ -3,3 +3,14 @@ export function materialStatus(summary) {
   if (summary.available) return '材料充足'
   return summary.craftable ? '可合成' : '材料不足'
 }
+
+export function materialStatusType(summary) {
+  if (!summary) return undefined
+  if (summary.available) return 'success'
+  return summary.craftable ? 'warning' : 'error'
+}
+
+export function materialQuantityType(material) {
+  if (material.owned >= material.required) return undefined
+  return material.craftable ? 'warning' : 'error'
+}

--- a/ui/src/utils/masteryMaterials.js
+++ b/ui/src/utils/masteryMaterials.js
@@ -1,0 +1,5 @@
+export function materialStatus(summary) {
+  if (!summary) return '待计算'
+  if (summary.available) return '材料充足'
+  return summary.craftable ? '可合成' : '材料不足'
+}

--- a/ui/src/utils/masteryMaterials.test.js
+++ b/ui/src/utils/masteryMaterials.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { materialQuantityType, materialStatus, materialStatusType } from './masteryMaterials'
+
+describe('mastery material colors', () => {
+  it.each([
+    [{ available: true, craftable: true }, '材料充足', 'success'],
+    [{ available: false, craftable: true }, '可合成', 'warning'],
+    [{ available: false, craftable: false }, '材料不足', 'error'],
+    [null, '待计算', undefined]
+  ])('keeps the overall status text and color consistent', (summary, label, color) => {
+    expect(materialStatus(summary)).toBe(label)
+    expect(materialStatusType(summary)).toBe(color)
+  })
+
+  it('colors each shortage independently and keeps stocked materials neutral', () => {
+    expect(materialQuantityType({ owned: 2, required: 2, craftable: false })).toBeUndefined()
+    expect(materialQuantityType({ owned: 0, required: 2, craftable: true })).toBe('warning')
+    expect(materialQuantityType({ owned: 0, required: 2, craftable: false })).toBe('error')
+  })
+})


### PR DESCRIPTION
专精主页合并展示所有计划剩余材料消耗与库存，包含技巧概要。多个技能共用库存，成品不足时按 T5 → T4 → T3 逐级展开；低阶材料按实际可完成的合成数量抵扣，T1、T2 消耗不超过库存，最终缺口显示为 T3。

单干员技能页面显示完整材料消耗与「材料充足 / 可合成 / 材料不足」。库存不足但可合成的材料数量和标签使用黄色，合成后仍不足才使用红色，计划总览按计划顺序列出缺料技能；仅缺技巧概要时不列出技能。添加计划前检查合计需求，不足仅提示，仍允许加入。总材料汇总仅放在主页，不放入计划弹窗。

加工站干员设置新增「不使用装置/固源岩进行合成」开关，默认关闭。开启后仅禁止消耗这两种 T2 原料，其他等级正常使用；同时约束自动生成配置、已有配置的实际加工及材料预算，避免用 T1 合成受保护的 T2 后继续计算可合成。切换后刷新预算，保留用户原配置，关闭即可恢复原行为。

自动备料前按该技能的计划目标等级检查剩余材料，扣除已支付的训练档位，并为正在训练的技能预留后续需求。若现有库存经合成仍不能备齐，则不生成该技能的加工任务，也不开始专精，保留计划等待后续扫描确认材料补齐；已有自动加工任务会在配置清理后失效。开始训练仍须成品材料实际齐全。

验证：
- 加工与专精相关后端回归：526 项通过；本次颜色调整后的材料预算相关回归：91 项通过。
- 前端测试：25 个文件、241 项通过。
- Ruff、Prettier、diff 空白检查通过。
- 前端生产构建及资源预压缩通过。

