### PR TITLE
fix(mastery): 修复原协助者排班误拦截并保护训练室绑组

### DIFF
--- a/arknights_mower/solvers/mastery.py
+++ b/arknights_mower/solvers/mastery.py
@@ -630,6 +630,16 @@ def _start_new_training(solver, plan, arrange_support=True, room=None, step_leve
         get_mastery_requirement_error,
     )
     from arknights_mower.utils.mastery_support import SupportPlanError
+    from arknights_mower.utils.mastery_support_data import training_room_group_error
+
+    group_error = training_room_group_error()
+    if group_error:
+        from arknights_mower.utils.email import send_message
+
+        logger.warning(f"[mastery] 暂不开始训练：{group_error}")
+        update_plan_status(plan["id"], "failed", failed_reason=group_error)
+        send_message(f"{_plan_fail_label(plan)} {group_error}", level="ERROR")
+        return
 
     requirement_error = get_mastery_requirement_error(plan["char_id"])
     if requirement_error:
@@ -1193,6 +1203,15 @@ def run_swap_support(solver):
             logger.debug(f"主面板读取失败: {e}")
     countdown_active = bool(panel is not None and panel.countdown_state == "active")
     step_level = panel.mastery_tier if panel is not None else None
+
+    from arknights_mower.utils.mastery_support_data import training_room_group_error
+
+    if group_error := training_room_group_error():
+        from arknights_mower.solvers.mastery_support_state import stop_support_swap
+
+        stop_support_swap(solver, plan, step_level, group_error)
+        solver.back()
+        return
 
     route = _get_plan_route(plan, step_level)
     operator = route.get("operator") if route else None

--- a/arknights_mower/solvers/mastery_support_runtime.py
+++ b/arknights_mower/solvers/mastery_support_runtime.py
@@ -9,7 +9,6 @@ from arknights_mower.utils.mastery_support import (
     SupportPlanError,
     TrainingInputs,
     candidates,
-    check_schedule_name,
     decode_json,
     decode_supports,
     schedule_context,
@@ -31,7 +30,8 @@ def _observed_support(solver):
     support, trainee, _, reliable = _read_slots_checked(solver)
     if not reliable:
         raise SupportPlanError("无法确认当前训练室协助者，请重试")
-    check_schedule_name(support, schedule_context()[0])
+    # This is the existing occupant, not necessarily the planned assistant.
+    # candidates() filters the assistants used by _stage_trainers/_follow_schedule.
     return support, trainee
 
 

--- a/arknights_mower/tests/mastery_arranging_tests.py
+++ b/arknights_mower/tests/mastery_arranging_tests.py
@@ -14,6 +14,13 @@ from arknights_mower.utils.scheduler_task import TaskTypes
 START = datetime(2026, 7, 31, 12, 0, 0)
 
 
+def setUpModule():
+    # Arrangement scenarios define their own room state; never read user schedules.
+    schedule_patch = patch.object(config_mod, "plan", {})
+    schedule_patch.start()
+    unittest.addModuleCleanup(schedule_patch.stop)
+
+
 def make_plan(**overrides):
     plan = {
         "id": 1,

--- a/arknights_mower/tests/mastery_support_fixtures.py
+++ b/arknights_mower/tests/mastery_support_fixtures.py
@@ -49,6 +49,7 @@ def database(tmp_path, monkeypatch):
 @pytest.fixture
 def context_game(game, monkeypatch):
     data, ids = game
+    monkeypatch.setattr("arknights_mower.utils.config.plan", {})
     monkeypatch.setattr(support_data, "training_data", lambda: data)
     roster = [owned(ids[n]) for n in ("能天使", "假日威龙陈", "芬", "艾丽妮", "逻各斯")]
     monkeypatch.setattr(support_data, "owned_roster", lambda: roster)

--- a/arknights_mower/tests/mastery_support_runtime_tests.py
+++ b/arknights_mower/tests/mastery_support_runtime_tests.py
@@ -59,6 +59,44 @@ def test_preflight_preserves_planned_reducer_without_changing_occupants(
     solver.ctap.assert_not_called()
 
 
+@pytest.mark.parametrize("follow_schedule", [False, True])
+def test_preflight_still_rejects_scheduled_assistant_in_use(
+    context_game, follow_schedule
+):
+    _, ids = context_game
+    route = support.stage_route(stat("艾丽妮", 30, True), None, StageSpec(1, 8))
+    plan = {
+        "id": 1,
+        "char_id": ids["能天使"],
+        "char_name": "能天使",
+        "target_level": 3,
+        "support_plan": {"stages": [route]},
+    }
+    # In automatic mode the planned assistant conflicts. In follow-schedule mode
+    # the planned assistant is available, but the occupant to be retained conflicts.
+    blocked_name = "逻各斯" if follow_schedule else "艾丽妮"
+    solver = MagicMock()
+    with (
+        patch.object(
+            runtime, "schedule_context", return_value=({blocked_name: {"room_3_2"}}, 0)
+        ),
+        patch.object(runtime, "save_runtime") as persist,
+        patch(
+            "arknights_mower.solvers.mastery_reader._read_slots_checked",
+            return_value=("逻各斯", "能天使", None, True),
+        ),
+        patch(
+            "arknights_mower.utils.config.conf",
+            SimpleNamespace(assistant_follows_schedule=follow_schedule),
+        ),
+    ):
+        message = "协助位跟随排班" if follow_schedule else "计划协助者已不可用"
+        with pytest.raises(support.SupportPlanError, match=message):
+            runtime.prepare_plan_supports(solver, plan, 1)
+    persist.assert_not_called()
+    solver.choose_train.assert_not_called()
+
+
 def test_waiting_collection_time_does_not_earn_five_hour_credit(context_game):
     _, ids = context_game
     route = support.stage_route(stat("艾丽妮", 30, True), None, StageSpec(2, 16, 0, 10))

--- a/arknights_mower/tests/mastery_support_start_tests.py
+++ b/arknights_mower/tests/mastery_support_start_tests.py
@@ -24,7 +24,7 @@ from arknights_mower.utils.mastery_support_types import StageSpec
 from arknights_mower.utils.scene import Scene
 
 
-def scene_solver(transient, readable):
+def scene_solver(transient, readable, support_name="艾丽妮"):
     solver = MagicMock()
     solver.recog.w, solver.recog.h = 1920, 1080
     current = [Scene.TRAIN_MAIN]
@@ -57,7 +57,7 @@ def scene_solver(transient, readable):
         assert solver.choose_train.call_count == solver.ctap.call_count == 0
         events.append("read")
         current[0] = Scene.INFRA_DETAILS if readable else Scene.TRAIN_MAIN
-        return [{"agent": "艾丽妮"}, {"agent": "能天使"}]
+        return [{"agent": support_name}, {"agent": "能天使"}]
 
     def select_skill(*args):
         assert current[0] == Scene.TRAIN_SKILL_SELECT
@@ -79,8 +79,9 @@ def scene_solver(transient, readable):
     "transient", [Scene.TRAIN_MAIN, Scene.UNKNOWN, Scene.CONNECTING]
 )
 @pytest.mark.parametrize("readable", [True, False])
+@pytest.mark.parametrize("scheduled_occupant", [False, True])
 def test_start_waits_for_main_before_real_preparation(
-    database, context_game, transient, readable
+    database, context_game, transient, readable, scheduled_occupant
 ):
     _, ids = context_game
     stage = support.stage_route(stat("艾丽妮", 30, True), None, StageSpec(1, 8))
@@ -88,8 +89,14 @@ def test_start_waits_for_main_before_real_preparation(
         ids["能天使"], 0, 3, char_name="能天使", support_plan={"stages": [stage]}
     )
     plan = db.get_plan_by_id(pid)
-    solver, events = scene_solver(transient, readable)
+    solver, events = scene_solver(
+        transient, readable, "赫默" if scheduled_occupant else "艾丽妮"
+    )
     with (
+        patch(
+            "arknights_mower.solvers.mastery_support_runtime.schedule_context",
+            return_value=({"赫默": {"room_3_2"}} if scheduled_occupant else {}, 0),
+        ),
         patch.object(mastery, "_read_train_countdown3", return_value=("failed", None)),
         patch(
             "arknights_mower.solvers.mastery_reader._read_slot_mastery_tier",

--- a/arknights_mower/tests/mastery_training_group_tests.py
+++ b/arknights_mower/tests/mastery_training_group_tests.py
@@ -1,0 +1,122 @@
+"""Do not let mastery replace occupants managed by a scheduled group."""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from arknights_mower.solvers import mastery
+from arknights_mower.utils.config.plan import PlanModel
+from arknights_mower.utils.mastery_support_data import training_room_group_error
+from arknights_mower.utils.scene import Scene
+
+
+def grouped_schedule(backup=False, index=0):
+    slots = [{"agent": "Current"}, {"agent": "Current"}]
+    slots[index] = {"agent": "赫默", "group": "训练组"}
+    table = {"train": {"plans": slots}}
+    return {
+        "default": "plan1",
+        "plan1": {} if backup else table,
+        "backup_plans": [{"name": "夜班", "plan": table}] if backup else [],
+    }
+
+
+@pytest.mark.parametrize("backup", [False, True])
+@pytest.mark.parametrize("index", [0, 1])
+@pytest.mark.parametrize("as_model", [False, True])
+def test_training_group_reports_both_slots_and_schedule_types(backup, index, as_model):
+    plan = grouped_schedule(backup, index)
+    error = training_room_group_error(PlanModel(**plan) if as_model else plan)
+    assert "赫默（组名：训练组）" in error
+    assert ("备用排班「夜班」" if backup else "主排班") in error
+
+
+@pytest.mark.parametrize(
+    "train",
+    [
+        None,
+        {"plans": []},
+        {"plans": [{"agent": "赫默", "group": ""}]},
+        {"plans": [{"agent": "Current", "group": "旧组名"}]},
+    ],
+)
+def test_unbound_training_room_allows_groups_in_other_rooms(train):
+    plan = {
+        "plan1": {
+            "train": train,
+            "room_3_2": {"plans": [{"agent": "赫默", "group": "生产组"}]},
+        }
+    }
+    assert training_room_group_error(plan) is None
+
+
+@pytest.mark.parametrize("automatic", [False, True])
+@pytest.mark.parametrize("backup", [False, True])
+def test_start_fails_before_changing_either_slot(automatic, backup):
+    plan = {
+        "id": 1,
+        "char_id": "test",
+        "char_name": "异客",
+        "skill_index": 1,
+        "skill_name": "聚焦指令",
+        "target_level": 3,
+        "support_plan": {"stages": []} if automatic else None,
+    }
+    solver = MagicMock()
+    with (
+        patch(
+            "arknights_mower.utils.config.plan", PlanModel(**grouped_schedule(backup))
+        ),
+        patch("arknights_mower.utils.mastery_db.update_plan_status") as update,
+        patch("arknights_mower.utils.email.send_message") as notify,
+    ):
+        mastery._start_new_training(solver, plan)
+    assert solver.mock_calls == []
+    update.assert_called_once()
+    assert update.call_args.args == (1, "failed")
+    assert "训练组" in update.call_args.kwargs["failed_reason"]
+    notify.assert_called_once()
+    assert "赫默" in notify.call_args.args[0]
+    assert notify.call_args.kwargs["level"] == "ERROR"
+
+
+@pytest.mark.parametrize("automatic", [False, True])
+def test_pending_swap_freezes_without_selecting_anyone_and_keeps_collection(automatic):
+    plan = {
+        "id": 1,
+        "status": "training",
+        "swap_frozen": 0,
+        "char_name": "异客",
+        "target_level": 3,
+        "support_plan": {"stages": []} if automatic else None,
+    }
+    panel = SimpleNamespace(
+        mastery_tier=2,
+        countdown_state="active",
+        countdown=datetime.now() + timedelta(hours=6),
+    )
+    solver = MagicMock()
+    solver.train_scene.return_value = Scene.TRAIN_MAIN
+    with (
+        patch("arknights_mower.utils.config.plan", PlanModel(**grouped_schedule())),
+        patch(
+            "arknights_mower.utils.config.conf",
+            SimpleNamespace(enable_mastery=True, assistant_follows_schedule=False),
+        ),
+        patch("arknights_mower.utils.mastery_db.get_active_plan", return_value=plan),
+        patch("arknights_mower.utils.mastery_db.update_plan_status") as update,
+        patch("arknights_mower.utils.mastery_db.should_notify", return_value=True),
+        patch("arknights_mower.utils.email.send_message") as notify,
+        patch.object(mastery, "read_main_panel", return_value=panel),
+        patch.object(mastery, "_schedule_collect_after_swap") as collect,
+        patch.object(mastery, "_read_slots_checked") as slots,
+    ):
+        mastery.run_swap_support(solver)
+    solver.choose_train.assert_not_called()
+    slots.assert_not_called()
+    update.assert_called_once_with(1, "training", swap_frozen=1)
+    collect.assert_called_once_with(solver, plan, tier=2)
+    notify.assert_called_once()
+    assert "训练组" in notify.call_args.args[0]

--- a/arknights_mower/utils/mastery_support_data.py
+++ b/arknights_mower/utils/mastery_support_data.py
@@ -44,6 +44,33 @@ def check_schedule_name(name, blocked):
         )
 
 
+def training_room_group_error(plan=None):
+    """Protect training-room groups declared in primary and backup schedules."""
+    if plan is None:
+        from arknights_mower.utils import config
+
+        plan = config.plan
+    if hasattr(plan, "model_dump"):
+        plan = plan.model_dump(exclude_none=True)
+    base = plan.get(plan.get("default", "plan1"), {})
+    tables = [("主排班", base)] + [
+        (f"备用排班「{p.get('name', '未命名')}」", p.get("plan", {}))
+        for p in plan.get("backup_plans", [])
+    ]
+    conflicts = []
+    for label, table in tables:
+        for slot in (table.get("train") or {}).get("plans", []):
+            name, group = slot.get("agent", ""), slot.get("group", "").strip()
+            if name not in IGNORED_NAMES and group:
+                conflicts.append(f"{label}：{name}（组名：{group}）")
+    if conflicts:
+        return (
+            f"训练室排班含绑组干员：{'；'.join(conflicts)}。"
+            "已阻止自动专精换人，请先解除训练室干员绑组后重试"
+        )
+    return None
+
+
 @lru_cache(maxsize=2)
 def _read_roster(path, mtime, size):
     with open(path, encoding="utf-8") as f:


### PR DESCRIPTION
训练室原有协助者出现在非训练室排班时，即使本次计划会换成其他教官，也会在开训前被误拦截。本次改为只读取原协助者；计划实际使用的教官，以及开启“跟随排班”后保留的教官，仍须通过排班冲突检查。

同时保护训练室绑组：主排班或备用排班的训练室任一槽位配置了绑组干员时，阻断开训并提示干员、组名及所在排班。已在训练中的计划若触发换人任务，则停止自动换人并保留收取安排。

验证：142 项相关测试通过，Ruff 检查、格式检查及 `git diff --check` 通过。覆盖原协助者冲突、实际教官冲突、训练室两个槽位、主/备用排班，以及已排换人任务的保护。
