### PR TITLE
fix(ui): 修复日志版本号被误识别为日期

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -713,7 +713,7 @@ onMounted(async () => {
         relevance: 10
       },
       {
-        begin: /[0-9]+(-[0-9]+)+/,
+        begin: /\b[0-9]{4}-[0-9]{2}-[0-9]{2}\b/,
         className: 'date'
       },
       {


### PR DESCRIPTION
日志日期高亮原先匹配任意“数字-数字”，导致资源版本号 `v2026.09.11-779400f` 中的 `11-779400` 被误识别为日期并显示为橙色。

本 PR 将日期规则收紧为带单词边界的完整 `YYYY-MM-DD` 格式，保留日志时间戳和正文中完整日期的高亮。

验证：

- 使用 PR 中实际注册的 highlight.js 规则验证截图原始日志，版本号保持普通文本，日期、时间和 INFO 等级仍正常高亮。
- 验证数字连字符、日期边界、正文日期及多行日志场景，专项检查全部通过。
- `git diff --check` 通过；相对最新 alpha 仅修改一行日期规则。
- 本地 Prettier 检查发现 alpha 原有 Vue 模板表达式格式差异，基线与本 PR 均有相同告警，本次未调整无关格式。
