### PR TITLE
fix(schedule): 修复宿舍单回重排的职业筛选与失败重选

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -3438,6 +3438,12 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                     ed = ret[0][1][0]  # 终点
                     self.swipe_noinertia(st, (ed[0] - st[0], 0))
                     right_swipe += 1
+        # 重排按完整已选名单的位置点击，不能保留最后一名干员的职业筛选。
+        # 单回暂留名单没有 Free，也必须在重排和校验前恢复全部职业。
+        if last_special_filter != "ALL":
+            self.profession_filter("ALL")
+            last_special_filter = "ALL"
+            right_swipe = 0
         # 排序
         if len(agents) != 1:
             # 左移
@@ -3731,7 +3737,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 )
             )
 
-    def ensure_dorm_recovery_order(self, room, agents):
+    def ensure_dorm_recovery_order(self, room, agents, fast_mode=True):
         """先确认单回目标的入驻顺序，再由原任务恢复完整阵容。
 
         中间名单只用于这次点击，不能覆盖持久化任务中的完整恢复名单。
@@ -3776,7 +3782,9 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                 if attempt == 4:
                     raise Exception("未成功进入干员选择界面")
                 self.ctap((self.recog.w * 0.82, self.recog.h * 0.2))
-            self.choose_agent(retained.copy(), room, preserve_dorm_occupants=True)
+            self.choose_agent(
+                retained.copy(), room, fast_mode, preserve_dorm_occupants=True
+            )
             self.tap_confirm(room, {})
             current = [item["agent"] for item in self.get_agent_from_room(room)]
             if current != expected:
@@ -3905,7 +3913,9 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
                         if plan[room] != self.op_data.get_current_room(room):
                             self.refresh_run_order_time(room)
                 checked = True
-                recovery_ordered = self.ensure_dorm_recovery_order(room, plan[room])
+                recovery_ordered = self.ensure_dorm_recovery_order(
+                    room, plan[room], fast_mode=choose_error <= 0
+                )
                 current_room = self.op_data.get_current_room(room, True)
                 same = len(plan[room]) == len(current_room)
                 if same:

--- a/arknights_mower/tests/choose_agent_filter_tests.py
+++ b/arknights_mower/tests/choose_agent_filter_tests.py
@@ -1,0 +1,123 @@
+"""执行真实选人流程，模拟职业筛选后的可见卡片及点击结果。"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault("arknights_mower.utils.skland", MagicMock())
+
+from arknights_mower.solvers import base_mixin, base_schedule  # noqa: E402
+from arknights_mower.solvers.base_schedule import BaseSchedulerSolver  # noqa: E402
+
+RESIDENTS = ["冰酿", "闪灵", "菲亚梅塔", "爱丽丝"]
+
+
+@pytest.mark.parametrize("fast_mode", [True, False])
+@pytest.mark.parametrize("preserve", [True, False])
+@pytest.mark.parametrize("fill_free", [True, False])
+def test_mixed_professions_reordered_after_filtered_selection(
+    monkeypatch, fast_mode, preserve, fill_free
+):
+    agents = RESIDENTS + ["Free" if fill_free else "伊芙利特"]
+    solver, selected = selection_solver(monkeypatch)
+
+    solver.choose_agent(
+        agents, "dormitory_1", fast_mode, preserve_dorm_occupants=preserve
+    )
+
+    assert selected == RESIDENTS + ["伊芙利特"]
+    assert agents == selected
+    if not fill_free:
+        assert any(
+            call.args == ("CASTER",) for call in solver.profession_filter.call_args_list
+        )
+
+
+def test_single_operator_still_selects_correctly(monkeypatch):
+    solver, selected = selection_solver(monkeypatch, residents=[])
+    solver.choose_agent(["伊芙利特"], "dormitory_1")
+    assert selected == ["伊芙利特"]
+
+
+def test_already_selected_mixed_roster_still_reorders(monkeypatch):
+    current = ["伊芙利特"] + RESIDENTS
+    solver, selected = selection_solver(monkeypatch, residents=current)
+    solver.choose_agent(RESIDENTS + ["伊芙利特"], "dormitory_1")
+    assert selected == RESIDENTS + ["伊芙利特"]
+    solver.scan_agent.assert_not_called()
+
+
+def selection_solver(monkeypatch, residents=None):
+    solver = object.__new__(BaseSchedulerSolver)
+    current = list(RESIDENTS if residents is None else residents)
+    selected = current.copy()
+    cards = current.copy()
+    profession = "ALL"
+    first_scan = True
+    roster = RESIDENTS + ["伊芙利特", "杜林", "妮芙", "特米米", "深靛"]
+    positions = [(672, 378), (672, 810), (864, 378), (864, 810), (1056, 378)]
+    solver.recog = SimpleNamespace(w=1920, h=1080, img=None)
+    solver.op_data = SimpleNamespace(
+        operators={},
+        profession_filter=set(),
+        get_current_room=lambda *args: current.copy(),
+    )
+    solver.last_room = ""
+    solver.choose_error = set()
+    solver.preserve_resting_crafters = MagicMock()
+    solver.get_free_list = MagicMock(return_value=["伊芙利特"])
+    solver.detect_arrange_order = MagicMock(return_value=("技能", False))
+    solver.get_order = MagicMock(return_value=(False, ("心情", "true")))
+    solver.find = MagicMock(return_value=False)
+    solver.sleep = MagicMock()
+    solver.swipe_noinertia = MagicMock()
+
+    def visible(names):
+        return [
+            name
+            for name in names
+            if profession == "ALL" or base_schedule.agent_profession[name] == profession
+        ]
+
+    def set_filter(value=None):
+        nonlocal profession
+        profession = value or "ALL"
+
+    def order(kind, *args):
+        if kind == "技能":
+            cards[:] = visible(selected + [n for n in roster if n not in selected])
+
+    def tap(point, **kwargs):
+        if point[1] == 1026:
+            selected.clear()
+        else:
+            name = cards[positions.index(point)]
+            if name in selected:
+                selected.remove(name)
+            else:
+                selected.append(name)
+
+    def scan(names, max_agent_count=None, **kwargs):
+        nonlocal first_scan
+        # 首屏找不到目标，需要走后续职业筛选分支。
+        found = [] if first_scan else visible(names)
+        first_scan = False
+        if max_agent_count is not None:
+            found = found[:max_agent_count]
+        for name in found:
+            selected.append(name)
+            names.remove(name)
+        return found, [("杜林", ((0, 0), (1, 1)))] * 2
+
+    solver.profession_filter = MagicMock(side_effect=set_filter)
+    solver.switch_arrange_order = MagicMock(side_effect=order)
+    solver.tap = MagicMock(side_effect=tap)
+    solver.scan_agent = MagicMock(side_effect=scan)
+    monkeypatch.setattr(
+        base_mixin,
+        "operator_list",
+        lambda *args, **kwargs: [(name, None) for name in cards],
+    )
+    return solver, selected

--- a/arknights_mower/tests/dorm_recovery_tests.py
+++ b/arknights_mower/tests/dorm_recovery_tests.py
@@ -204,6 +204,27 @@ def test_intermediate_confirmation_failure_keeps_restore_plan_and_no_success_mar
     assert solver.op_data.operators["银灰"].dorm_recovery_room == ""
 
 
+def test_compact_selection_failure_retries_with_full_selection(solver):
+    choose = solver.choose_agent.side_effect
+    modes = []
+
+    def fail_fast_selection(agents, room, fast_mode=True, **kwargs):
+        modes.append(fast_mode)
+        if fast_mode:
+            assert solver.task.plan == {ROOM: FINAL}
+            assert solver.op_data.operators["银灰"].dorm_recovery_room == ""
+            raise RuntimeError("检测到干员选择错误，重新选择")
+        return choose(agents, room, fast_mode, **kwargs)
+
+    solver.choose_agent.side_effect = fail_fast_selection
+    arrange(solver)
+    assert modes == [True, False, False]
+    assert solver.confirms == [["杜林", "琴柳", "银灰", "", ""], FINAL]
+    assert solver.physical == FINAL
+    assert solver.task.plan == {}
+    assert solver.op_data.operators["银灰"].dorm_recovery_room == ROOM
+
+
 def test_read_failure_keeps_restore_plan_then_retry_does_not_clear_twice(solver):
     read = solver.get_agent_from_room.side_effect
     calls = 0


### PR DESCRIPTION
宿舍单回整理补选伊芙利特时，职业筛选停留在“术师”，随后却按完整五人名单的位置清空重选，导致错选并反复报“检测到干员选择错误，重新选择”。没有 `Free` 占位符的暂留名单会触发这一问题。

本 PR 在位置重排及校验前恢复“全部职业”筛选，并同步重置横向滚动计数。单回整理同时继承房间安排的重试模式，首次选人失败后执行完整重选，避免持续复用快速选人。选人失败时仍保留完整恢复名单，确认与识别成功后才记录单回目标。

关联 #1018，补充修复其单回整理流程中暴露的选人问题。

验证：
- 新增测试执行真实 `choose_agent` 与校验逻辑，模拟职业筛选后的可见卡片及点击结果，覆盖原住民补选、完整重选、有无 `Free`、单人选择及已有人员调位。
- 新增单回整理失败后降级完整重选的回归测试。修复前共 5 个用例失败，修复后全部通过。
- 相关回归测试 266 项及 12 个子测试通过，覆盖宿舍绑组、单回整理、休息纠错、候补分床、加工站宿舍及训练室选人。
- Ruff 检查、格式检查及 `git diff --check` 通过。

尚未部署到 alex 远端进行实机验证。
