### PR TITLE
test(mastery): 隔离槽位读取测试的自动专精开关

### DIFF
--- a/arknights_mower/tests/mastery_reader_tests.py
+++ b/arknights_mower/tests/mastery_reader_tests.py
@@ -694,7 +694,8 @@ class TestReadRoomState(unittest.TestCase):
             {"agent": "训练干员", "mood": 15.5678},
         ]
         solver.get_agent_from_room.return_value = scan
-        room, mood = reader.read_room_state(solver, want_mood=True)
+        with patch.object(reader.config.conf, "enable_mastery", True):
+            room, mood = reader.read_room_state(solver, want_mood=True)
         self.assertEqual(room.state, "waiting_collect")
         self.assertEqual(room.support_slot, "支援干员")
         self.assertEqual(room.train_slot, "训练干员")
@@ -709,7 +710,8 @@ class TestReadRoomState(unittest.TestCase):
             {"agent": "训练干员", "mood": 15.5678},
         ]
         solver.get_agent_from_room.return_value = scan
-        room, mood = reader.read_room_state(solver, want_mood=True)
+        with patch.object(reader.config.conf, "enable_mastery", True):
+            room, mood = reader.read_room_state(solver, want_mood=True)
         self.assertEqual(room.state, "training")
         self.assertEqual(room.support_slot, "支援干员")
         self.assertEqual(room.train_slot, "训练干员")


### PR DESCRIPTION
本地配置关闭自动专精时，两项训练室槽位读取测试会返回空槽位并失败；CI 使用默认开启的配置，因此同样的测试能够通过。

在这两项测试调用读取逻辑期间显式开启 enable_mastery，结束后自动恢复原值，使断言不再依赖用户配置。仅修改测试，不调整生产环境的读取行为。

验证：mastery_reader_tests.py 全部 197 项通过；Ruff 和格式检查通过。
