### PR TITLE
fix(workshop): 防止延后的加工任务重复入队

### DIFF
--- a/arknights_mower/tests/workshop_queue_tests.py
+++ b/arknights_mower/tests/workshop_queue_tests.py
@@ -1,0 +1,134 @@
+"""Delayed workshop tasks must not be regenerated on every planning pass."""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from arknights_mower.utils import config, scheduler_task, workshop_automation
+from arknights_mower.utils.config.conf import RIICPart, WorkShopItem
+from arknights_mower.utils.scheduler_task import SchedulerTask, TaskTypes
+
+
+@pytest.fixture
+def queue(monkeypatch):
+    monkeypatch.setattr(config, "conf", config.Conf())
+    monkeypatch.setattr(config.conf, "workshop_auto_active", False)
+    monkeypatch.setattr(workshop_automation, "restore_if_no_plans", lambda: None)
+    settings = [
+        RIICPart.WorkShopSetting(
+            operator=name,
+            items=[WorkShopItem(item_names=["双极纳米片"], upper_limit=10)],
+        )
+        for name in ("年", "泥岩")
+    ]
+    monkeypatch.setattr(config.conf, "workshop_settings", settings)
+    monkeypatch.setattr(scheduler_task, "get_inventory_counts", lambda: {"糖": 100})
+    from arknights_mower.utils import workshop_limits, workshop_recommendation
+
+    monkeypatch.setattr(workshop_limits, "batch_limit", lambda *args: 1)
+    monkeypatch.setattr(
+        workshop_recommendation, "prioritize_workshop_settings", lambda items: items
+    )
+    data = SimpleNamespace(
+        operators={item.operator: SimpleNamespace(mood=24) for item in settings}
+    )
+    return data, []
+
+
+def test_repeated_planning_after_run_order_delay_keeps_one_task_per_operator(queue):
+    data, tasks = queue
+    scheduler_task.try_workshop_tasks(data, tasks)
+    original = list(tasks)
+    for _ in range(5):
+        # 跑单把加工延至五分钟之后，plan_solver 会再次进入加工任务生成。
+        for task in tasks:
+            task.time = datetime.now() + timedelta(minutes=8)
+        scheduler_task.try_workshop_tasks(data, tasks)
+    assert len(tasks) == 2
+    assert all(task is expected for task, expected in zip(tasks, original))
+
+
+def test_real_run_order_scheduler_does_not_cause_repeated_workshop_batches(
+    queue, monkeypatch
+):
+    data, tasks = queue
+    names = [
+        "谬因",
+        "蜜莓",
+        "缇缇",
+        "凯尔希·思衡托",
+        "空爆",
+        "苏苏洛",
+        "莱伊",
+        "锡兰",
+        "陨星",
+    ]
+    template = config.conf.workshop_settings[0]
+    for name in names:
+        config.conf.workshop_settings.append(
+            template.model_copy(update={"operator": name})
+        )
+        data.operators[name] = SimpleNamespace(mood=24)
+    now = datetime.now()
+    tasks.append(
+        SchedulerTask(
+            time=now + timedelta(minutes=8),
+            task_type=TaskTypes.RUN_ORDER,
+            task_plan={"room_2_1": ["但书"]},
+            meta_data="room_2_1",
+        )
+    )
+    monkeypatch.setattr(config.conf, "enable_mastery", False)
+    monkeypatch.setattr(
+        scheduler_task.NewsChecker, "get_update_time", lambda: (None, None)
+    )
+    for _ in range(3):
+        # 与 plan_solver 相同的五分钟入口，以及真实的跑单推迟逻辑。
+        assert scheduler_task.find_next_task(tasks, now + timedelta(minutes=5)) is None
+        scheduler_task.try_workshop_tasks(data, tasks)
+        scheduler_task.scheduling(tasks, time_now=now)
+        pending = [task for task in tasks if task.type == TaskTypes.WORKSHOP]
+        assert len(pending) == 11
+        assert all(task.time > now + timedelta(minutes=5) for task in pending)
+
+
+def test_pending_task_only_blocks_same_operator_and_completion_allows_next_run(queue):
+    data, tasks = queue
+    scheduler_task.try_workshop_tasks(data, tasks)
+    remaining = tasks.pop()
+    tasks[:] = [remaining]
+    scheduler_task.try_workshop_tasks(data, tasks)
+    assert [task.meta_data for task in tasks] == ["泥岩", "年"]
+    assert tasks[0] is remaining
+
+
+def test_duplicate_settings_do_not_create_duplicate_tasks(queue):
+    data, tasks = queue
+    config.conf.workshop_settings *= 2
+    scheduler_task.try_workshop_tasks(data, tasks)
+    assert [task.meta_data for task in tasks] == ["年", "泥岩"]
+
+
+@pytest.mark.parametrize("stale", [False, True])
+def test_only_current_generation_blocks_new_automatic_work(queue, stale):
+    data, tasks = queue
+    config.conf.workshop_auto_active = True
+    config.conf.workshop_generation = 10
+    old = SchedulerTask(task_type=TaskTypes.WORKSHOP, meta_data="年")
+    old.workshop_generation = 9 if stale else 10
+    tasks.append(old)
+    scheduler_task.try_workshop_tasks(data, tasks)
+    assert [t.meta_data for t in tasks] == (
+        ["年", "年", "泥岩"] if stale else ["年", "泥岩"]
+    )
+
+
+def test_non_workshop_task_for_same_operator_does_not_block(queue):
+    data, tasks = queue
+    tasks.append(SchedulerTask(task_type=TaskTypes.RELEASE_DORM, meta_data="年"))
+    scheduler_task.try_workshop_tasks(data, tasks)
+    assert [t.meta_data for t in tasks if t.type == TaskTypes.WORKSHOP] == [
+        "年",
+        "泥岩",
+    ]

--- a/arknights_mower/utils/scheduler_task.py
+++ b/arknights_mower/utils/scheduler_task.py
@@ -619,16 +619,27 @@ def next_workshop_task_time(tasks, earliest=None):
 def try_workshop_tasks(op_data, tasks):
     # 如果没有其他任务则进行加工站干员检查
     from arknights_mower.data import workshop_formula
-    from arknights_mower.utils.workshop_automation import restore_if_no_plans
+    from arknights_mower.utils.workshop_automation import (
+        restore_if_no_plans,
+        workshop_task_current,
+    )
     from arknights_mower.utils.workshop_limits import batch_limit
     from arknights_mower.utils.workshop_recommendation import (
         prioritize_workshop_settings,
     )
 
     restore_if_no_plans()
+    # 跑单/专精换人可能将加工推迟到五分钟之后，不能把它当作没有待办。
+    pending_operators = {
+        task.meta_data
+        for task in tasks
+        if task.type == TaskTypes.WORKSHOP and workshop_task_current(task)
+    }
     inventory_data = get_inventory_counts()
     if config.conf.workshop_settings and inventory_data:
         for item in prioritize_workshop_settings(config.conf.workshop_settings):
+            if item.operator in pending_operators:
+                continue
             if not item.enabled:
                 logger.info(f"{item.operator}加工站任务被禁用，跳过")
                 continue
@@ -685,6 +696,7 @@ def try_workshop_tasks(op_data, tasks):
 
                 stamp_workshop_task(task)
                 tasks.append(task)
+                pending_operators.add(item.operator)
             else:
                 logger.debug("数据不满足条件，跳过加工站任务生成")
     else:


### PR DESCRIPTION
加工任务被跑单或专精换人推迟到五分钟以后时，排班逻辑会再次进入自动加工检查。旧逻辑未检查已有待办，导致同一批干员重复入队，随后逐条执行无材料检查，拖延后续换班。

本次在自动入队前按干员检查全队列中的有效加工任务，不受任务时间影响；同轮重复配置也只生成一次。已完成任务可以再次调度，旧专精配置产生的失效任务不会阻塞新任务。保留已有任务的时间、顺序及手动任务。

验证：42 项加工与调度回归测试通过，包括真实跑单调度推迟 11 名加工干员后反复规划、重复配置、配置代次变更和调度器唤醒；Ruff、格式及 diff 检查通过。修复前新增测试中的 4 项失败，修复后全部通过。本次仅修改后端，无前端构建变更。
