### PR TITLE
fix(schedule): 修复副表切换后提前回班及心情重复扣减

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -1972,6 +1972,13 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     )
                     logger.info(f"新条件列表:{con}")
                     self.op_data.swap_plan(con, refresh=True)
+                    # 回班时间和岗位依赖生效排班；副表可能改变用尽、回满或组员岗位。
+                    # 已生成的宿舍任务不能继续沿用切换前的急救预测。
+                    if any(
+                        task.type in (TaskTypes.SHIFT_ON, TaskTypes.RELEASE_DORM)
+                        for task in self.tasks
+                    ):
+                        self.plan_metadata()
                     if append_empty_task and not new_task:
                         self.tasks.append(SchedulerTask(task_plan={}))
             return new_task
@@ -3509,8 +3516,9 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     update_time = True
                 else:
                     _mood = self.op_data.operators[_name].current_mood()
+                # 估算值只用于本次读数，保留与原采样时间配对的心情，避免重复扣减。
                 high_no_time = self.op_data.update_detail(
-                    _name, _mood, room, i, update_time
+                    _name, _mood if update_time else agent.mood, room, i, update_time
                 )
                 data["depletion_rate"] = agent.depletion_rate
                 if high_no_time is not None and high_no_time not in read_time_index:

--- a/arknights_mower/tests/backup_rest_schedule_tests.py
+++ b/arknights_mower/tests/backup_rest_schedule_tests.py
@@ -1,0 +1,130 @@
+"""副表切换后，回班任务必须使用新排班的耗尽配置和岗位。"""
+
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault("arknights_mower.utils.skland", MagicMock())
+
+from arknights_mower.solvers import base_schedule as base  # noqa: E402
+from arknights_mower.utils import config, operators, scheduler_task  # noqa: E402
+from arknights_mower.utils.logic_expression import LogicExpression  # noqa: E402
+from arknights_mower.utils.plan import (  # noqa: E402
+    Plan,
+    PlanConfig,
+    PlanTriggerTiming,
+    Room,
+)
+from arknights_mower.utils.scheduler_task import SchedulerTask, TaskTypes  # noqa: E402
+
+
+@pytest.fixture
+def solver(monkeypatch):
+    class Clock(datetime):
+        @classmethod
+        def now(cls):
+            return cls(2026, 9, 11, 16, 2, 21)
+
+    for module in (base, operators, scheduler_task):
+        monkeypatch.setattr(module, "datetime", Clock)
+    monkeypatch.setattr(config, "conf", config.Conf())
+    monkeypatch.setattr(config, "save_conf", lambda: None)
+    config.conf.enable_mastery = False
+    instance = object.__new__(base.BaseSchedulerSolver)
+    instance.global_plan = {
+        "default_plan": Plan(
+            {
+                "central": [Room("歌蕾蒂娅", "", ["陈"])],
+                "contact": [Room("黑键", "感知", ["红"])],
+                "dormitory_1": [
+                    Room("塑心", "感知", ["隐德来希"]),
+                    Room("冰酿", "", []),
+                    *[Room("Free", "", []) for _ in range(3)],
+                ],
+            },
+            PlanConfig("", "", ""),
+        ),
+        "backup_plans": [
+            Plan(
+                {},
+                PlanConfig("", "歌蕾蒂娅", ""),
+                trigger=LogicExpression(
+                    "op_data.operators['黑键'].is_resting()", "==", "True"
+                ),
+                trigger_timing="AFTER_PLANNING",
+            )
+        ],
+    }
+    assert instance.initialize_operators() is None
+    monkeypatch.setattr(operators.Operators, "current_room_changed_callback", None)
+    for op in instance.op_data.operators.values():
+        op.current_room, op.current_index = op.room, op.index
+        op.time_stamp = Clock.now()
+        op.mood = 24
+    gladiia = instance.op_data.operators["歌蕾蒂娅"]
+    gladiia.time_stamp = datetime(2026, 9, 11, 15, 35, 45, 810059)
+    gladiia.mood = 3.1665609162721444
+    gladiia.depletion_rate = 3.1050745754008617
+    black_key = instance.op_data.operators["黑键"]
+    black_key.current_room, black_key.current_index = "dormitory_1", 2
+    black_key.mood = 18
+    dorm = instance.op_data.dorm[0]
+    dorm.name, dorm.time = "黑键", datetime(2026, 9, 11, 17, 13, 3)
+    instance.tasks = []
+    instance.task = None
+    instance.find = MagicMock(return_value=True)
+    instance.skip = MagicMock()
+    instance.agent_arrange = MagicMock()  # 设备操作；在岗/休息状态已按下班结果设置。
+    return instance
+
+
+def return_task(solver):
+    return next(t for t in solver.tasks if t.type == TaskTypes.SHIFT_ON)
+
+
+def test_shift_off_recomputes_emergency_return_after_backup_switch(solver):
+    solver.task = SchedulerTask(
+        time=datetime(2026, 9, 11, 16),
+        task_plan={"contact": ["红"]},
+        task_type=TaskTypes.SHIFT_OFF,
+    )
+    solver.tasks = [solver.task]
+    solver.infra_main()
+    assert solver.op_data.operators["歌蕾蒂娅"].exhaust_require
+    assert return_task(solver).time == datetime(2026, 9, 11, 17, 5, 3)
+    assert return_task(solver).plan["dormitory_1"][0] == "塑心"
+    solver.agent_arrange.assert_called_once_with({"contact": ["红"]}, True)
+
+
+@pytest.mark.parametrize("custom_task", [None, {"central": ["Current"]}])
+def test_switch_rebuilds_existing_return_and_preserves_other_tasks(solver, custom_task):
+    solver.op_data.backup_plans[0].task = custom_task
+    solver.plan_metadata()
+    old_task = return_task(solver)
+    assert old_task.time == datetime(2026, 9, 11, 16, 24, 21)
+    depot = SchedulerTask(task_type=TaskTypes.DEPOT)
+    solver.tasks.append(depot)
+    assert solver.backup_plan_solver() == bool(custom_task)
+    assert return_task(solver).time == datetime(2026, 9, 11, 17, 5, 3)
+    assert all(t is not old_task for t in solver.tasks)
+    assert any(t is depot for t in solver.tasks)
+    if custom_task:
+        assert any(t.plan == custom_task for t in solver.tasks)
+
+
+def test_unchanged_or_not_yet_eligible_backup_keeps_return(solver):
+    solver.plan_metadata()
+    original = return_task(solver)
+    solver.backup_plan_solver(PlanTriggerTiming.BEFORE_PLANNING)
+    assert return_task(solver) is original
+    solver.backup_plan_solver()
+    updated = return_task(solver)
+    solver.backup_plan_solver()
+    assert return_task(solver) is updated
+
+
+def test_switch_without_existing_rest_schedule_does_not_create_one(solver):
+    solver.backup_plan_solver()
+    assert all(t.type != TaskTypes.SHIFT_ON for t in solver.tasks)

--- a/arknights_mower/tests/mood_estimate_sampling_tests.py
+++ b/arknights_mower/tests/mood_estimate_sampling_tests.py
@@ -1,0 +1,102 @@
+"""Cached room reads must not turn estimated mood into another measured sample."""
+
+import sys
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+sys.modules.setdefault("arknights_mower.utils.skland", MagicMock())
+
+from arknights_mower.solvers import base_schedule as base  # noqa: E402
+from arknights_mower.solvers import record  # noqa: E402
+from arknights_mower.utils import config, operators  # noqa: E402
+from arknights_mower.utils.plan import Plan, PlanConfig, Room  # noqa: E402
+
+
+@pytest.fixture
+def room_reader(monkeypatch):
+    class Clock(datetime):
+        current = datetime(2026, 9, 11, 12)
+
+        @classmethod
+        def now(cls):
+            return cls.current
+
+    monkeypatch.setattr(base, "datetime", Clock)
+    monkeypatch.setattr(operators, "datetime", Clock)
+    monkeypatch.setattr(config, "conf", config.Conf())
+    monkeypatch.setattr(config, "save_conf", lambda: None)
+    monkeypatch.setattr(record, "_conn", MagicMock())
+    config.conf.enable_mastery = False
+    solver = object.__new__(base.BaseSchedulerSolver)
+    solver.global_plan = {
+        "default_plan": Plan(
+            {
+                "central": [Room("夕", "感知", ["诗怀雅"])],
+                "contact": [Room("絮雨", "感知", ["斥罪"])],
+                "dormitory_1": [
+                    Room("塑心", "感知", ["隐德来希"]),
+                    Room("冰酿", "", []),
+                    *[Room("Free", "", []) for _ in range(3)],
+                ],
+            },
+            PlanConfig("", "", "", ling_xi=1, resting_threshold=0.65),
+        ),
+        "backup_plans": [],
+    }
+    assert solver.initialize_operators() is None
+    monkeypatch.setattr(operators.Operators, "current_room_changed_callback", None)
+    for op in solver.op_data.operators.values():
+        op.current_room, op.current_index = op.room, op.index
+        op.time_stamp = Clock.now() - timedelta(hours=1)
+        op.mood = 24
+    target = solver.op_data.operators["夕"]
+    target.mood, target.depletion_rate = 21, 1
+    solver.tasks = []
+    solver.task = None
+    solver.recog = MagicMock(gray=np.zeros((1080, 1920), dtype=np.uint8))
+    solver.turn_on_room_detail = MagicMock()
+    solver.detect_product_complete = MagicMock(return_value=None)
+    solver.find = MagicMock(return_value=None)
+    solver.read_screen = MagicMock(return_value="夕")
+    solver.read_accurate_mood = MagicMock(return_value=20)
+    solver.double_read_time = MagicMock(return_value=Clock.now() + timedelta(hours=1))
+    solver.plan_metadata = MagicMock()
+    solver.total_agent = [target, solver.op_data.operators["絮雨"]]
+    return solver, target, Clock
+
+
+def test_repeated_cached_reads_do_not_schedule_premature_group_downshift(room_reader):
+    solver, target, clock = room_reader
+    sample_time = target.time_stamp
+    readings = [solver.get_agent_from_room("central")[0]["mood"] for _ in range(3)]
+    solver.resting()
+    assert solver.tasks == []  # 当前 20 高于下班线 19，宿舍成员不应跟着撤下。
+    assert readings == [20, 20, 20]
+    assert (target.mood, target.time_stamp) == (21, sample_time)
+    assert target.current_mood() == 20
+    solver.read_accurate_mood.assert_not_called()
+
+
+def test_elapsed_time_is_deducted_once_across_cached_reads(room_reader):
+    solver, target, clock = room_reader
+    assert solver.get_agent_from_room("central")[0]["mood"] == 20
+    clock.current += timedelta(minutes=30)
+    assert solver.get_agent_from_room("central")[0]["mood"] == 19.5
+    assert target.current_mood() == 19.5
+    assert target.predict_exhaust() == datetime(2026, 9, 11, 19, 30)
+
+
+def test_real_read_still_updates_sample_and_depletion_from_measurements(room_reader):
+    solver, target, clock = room_reader
+    sample_time = target.time_stamp
+    solver.get_agent_from_room("central")
+    solver.read_accurate_mood.return_value = 19.5
+    result = solver.get_agent_from_room("central", read_time_index=[0])
+    assert result[0]["mood"] == 19.5
+    assert target.time_stamp == clock.now() > sample_time
+    assert target.mood == 19.5
+    assert target.depletion_rate == 1.5
+    solver.read_accurate_mood.assert_called_once()


### PR DESCRIPTION
下班后可能先按旧排班的耗尽预测生成提前回班任务，随后副表才把触发急救的干员设为「用尽」。旧任务没有随之重算，导致刚入住宿舍的整组干员只休息约 22 分钟就被召回。另一个缓存读数问题会重复扣除从上次实测到当前的心情消耗，进一步提前下班和耗尽预测。

本次修复：

- 副表条件实际变化后，用新排班重新生成已有的回班、宿舍释放任务，同时保留其他任务及副表自定义任务。没有条件变化时不重复计算。
- 房间读取复用缓存时，返回当前估算心情，但保留原始实测心情及对应时间；下次实测仍以两次实测值校准消耗速度。

验证覆盖真实 `infra_main()`、副表切换、恢复计划生成、房间读取和下班规划，设备操作使用 mock。同一场景旧代码生成 16:24 回班，修复后按宿舍恢复记录生成 17:05 回班；连续读取缓存不会再使心情逐次降低。

相关调度、宿舍绑组、宿舍恢复、心情读取及唤醒测试共 216 项通过，另有 7 个子测试通过；Ruff 检查及格式检查通过。此修复不改变原有急救、回满、提前 8 分钟回班策略。
