### PR TITLE
fix(base): 排班修改后重新生成宿舍优先级

### DIFF
--- a/arknights_mower/tests/config_backup_tests.py
+++ b/arknights_mower/tests/config_backup_tests.py
@@ -71,6 +71,16 @@ def write_json(path, data):
     path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
 
 
+def test_importing_changed_plan_resets_dorm_priority(storage):
+    data = backup.export_configuration()
+    data["data"]["plan"]["conf"]["ling_xi"] = 2
+    assert config.plan.conf.ling_xi != 2
+    backup.import_configuration(data)
+    assert config.plan.conf.ling_xi == 2
+    assert config.conf.dorm_order == ""
+    assert json.loads(config.conf_path.read_text())["dorm_order"] == ""
+
+
 def test_full_round_trip_includes_optional_files_secrets_and_mastery(storage):
     config.conf.ai_key = "test-secret"
     config.conf.maa_eat_stone = True  # Not included in the web form.

--- a/arknights_mower/tests/dorm_priority_refresh_tests.py
+++ b/arknights_mower/tests/dorm_priority_refresh_tests.py
@@ -1,8 +1,10 @@
 """排班改变后重新生成优先级，历史失效床位不再阻断启动。"""
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
+import yaml
 
 from arknights_mower.utils import config
 from arknights_mower.utils.operators import Operators
@@ -105,3 +107,55 @@ def test_plan_save_clears_old_order_only_when_content_changes(saved, monkeypatch
     assert response.json["dorm_order_reset"] is False
     assert config.conf.dorm_order == ",".join(DEFAULT)
     saved.assert_called_once()
+
+
+@pytest.mark.parametrize("failed_save", ["save_plan", "save_conf"])
+def test_failed_plan_save_can_retry_dorm_order_reset(
+    monkeypatch, tmp_path, failed_save
+):
+    import server
+
+    original_plan = config.PlanModel()
+    original_order = ",".join(reversed(DEFAULT))
+    monkeypatch.setattr(config, "plan", original_plan)
+    monkeypatch.setattr(config, "conf", config.Conf(dorm_order=original_order))
+    monkeypatch.setattr(config, "plan_path", tmp_path / "plan.json")
+    monkeypatch.setattr(config, "conf_path", tmp_path / "conf.yml")
+    config.save_plan()
+    config.save_conf()
+    real_save = getattr(config, failed_save)
+
+    def fail_once():
+        nonlocal first_attempt
+        if first_attempt:
+            first_attempt = False
+            raise OSError("temporary write failure")
+        real_save()
+
+    first_attempt = True
+    monkeypatch.setattr(config, failed_save, fail_once)
+    monkeypatch.setitem(server.app.config, "PROPAGATE_EXCEPTIONS", False)
+    client = server.app.test_client()
+    payload = original_plan.model_dump(mode="json", exclude_none=True)
+    payload["conf"]["ling_xi"] = 2
+
+    response = client.post("/plan", json=payload)
+    assert response.status_code == 500
+    assert config.plan is original_plan
+    assert config.conf.dorm_order == original_order
+
+    response = client.post("/plan", json=payload)
+    assert response.status_code == 200
+    assert response.json["dorm_order_reset"] is True
+    assert config.plan.conf.ling_xi == 2
+    assert config.conf.dorm_order == ""
+    assert json.loads(config.plan_path.read_text())["conf"]["ling_xi"] == 2
+    assert yaml.safe_load(config.conf_path.read_text())["dorm_order"] == ""
+
+    config.conf.dorm_order = original_order
+    config.save_conf()
+    response = client.post("/plan", json=payload)
+    assert response.status_code == 200
+    assert response.json["dorm_order_reset"] is False
+    assert config.conf.dorm_order == original_order
+    assert yaml.safe_load(config.conf_path.read_text())["dorm_order"] == original_order

--- a/arknights_mower/tests/dorm_priority_refresh_tests.py
+++ b/arknights_mower/tests/dorm_priority_refresh_tests.py
@@ -1,0 +1,107 @@
+"""排班改变后重新生成优先级，历史失效床位不再阻断启动。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from arknights_mower.utils import config
+from arknights_mower.utils.operators import Operators
+from arknights_mower.utils.plan import Plan, PlanConfig, Room
+
+
+@pytest.fixture
+def saved(monkeypatch):
+    monkeypatch.setattr(config, "conf", config.Conf())
+    save = MagicMock()
+    monkeypatch.setattr(config, "save_conf", save)
+    return save
+
+
+def operators():
+    return Operators(
+        {
+            "default_plan": Plan(
+                {
+                    "dormitory_1": [
+                        Room(n, "", [])
+                        for n in ["冰酿", "闪灵", "至简", "Free", "Free"]
+                    ],
+                    "dormitory_2": [
+                        Room(n, "", [])
+                        for n in ["流明", "蜜莓", "Free", "Free", "Free"]
+                    ],
+                },
+                PlanConfig("", "", ""),
+            ),
+            "backup_plans": [],
+        }
+    )
+
+
+DEFAULT = [
+    "dormitory_1_3",
+    "dormitory_2_2",
+    "dormitory_1_4",
+    "dormitory_2_3",
+    "dormitory_2_4",
+]
+
+
+@pytest.mark.parametrize(
+    "old",
+    [
+        "dormitory_2_4,dormitory_1_2,dormitory_2_2,dormitory_1_4,dormitory_1_3,dormitory_2_3",
+        "dormitory_2_4",
+        "",
+    ],
+)
+def test_stale_or_empty_order_regenerates_entire_default_order(saved, old):
+    config.conf.dorm_order = old
+    op = operators()
+    assert op.init_and_validate() is None
+    assert [f"{d.position[0]}_{d.position[1]}" for d in op.dorm] == DEFAULT
+    assert config.conf.dorm_order == ",".join(DEFAULT)
+    saved.assert_called_once()
+    assert operators().init_and_validate() is None
+    saved.assert_called_once()
+
+
+def test_valid_manual_order_unchanged_until_plan_is_edited(saved):
+    order = list(reversed(DEFAULT))
+    config.conf.dorm_order = ",".join(order)
+    op = operators()
+    assert op.init_and_validate() is None
+    assert [f"{d.position[0]}_{d.position[1]}" for d in op.dorm] == order
+    saved.assert_not_called()
+
+
+def test_invalid_plan_still_rejected(saved):
+    config.conf.dorm_order = "obsolete"
+    op = operators()
+    op.plan["dormitory_1"][0] = Room("Free", "", [])
+    assert op.init_and_validate() == "宿舍必须安排2个宿管"
+    saved.assert_not_called()
+
+
+def test_plan_save_clears_old_order_only_when_content_changes(saved, monkeypatch):
+    import server
+
+    monkeypatch.setattr(config, "plan", config.PlanModel())
+    monkeypatch.setattr(config, "save_plan", MagicMock())
+    client = server.app.test_client()
+    config.conf.dorm_order = ",".join(reversed(DEFAULT))
+    payload = config.plan.model_dump(mode="json", exclude_none=True)
+    response = client.post("/plan", json=payload)
+    assert response.status_code == 200
+    assert response.json["dorm_order_reset"] is False
+    saved.assert_not_called()
+    payload["conf"]["ling_xi"] = 2
+    response = client.post("/plan", json=payload)
+    assert response.json["dorm_order_reset"] is True
+    assert config.conf.dorm_order == ""
+    saved.assert_called_once()
+    config.conf.dorm_order = ",".join(DEFAULT)
+    response = client.post("/plan", json=payload)
+    assert response.json["dorm_order_reset"] is False
+    assert config.conf.dorm_order == ",".join(DEFAULT)
+    saved.assert_called_once()

--- a/arknights_mower/utils/config_backup.py
+++ b/arknights_mower/utils/config_backup.py
@@ -243,6 +243,9 @@ def import_configuration(backup):
     with backup_lock, workshop_lock:
         conf, plan = validate_configuration(backup)
         imported_conf = _conf_for_import(backup["data"]["conf"])
+        if plan != config.plan:
+            conf.dorm_order = ""
+            imported_conf["dorm_order"] = ""
         paths = configuration_paths()
         previous = {
             name: path.read_text(encoding="utf-8") if path.exists() else None

--- a/arknights_mower/utils/operators.py
+++ b/arknights_mower/utils/operators.py
@@ -319,9 +319,12 @@ class Operators:
                         )
                     )
                 else:
-                    return (
-                        "宿舍优先级和当前宿舍不匹配，请清除优先级自动排序或者自己更正"
+                    logger.info("宿舍休息位已变化，按当前排班重新生成宿舍优先级")
+                    config.conf.dorm_order = ",".join(
+                        dorm.position[0] + "_" + str(dorm.position[1])
+                        for dorm in self.dorm
                     )
+                    config.save_conf()
         else:
             for key, value in self.shadow_copy.items():
                 if key not in self.operators:

--- a/server.py
+++ b/server.py
@@ -744,14 +744,25 @@ def load_plan_from_json():
     if request.method == "GET":
         return config.plan.model_dump(exclude_none=True)
     else:
+        from arknights_mower.utils.workshop_config import workshop_lock
+
         plan = config.PlanModel(**request.json)
-        changed = plan != config.plan
-        config.plan = plan
-        config.save_plan()
-        # 排班实际改变后丢弃旧床位顺序；相同内容的自动保存不重置手动排序。
-        if changed and config.conf.dorm_order:
-            config.conf.dorm_order = ""
-            config.save_conf()
+        with workshop_lock:
+            previous_plan = config.plan
+            previous_dorm_order = config.conf.dorm_order
+            changed = plan != previous_plan
+            config.plan = plan
+            try:
+                config.save_plan()
+                # 排班实际改变后丢弃旧床位顺序；相同内容的自动保存不重置手动排序。
+                if changed and previous_dorm_order:
+                    config.conf.dorm_order = ""
+                    config.save_conf()
+            except Exception:
+                # 任一步写盘失败都恢复比较基准，重试仍需重置并通知前端。
+                config.plan = previous_plan
+                config.conf.dorm_order = previous_dorm_order
+                raise
         return {"message": "New plan saved。", "dorm_order_reset": changed}
 
 

--- a/server.py
+++ b/server.py
@@ -744,9 +744,15 @@ def load_plan_from_json():
     if request.method == "GET":
         return config.plan.model_dump(exclude_none=True)
     else:
-        config.plan = config.PlanModel(**request.json)
+        plan = config.PlanModel(**request.json)
+        changed = plan != config.plan
+        config.plan = plan
         config.save_plan()
-        return "New plan saved。"
+        # 排班实际改变后丢弃旧床位顺序；相同内容的自动保存不重置手动排序。
+        if changed and config.conf.dorm_order:
+            config.conf.dorm_order = ""
+            config.save_conf()
+        return {"message": "New plan saved。", "dorm_order_reset": changed}
 
 
 @app.route("/operator")

--- a/ui/src/stores/configBackup.test.js
+++ b/ui/src/stores/configBackup.test.js
@@ -28,6 +28,26 @@ function setup() {
 }
 
 describe('configuration restore autosave coordination', () => {
+  it('clears the browser dorm order after a changed plan is saved', async () => {
+    const { config, plan } = setup()
+    config.dorm_order = ['dormitory_1_2']
+    axios.post.mockResolvedValueOnce({ data: { dorm_order_reset: true } })
+    await plan.save_plan()
+    expect(config.dorm_order).toEqual([])
+    config.dorm_order = ['dormitory_2_3']
+    axios.post.mockResolvedValueOnce({ data: { dorm_order_reset: false } })
+    await plan.save_plan()
+    expect(config.dorm_order).toEqual(['dormitory_2_3'])
+  })
+
+  it('preserves the browser dorm order when saving a plan fails', async () => {
+    const { config, plan } = setup()
+    config.dorm_order = ['dormitory_1_2']
+    axios.post.mockRejectedValueOnce(new Error('offline'))
+    await expect(plan.save_plan()).rejects.toThrow('offline')
+    expect(config.dorm_order).toEqual(['dormitory_1_2'])
+  })
+
   it('flushes the latest drafts then prevents old stores from overwriting restored values', async () => {
     const { config, plan, loaded } = setup()
     loaded.value = true

--- a/ui/src/stores/plan.js
+++ b/ui/src/stores/plan.js
@@ -237,10 +237,18 @@ export const usePlanStore = defineStore('plan', () => {
   let planSaveRequest = Promise.resolve()
 
   function save_plan() {
+    const configStore = useConfigStore()
     const payload = JSON.parse(JSON.stringify(build_plan()))
     planSaveRequest = planSaveRequest
       .catch(() => {})
       .then(() => axios.post(`${import.meta.env.VITE_HTTP_URL}/plan`, payload))
+      .then((response) => {
+        if (response.data?.dorm_order_reset) {
+          // 同步后端的重置，防止下一次配置自动保存又写回旧优先级。
+          configStore.dorm_order = []
+        }
+        return response
+      })
     return planSaveRequest
   }
 


### PR DESCRIPTION
#1027 为保留完整配置导入的宿舍优先级，取消了页面启动时的自动清空。排班修改后旧优先级未同步，例如原 Free 床位改为固定干员，重启仍会因“宿舍优先级和当前宿舍不匹配”阻止调度。

现在在排班内容实际修改、或完整配置导入了不同排班时，清空旧优先级，下次初始化按新排班的默认床位顺序完整生成。前端同步清空，防止随后自动保存写回旧值；重复保存相同排班不重置。历史不匹配列表也按当前排班完整重建，不沿用旧顺序，不放过宿管缺失等原有校验。

验证：130 项 Python 测试、6 项前端测试、WebUI 生产构建、Ruff 和 git diff --check 通过。覆盖排班改变/不变、完整配置导入、保存失败、旧床位失效、空优先级及重复启动不重复写盘。手机旧配置已确认存在失效床位，修正后主/备用排班 5 次校验通过；此代码的手机组件测试待当前任务结束，暂保留草稿。
