### PR TITLE
fix(mastery): 修正减半换人检查并支持分档缓冲

### DIFF
--- a/arknights_mower/solvers/mastery.py
+++ b/arknights_mower/solvers/mastery.py
@@ -22,6 +22,7 @@ from arknights_mower.solvers.mastery_reader import (
     read_main_panel,
 )
 from arknights_mower.utils.log import logger
+from arknights_mower.utils.mastery_support_types import DEFAULT_SWAP_BUFFER_MINUTES
 from arknights_mower.utils.scene import Scene
 
 ARRANGING_DEADLINE = timedelta(minutes=5)
@@ -278,10 +279,16 @@ def validate_route_supports(supports_json: str) -> str | None:
 
 def get_route_config(profession_cn: str, level: int) -> dict | None:
     from arknights_mower.utils.mastery_db import get_route, get_route_settings
+    from arknights_mower.utils.mastery_support_types import (
+        configured_swap_buffer,
+        swap_buffer_minutes,
+    )
 
     # #91 修订：central_bonus（0/5）+ 缓冲统一从全局设置行读（默认 0 / 10），自定义与
     # DEFAULT_ROUTES 回退共用同一值——旧代码 hardcode 5、conf 值被忽略。
     settings = get_route_settings()
+    configured = configured_swap_buffer(settings)
+    buffer = swap_buffer_minutes(level, configured, central=settings["central_bonus"])
     route_data = get_route(profession_cn)
     if route_data:
         parsed = json.loads(route_data["supports"])
@@ -289,7 +296,8 @@ def get_route_config(profession_cn: str, level: int) -> dict | None:
         if config_entry is not None:
             config_entry.update(
                 central_bonus=settings["central_bonus"],
-                mastery_swap_buffer=settings["mastery_swap_buffer"],
+                mastery_swap_buffer=buffer,
+                configured_swap_buffer=configured,
             )
             return config_entry
 
@@ -300,7 +308,8 @@ def get_route_config(profession_cn: str, level: int) -> dict | None:
             config_entry = dict(entry)
             config_entry.update(
                 central_bonus=settings["central_bonus"],
-                mastery_swap_buffer=settings["mastery_swap_buffer"],
+                mastery_swap_buffer=buffer,
+                configured_swap_buffer=configured,
             )
             return config_entry
     return None
@@ -335,9 +344,7 @@ def _fmt_completion_time(dt: datetime) -> str:
 
 
 def _swap_speed_totals(job_match, efficiency, central_bonus) -> tuple[float, float]:
-    """换人公式速率口径（#142 保守）：swap_total 含中枢（减半对象）、current_total 不含
-    （路线协助干员）。calc_swap_threshold / _swap_worthwhileness 共用——改口径只改一处。
-    """
+    """排期采用保守速率：当前协助者不计中枢，减半干员计入中枢。"""
     swap_total = 100 + 5 + (30 if job_match else 0) + central_bonus
     current_total = 100 + efficiency + 5
     return swap_total, current_total
@@ -348,7 +355,7 @@ def calc_swap_threshold(
     swap_job_match: bool,
     central_bonus: int,
     remaining_minutes: float,
-    buffer: int = 10,
+    buffer: int = DEFAULT_SWAP_BUFFER_MINUTES,
 ) -> tuple[bool, float]:
     """计算是否应该换入减半对象。
 
@@ -366,18 +373,16 @@ def calc_swap_threshold(
     """
     target_minutes = 300 + buffer  # 5小时 + 缓冲
 
-    # #142（用户拍板保守口径）：中枢 +5% 只给减半对象（swap_total），不给路线协助干员
-    # （current_total）。中枢加成干员（阿斯卡纶/烛煌/斩业星熊）不一定在上班，屏幕倒计时
-    # 反映实际速度而公式用固定 central_bonus——静态设置与实际对不上时，换人时机偏晚。
-    # 保守口径让换人**只早不晚**：艾丽妮累计 ≥ 5h 稳定触发下一级减半（代价是中枢真开着
-    # 时换人提前几分钟、邮件完成时间差 ~10 分钟，无害）。
+    # 排期继续保守提前；最后检查按同一中枢设置计算两边速度。
     swap_total, current_total = _swap_speed_totals(
         swap_job_match, current_efficiency, central_bonus
     )
 
     threshold = target_minutes * swap_total / current_total
 
-    real_time_after_swap = remaining_minutes * current_total / swap_total
+    real_time_after_swap = (
+        remaining_minutes * (current_total + central_bonus) / swap_total
+    )
     if real_time_after_swap < 301:
         return False, threshold
 
@@ -974,7 +979,11 @@ def _confirm_training_started(
                 if swap_time is not None:
                     route = _get_plan_route(plan, step_level)
                     swap_target = route.get("swap_target") if route else None
-                    buffer = route.get("mastery_swap_buffer", 10) if route else 10
+                    buffer = (
+                        route.get("mastery_swap_buffer", DEFAULT_SWAP_BUFFER_MINUTES)
+                        if route
+                        else DEFAULT_SWAP_BUFFER_MINUTES
+                    )
                     completion = swap_time + timedelta(minutes=300 + buffer)
                     swap_clause = (
                         f"，将于 {_fmt_completion_time(swap_time)} 换入{swap_target}"
@@ -1097,7 +1106,7 @@ def _schedule_swap_if_needed(
         return None
 
     central_bonus = route.get("central_bonus", 0)
-    buffer = route.get("mastery_swap_buffer", 10)
+    buffer = route.get("mastery_swap_buffer", DEFAULT_SWAP_BUFFER_MINUTES)
 
     remaining = (execute_time - datetime.now()).total_seconds() / 60
     should_swap, threshold = calc_swap_threshold(
@@ -1240,7 +1249,7 @@ def run_swap_support(solver):
             and panel.countdown is not None
         ):
             remaining_min = (panel.countdown - datetime.now()).total_seconds() / 60
-            buffer_min = route.get("mastery_swap_buffer", 10)
+            buffer_min = route.get("mastery_swap_buffer", DEFAULT_SWAP_BUFFER_MINUTES)
             if remaining_min < 300 + buffer_min:
                 logger.info(
                     f"[mastery] #107 协助位保护：{support_slot} 剩余不足 "
@@ -1272,7 +1281,7 @@ def run_swap_support(solver):
                         route.get("job_match", False),
                         route.get("central_bonus", 0),
                         remaining,
-                        route.get("mastery_swap_buffer", 10),
+                        route.get("mastery_swap_buffer", DEFAULT_SWAP_BUFFER_MINUTES),
                     )
                     place_swap_target = should_swap
                 if place_swap_target:
@@ -1528,7 +1537,7 @@ def _notify_swap_giveup(solver, plan):
 
 
 def _swap_worthwhileness(remaining_minutes, route) -> bool:
-    """「值不值得换」纯判定：换后真实剩余 ≥ 301 才值得（calc_swap_threshold 同式）。
+    """最后检查两边都计入中枢，预计剩余 ≥ 301 分钟才值得换人。
 
     与 calc_swap_threshold 的 real_time_after_swap 守卫一致；供 run_swap_support
     纠错/换人前用当前倒计时判定（#80：纠错不触发不该发生的减半换人）。
@@ -1538,7 +1547,9 @@ def _swap_worthwhileness(remaining_minutes, route) -> bool:
         route["efficiency"],
         route.get("central_bonus", 0),
     )
-    real_time_after_swap = remaining_minutes * current_total / swap_total
+    real_time_after_swap = (
+        remaining_minutes * (current_total + route.get("central_bonus", 0)) / swap_total
+    )
     return real_time_after_swap >= 301
 
 
@@ -1618,7 +1629,15 @@ def _get_plan_route(plan, step_level=None) -> dict | None:
         char_data = get_skill_data().get("characters", {}).get(plan["char_id"], {})
         prof_en = char_data.get("profession", "")
         prof_cn = PROF_MAP.get(prof_en, prof_en)
-        return get_route_config(prof_cn, step_level or plan["target_level"])
+        from arknights_mower.utils.mastery_support_types import route_swap_buffer
+
+        level = step_level or plan["target_level"]
+        route = get_route_config(prof_cn, level)
+        if route:
+            # Legacy plans have no verified halving record; use the longer M2
+            # margin unless inheritance is explicitly known.
+            route["mastery_swap_buffer"] = route_swap_buffer(route, level)
+        return route
     except Exception as e:
         logger.error(f"获取路线配置失败: {e}")
         return None

--- a/arknights_mower/solvers/mastery_support_runtime.py
+++ b/arknights_mower/solvers/mastery_support_runtime.py
@@ -15,6 +15,7 @@ from arknights_mower.utils.mastery_support import (
     stage_for,
     stage_route,
 )
+from arknights_mower.utils.mastery_support_types import DEFAULT_SWAP_BUFFER_MINUTES
 
 from .mastery_support_state import (
     enqueue_support_swap,
@@ -107,7 +108,10 @@ def prepare_plan_supports(solver, plan, level):
         level,
         BASE_HOURS[level] * (0.5 if carry else 1),
         central,
-        route.get("mastery_swap_buffer", 10),
+        route.get(
+            "configured_swap_buffer",
+            route.get("mastery_swap_buffer", DEFAULT_SWAP_BUFFER_MINUTES),
+        ),
         manual=route.get("manual", False),
     )
     save_runtime(plan, _prepare_stage(first, swap, spec, carry))

--- a/arknights_mower/solvers/mastery_support_state.py
+++ b/arknights_mower/solvers/mastery_support_state.py
@@ -85,7 +85,8 @@ def schedule_support_swap(solver, plan, end, level):
     target_seconds = (300 + route["mastery_swap_buffer"]) * 60
     now = datetime.now()
     left = (end - now).total_seconds()
-    if route.get("swap_halves", True) and left * current_rate / tail_rate < 301 * 60:
+    check_rate = rate(route["efficiency"], route["central_bonus"])
+    if route.get("swap_halves", True) and left * check_rate / tail_rate < 301 * 60:
         return None
     at = now + timedelta(
         seconds=max(0, left - target_seconds * tail_rate / current_rate)
@@ -133,9 +134,13 @@ def stop_support_swap(solver, plan, level, reason):
         finish_support_swap(solver, plan, level, freeze=True)
 
 
-def select_swap_support(work_seconds, current_rate, stats, settings):
-    """Return (candidate, delay_seconds). A slower alternate may need a later handoff."""
+def select_swap_support(
+    work_seconds, current_rate, stats, settings, *, schedule_rate=None
+):
+    """Validate with nominal rates, while keeping conservative handoff timing."""
     central, buffer = settings
+    schedule_rate = current_rate if schedule_rate is None else schedule_rate
+    remaining = work_seconds / current_rate
     minimum = (300 + max(1, buffer)) * 60
     for candidate in stats:
         dest_rate = rate(candidate["efficiency"], central)
@@ -144,7 +149,8 @@ def select_swap_support(work_seconds, current_rate, stats, settings):
             candidate["halves"] and available_seconds < 301 * 60
         ):
             continue
-        tail = min(available_seconds, minimum)
-        delay = max(0, (work_seconds - tail * dest_rate) / current_rate)
+        # The more permissive final check must not postpone an already-due swap.
+        # A slower alternate still uses the original conservative scheduling rate.
+        delay = max(0, remaining - minimum * dest_rate / schedule_rate)
         return candidate, delay
     return None, 0

--- a/arknights_mower/solvers/mastery_support_swap.py
+++ b/arknights_mower/solvers/mastery_support_swap.py
@@ -136,17 +136,17 @@ def _swap_candidates(execution, options):
     ]
 
 
-def _current_rate(options, support, level):
+def _current_rate(options, support, level, central=0):
     current = options.get(support, {}).get(level)
     if support and current is None:
         raise SupportPlanError("当前协助者不在可用名单中，停止自动换人")
-    # Count central acceleration only on the destination when validating a handoff.
-    return rate(current["efficiency"]) if current else 1
+    return rate(current["efficiency"], central) if current else 1
 
 
 def _apply_swap(execution, support, options, central):
     route, level = execution.route, execution.level
-    speed = _current_rate(options, support, level)
+    speed = _current_rate(options, support, level, central)
+    schedule_speed = _current_rate(options, support, level)
     stats = _swap_candidates(execution, options)
     swapping = bool(route.get("swap_target")) and level < execution.plan["target_level"]
     correcting = support != route["operator"]
@@ -158,7 +158,11 @@ def _apply_swap(execution, support, options, central):
     seconds = max(0, (panel.countdown - datetime.now()).total_seconds())
     selected, delay = (
         select_swap_support(
-            seconds * speed, speed, stats, (central, route["mastery_swap_buffer"])
+            seconds * speed,
+            speed,
+            stats,
+            (central, route["mastery_swap_buffer"]),
+            schedule_rate=schedule_speed,
         )
         if swapping
         else (None, 0)

--- a/arknights_mower/tests/mastery_db_tests.py
+++ b/arknights_mower/tests/mastery_db_tests.py
@@ -288,20 +288,44 @@ class TestMasteryDb(unittest.TestCase):
         # #91 修订：无设置行 → 中枢加成默认 0（不是 5）、缓冲默认 10
         self.assertEqual(
             get_route_settings(path=self.db_path),
-            {"central_bonus": 0, "mastery_swap_buffer": 10},
+            {
+                "central_bonus": 0,
+                "mastery_swap_buffer": 10,
+                "mastery_swap_buffers": {
+                    "no_central": 10,
+                    "central": 15,
+                    "central_unhalved_m2": 30,
+                },
+            },
         )
 
     def test_route_settings_save_and_read(self):
         save_route_settings(central_bonus=5, mastery_swap_buffer=15, path=self.db_path)
         self.assertEqual(
             get_route_settings(path=self.db_path),
-            {"central_bonus": 5, "mastery_swap_buffer": 15},
+            {
+                "central_bonus": 5,
+                "mastery_swap_buffer": 15,
+                "mastery_swap_buffers": {
+                    "no_central": 15,
+                    "central": 15,
+                    "central_unhalved_m2": 15,
+                },
+            },
         )
         # 再存回 0 也生效
         save_route_settings(central_bonus=0, mastery_swap_buffer=10, path=self.db_path)
         self.assertEqual(
             get_route_settings(path=self.db_path),
-            {"central_bonus": 0, "mastery_swap_buffer": 10},
+            {
+                "central_bonus": 0,
+                "mastery_swap_buffer": 10,
+                "mastery_swap_buffers": {
+                    "no_central": 10,
+                    "central": 10,
+                    "central_unhalved_m2": 10,
+                },
+            },
         )
 
     def test_get_all_routes_excludes_settings_row(self):

--- a/arknights_mower/tests/mastery_halving_buffer_tests.py
+++ b/arknights_mower/tests/mastery_halving_buffer_tests.py
@@ -1,0 +1,263 @@
+"""Central-aware final checks and stage-specific margins for reducer handoffs."""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from arknights_mower.solvers import mastery
+from arknights_mower.solvers import mastery_support_runtime as runtime
+from arknights_mower.solvers import mastery_support_state as state
+from arknights_mower.solvers import mastery_support_swap as swap
+from arknights_mower.tests.mastery_support_fixtures import stat
+from arknights_mower.utils import mastery_db as db
+from arknights_mower.utils.mastery_optimizer import stage_route
+from arknights_mower.utils.mastery_support_types import (
+    DEFAULT_SWAP_BUFFERS,
+    StageSpec,
+    configured_swap_buffer,
+    stage_for,
+    swap_buffer_minutes,
+)
+
+
+def test_saved_old_numeric_buffer_stays_custom_and_can_return_to_defaults(tmp_path):
+    path = str(tmp_path / "mastery.db")
+    assert configured_swap_buffer(db.get_route_settings(path)) == DEFAULT_SWAP_BUFFERS
+    # Existing installations saved only these two fields; do not reinterpret
+    # their smaller explicit values as the new automatic margin.
+    with db._conn(path) as conn:
+        conn.execute(
+            "INSERT INTO mastery_route (profession, supports, is_default) VALUES (?, ?, 0)",
+            ("__mastery_settings__", '{"central_bonus":5,"mastery_swap_buffer":5}'),
+        )
+        conn.commit()
+    settings = db.get_route_settings(path)
+    assert configured_swap_buffer(settings) == {key: 5 for key in DEFAULT_SWAP_BUFFERS}
+    custom = {"no_central": 4, "central": 7, "central_unhalved_m2": 6}
+    db.save_route_settings(5, path=path, mastery_swap_buffers=custom)
+    assert configured_swap_buffer(db.get_route_settings(path)) == custom
+
+
+@pytest.mark.parametrize("central", [0, 5])
+@pytest.mark.parametrize("configured", [None, 0, 5, 45])
+def test_legacy_routes_apply_defaults_only_when_requested(central, configured):
+    settings = {
+        "central_bonus": central,
+        "mastery_swap_buffer": 10 if configured is None else configured,
+        "mastery_swap_buffers": dict(DEFAULT_SWAP_BUFFERS)
+        if configured is None
+        else {key: configured for key in DEFAULT_SWAP_BUFFERS},
+    }
+    with (
+        patch.object(db, "get_route_settings", return_value=settings),
+        patch.object(db, "get_route", return_value=None),
+    ):
+        for level in (1, 2):
+            route = mastery.get_route_config("医疗", level)
+            expected = (
+                (10 if not central else 15 if level == 1 else 30)
+                if configured is None
+                else configured
+            )
+            assert route["mastery_swap_buffer"] == expected
+            assert route["configured_swap_buffer"] == settings["mastery_swap_buffers"]
+
+
+@pytest.mark.parametrize("central", [0, 5])
+@pytest.mark.parametrize("level,work", [(1, 8), (2, 8), (2, 16)])
+def test_preview_and_runtime_share_effective_buffer(central, level, work):
+    expected = 10 if not central else 30 if (level, work) == (2, 16) else 15
+    first, reducer = stat("教官", 60), stat("艾丽妮", 0, True)
+    route = stage_route(first, reducer, StageSpec(level, work, central))
+    assert route["mastery_swap_buffer"] == expected
+    assert route["configured_swap_buffer"] is None
+    route["working_operator"] = "教官"
+    plan = {"id": 1, "target_level": 3, "support_plan": {"stages": [route]}}
+    now = datetime(2026, 9, 12, 12)
+    end = now + timedelta(hours=work / (1.65 + central / 100))
+    with patch.object(state, "datetime") as clock:
+        clock.now.return_value = now
+        solver = SimpleNamespace(tasks=[], task=None)
+        at = state.schedule_support_swap(solver, plan, end, level)
+    assert at == end - timedelta(
+        minutes=(300 + expected) * (1.05 + central / 100) / 1.65
+    )
+    assert abs((at - now).total_seconds() - route["switch_after"] * 3600) < 1
+
+
+@pytest.mark.parametrize("configured", [0, 1, 5, 10, 45])
+@pytest.mark.parametrize("level", [1, 2])
+@pytest.mark.parametrize("central", [0, 5])
+def test_smaller_and_larger_manual_buffers_are_preserved(level, central, configured):
+    assert swap_buffer_minutes(level, configured, central=central) == configured
+
+
+@pytest.mark.parametrize("central", [0, 5])
+@pytest.mark.parametrize("inherited", [False, True])
+def test_independent_custom_buffers_follow_actual_inheritance(central, inherited):
+    configured = {"no_central": 4, "central": 7, "central_unhalved_m2": 6}
+    route = stage_route(
+        stat("教官", 60), stat("减半", 0, True), StageSpec(2, 8, central, configured)
+    )
+    plan = {
+        "support_plan": {"stages": [route]},
+        "support_runtime": {"level": 2, "half_inherited": inherited},
+    }
+    expected = 4 if not central else 7 if inherited else 6
+    assert stage_for(plan, 2)["mastery_swap_buffer"] == expected
+    assert stage_for(plan, 2)["configured_swap_buffer"] == configured
+
+
+@pytest.mark.parametrize(
+    "preview_inherited,actual_inherited", [(True, False), (False, True)]
+)
+def test_preparation_recalculates_buffer_from_observed_previous_stage(
+    preview_inherited, actual_inherited
+):
+    first, reducer = stat("教官", 60), stat("艾丽妮", 0, True)
+    planned = stage_route(
+        first, reducer, StageSpec(2, 8 if preview_inherited else 16, 5)
+    )
+    now = datetime.now()
+    previous = {
+        "level": 1,
+        "working_operator": "艾丽妮",
+        "working_halves": True,
+        "working_since": (now - timedelta(hours=6)).isoformat(),
+        "working_until": (
+            now - timedelta(minutes=5 if actual_inherited else 90)
+        ).isoformat(),
+    }
+    plan = {
+        "id": 1,
+        "char_id": "target",
+        "char_name": "学员",
+        "support_plan": {"stages": [planned]},
+        "support_runtime": previous,
+    }
+    with (
+        patch.object(
+            runtime,
+            "candidates",
+            return_value=({"教官": {2: first}, "艾丽妮": {2: reducer}}, 5),
+        ),
+        patch.object(runtime, "schedule_context", return_value=({}, 5)),
+        patch.object(runtime, "_observed_support", return_value=("艾丽妮", "学员")),
+        patch.object(
+            runtime, "_follow_schedule", side_effect=lambda trainers, *_: trainers
+        ),
+        patch.object(runtime, "save_runtime") as save,
+    ):
+        runtime.prepare_plan_supports(MagicMock(), plan, 2)
+    saved = save.call_args.args[1]
+    assert saved["half_inherited"] is actual_inherited
+    assert saved["mastery_swap_buffer"] == (15 if actual_inherited else 30)
+    assert saved["configured_swap_buffer"] is None
+    plan["support_runtime"] = saved
+    assert stage_for(plan, 2)["mastery_swap_buffer"] == saved["mastery_swap_buffer"]
+
+
+def test_logged_warfarin_countdown_passes_final_check_without_postponement():
+    route = stage_route(stat("阿", 60), stat("艾丽妮", 0, True), StageSpec(2, 8, 5))
+    execution = SimpleNamespace(
+        route=route,
+        level=2,
+        plan={"target_level": 3},
+        solver=MagicMock(),
+        handoff=MagicMock(),
+        collect=MagicMock(),
+    )
+    now = datetime(2026, 9, 12, 19, 49, 26)
+    panel = SimpleNamespace(countdown=now + timedelta(hours=3, minutes=17, seconds=13))
+    options = {"阿": {2: stat("阿", 60)}, "艾丽妮": {2: stat("艾丽妮", 0, True)}}
+    with (
+        patch.object(swap, "datetime") as clock,
+        patch.object(swap, "confirm_training_panel", return_value=panel),
+    ):
+        clock.now.return_value = now
+        swap._apply_swap(execution, "阿", options, 5)
+    selected, delay, central = execution.handoff.call_args.args
+    assert (selected["name"], delay, central) == ("艾丽妮", 0, 5)
+    execution.collect.assert_not_called()
+    legacy = {"efficiency": 60, "job_match": False, "central_bonus": 5}
+    assert mastery._swap_worthwhileness(197 + 13 / 60, legacy)
+
+
+@pytest.mark.parametrize("central", [0, 5])
+@pytest.mark.parametrize("efficiency", [30, 60, 95])
+@pytest.mark.parametrize("reducer_efficiency", [0, 30])
+@pytest.mark.parametrize("tail,allowed", [(300.5, False), (301.5, True)])
+def test_final_check_threshold_counts_same_central_bonus_on_both_sides(
+    central, efficiency, reducer_efficiency, tail, allowed
+):
+    speed = 1.05 + (efficiency + central) / 100
+    dest = 1.05 + (reducer_efficiency + central) / 100
+    remaining = tail * dest / speed
+    selected, _ = state.select_swap_support(
+        remaining * 60 * speed,
+        speed,
+        [stat("减半", reducer_efficiency, True)],
+        (central, 15),
+        schedule_rate=1.05 + efficiency / 100,
+    )
+    route = {
+        "efficiency": efficiency,
+        "central_bonus": central,
+        "job_match": bool(reducer_efficiency),
+    }
+    assert (selected is not None) is allowed
+    assert mastery._swap_worthwhileness(remaining, route) is allowed
+    assert (
+        mastery.calc_swap_threshold(
+            efficiency, bool(reducer_efficiency), central, remaining, 15
+        )[0]
+        is allowed
+    )
+
+
+@pytest.mark.parametrize("central", [0, 5])
+def test_nominal_final_check_does_not_delay_the_conservative_deadline(central):
+    speed = 1.65 + central / 100
+    dest = 1.05 + central / 100
+    remaining = 315 * dest / 1.65
+    selected, delay = state.select_swap_support(
+        remaining * 60 * speed,
+        speed,
+        [stat("减半", 0, True)],
+        (central, 15),
+        schedule_rate=1.65,
+    )
+    assert selected is not None
+    assert delay == pytest.approx(0, abs=1e-6)
+
+
+@pytest.mark.parametrize("level,work", [(1, 480), (2, 480), (2, 960)])
+@pytest.mark.parametrize("central", [0, 5])
+@pytest.mark.parametrize("reducer_efficiency", [0, 30])
+def test_default_margin_covers_five_minute_operation_estimate(
+    level, work, central, reducer_efficiency
+):
+    # Five minutes is a verification assumption, not a scheduler timeout. Use
+    # the worst central transition: absent at the initial read, then always on.
+    buffer = swap_buffer_minutes(
+        level, central=central, inherited=work == 480 and level == 2
+    )
+    for efficiency in range(30, 96):
+        first = 1.05 + efficiency / 100
+        dest = 1.05 + (reducer_efficiency + central) / 100
+        scheduled = work / first - (300 + buffer) * dest / first
+        actual_work = work - (first + central / 100) * (scheduled + 5)
+        assert actual_work / dest > 300
+
+
+def test_zero_custom_buffer_keeps_existing_one_minute_execution_margin():
+    configured = {key: 0 for key in DEFAULT_SWAP_BUFFERS}
+    route = stage_route(
+        stat("教官", 60), stat("减半", 0, True), StageSpec(2, 8, 5, configured)
+    )
+    plan = {"support_plan": {"stages": [route]}}
+    assert route["configured_swap_buffer"] == configured
+    assert route["mastery_swap_buffer"] == 1
+    assert stage_for(plan, 2)["mastery_swap_buffer"] == 1

--- a/arknights_mower/tests/mastery_handoff_formula_tests.py
+++ b/arknights_mower/tests/mastery_handoff_formula_tests.py
@@ -22,7 +22,7 @@ from arknights_mower.utils.mastery_support_types import StageSpec  # noqa: E402
 def test_conservative_swap_timing_matches_legacy_and_optimizer(central):
     now = datetime(2026, 9, 8, 17, 42)
     route = stage_route(
-        stat("缄默德克萨斯", 80), stat("逻各斯", 0, True), StageSpec(2, 8, central, 10)
+        stat("缄默德克萨斯", 80), stat("逻各斯", 0, True), StageSpec(2, 8, central)
     )
     route["working_operator"] = route["operator"]
     plan = {
@@ -32,7 +32,8 @@ def test_conservative_swap_timing_matches_legacy_and_optimizer(central):
         "support_runtime": route,
     }
     end = now + timedelta(hours=8 / (1.85 + central / 100))
-    expected = end - timedelta(minutes=310 * (1.05 + central / 100) / 1.85)
+    buffer = 15 if central else 10
+    expected = end - timedelta(minutes=(300 + buffer) * (1.05 + central / 100) / 1.85)
     with (
         patch.object(state, "datetime") as mock_now,
         patch.object(state, "enqueue_support_swap"),
@@ -46,11 +47,17 @@ def test_conservative_swap_timing_matches_legacy_and_optimizer(central):
         8 - route["switch_after"] * (1.85 + central / 100)
     ) / (1.05 + central / 100)
     assert route["hours"] == pytest.approx(expected_hours)
-    speed = swap_runtime._current_rate({"教官": {2: stat("教官", 80)}}, "教官", 2)
-    assert speed == pytest.approx(1.85)
+    speed = swap_runtime._current_rate(
+        {"教官": {2: stat("教官", 80)}}, "教官", 2, central
+    )
+    assert speed == pytest.approx(1.85 + central / 100)
     remaining = (end - at).total_seconds()
     selected, delay = swap_runtime.select_swap_support(
-        remaining * speed, speed, [stat("逻各斯", 0, True)], (central, 10)
+        remaining * speed,
+        speed,
+        [stat("逻各斯", 0, True)],
+        (central, buffer),
+        schedule_rate=1.85,
     )
     assert selected["name"] == "逻各斯"
     assert delay == pytest.approx(0, abs=1e-5)

--- a/arknights_mower/tests/mastery_view_tests.py
+++ b/arknights_mower/tests/mastery_view_tests.py
@@ -113,7 +113,30 @@ class TestMasteryRouteView(unittest.TestCase):
             json={"central_bonus": 5, "mastery_swap_buffer": 15},
         )
         self.assertEqual(response.status_code, 200)
-        save_mock.assert_called_once_with(central_bonus=5, mastery_swap_buffer=15)
+        save_mock.assert_called_once_with(
+            central_bonus=5, mastery_swap_buffer=15, mastery_swap_buffers=None
+        )
+
+    @patch("arknights_mower.views.mastery.save_route_settings")
+    def test_route_settings_post_forwards_independent_buffers(self, save_mock):
+        buffers = {"no_central": 0, "central": 5, "central_unhalved_m2": 7}
+        response = self.client.post(
+            "/mastery-route/settings",
+            json={"central_bonus": 5, "mastery_swap_buffers": buffers},
+        )
+        self.assertEqual(response.status_code, 200)
+        save_mock.assert_called_once_with(
+            central_bonus=5, mastery_swap_buffer=10, mastery_swap_buffers=buffers
+        )
+
+    @patch("arknights_mower.views.mastery.save_route_settings")
+    def test_route_settings_rejects_invalid_buffer_map(self, save_mock):
+        for buffers in ([], {"central": -1}, {"central": True}, {"unknown": 5}):
+            response = self.client.post(
+                "/mastery-route/settings", json={"mastery_swap_buffers": buffers}
+            )
+            self.assertEqual(response.status_code, 400)
+        save_mock.assert_not_called()
 
     @patch("arknights_mower.views.mastery.save_route_settings")
     def test_route_settings_post_keeps_zero_buffer(self, save_mock):
@@ -123,7 +146,9 @@ class TestMasteryRouteView(unittest.TestCase):
             json={"central_bonus": 0, "mastery_swap_buffer": 0},
         )
         self.assertEqual(response.status_code, 200)
-        save_mock.assert_called_once_with(central_bonus=0, mastery_swap_buffer=0)
+        save_mock.assert_called_once_with(
+            central_bonus=0, mastery_swap_buffer=0, mastery_swap_buffers=None
+        )
 
 
 class TestMasteryPlanView(unittest.TestCase):

--- a/arknights_mower/utils/mastery_db.py
+++ b/arknights_mower/utils/mastery_db.py
@@ -5,7 +5,13 @@ from contextlib import contextmanager
 from typing import Optional
 
 from arknights_mower.utils.log import logger
-from arknights_mower.utils.mastery_support_types import TrainingInputs, encode_supports
+from arknights_mower.utils.mastery_support_types import (
+    DEFAULT_SWAP_BUFFER_MINUTES,
+    DEFAULT_SWAP_BUFFERS,
+    TrainingInputs,
+    configured_swap_buffer,
+    encode_supports,
+)
 from arknights_mower.utils.path import get_path
 from arknights_mower.utils.skill_label import format_skill_label
 
@@ -272,7 +278,7 @@ def add_plan_checked(
                 current_level or 0,
                 target_level,
                 inputs=TrainingInputs(
-                    buffer=get_route_settings(path).get("mastery_swap_buffer", 10)
+                    buffer=configured_swap_buffer(get_route_settings(path))
                 ),
             )
         )
@@ -600,16 +606,22 @@ def save_route(
 # 全局路线设置的保留职业行（#91 修订）：中枢加成 + 换人缓冲时间，存 supports JSON。
 # 归在「路线配置」里——DB 管理删「专精路线配置」会一起清掉（回默认）；get_all_routes 排除。
 _SETTINGS_PROFESSION = "__mastery_settings__"
-_SETTINGS_DEFAULTS = {"central_bonus": 0, "mastery_swap_buffer": 10}
+_SETTINGS_DEFAULTS = {
+    "central_bonus": 0,
+    "mastery_swap_buffer": DEFAULT_SWAP_BUFFER_MINUTES,
+}
 
 
 def get_route_settings(path: Optional[str] = None) -> dict:
-    """全局路线设置：central_bonus（0/5）+ mastery_swap_buffer（分钟）。
+    """读取中枢加成及三档减半换人缓冲（分钟）。
 
-    存 `mastery_route` 保留行（_SETTINGS_PROFESSION 的 supports JSON），缺行回默认
-    (0, 10)。不再走 conf（旧 `mastery_control_center`/`mastery_swap_buffer` 已废弃）。
+    存 `mastery_route` 保留行（_SETTINGS_PROFESSION 的 supports JSON）。
+    缺行使用 10/15/30 分钟；旧版单值配置兼容应用到三档。
     """
-    defaults = dict(_SETTINGS_DEFAULTS)
+    defaults = {
+        **_SETTINGS_DEFAULTS,
+        "mastery_swap_buffers": dict(DEFAULT_SWAP_BUFFERS),
+    }
     try:
         with _conn(path) as conn:
             row = conn.execute(
@@ -623,6 +635,16 @@ def get_route_settings(path: Optional[str] = None) -> dict:
                     parsed = {}
                 if isinstance(parsed, dict):
                     defaults.update({k: parsed[k] for k in defaults if k in parsed})
+                    if isinstance(parsed.get("mastery_swap_buffers"), dict):
+                        defaults["mastery_swap_buffers"] = {
+                            **DEFAULT_SWAP_BUFFERS,
+                            **parsed["mastery_swap_buffers"],
+                        }
+                    elif "mastery_swap_buffer" in parsed:
+                        defaults["mastery_swap_buffers"] = {
+                            key: parsed["mastery_swap_buffer"]
+                            for key in DEFAULT_SWAP_BUFFERS
+                        }
     except Exception as e:
         logger.error(f"get_route_settings failed: {e}")
     return defaults
@@ -630,14 +652,21 @@ def get_route_settings(path: Optional[str] = None) -> dict:
 
 def save_route_settings(
     central_bonus: int = 0,
-    mastery_swap_buffer: int = 10,
+    mastery_swap_buffer: int = DEFAULT_SWAP_BUFFER_MINUTES,
     path: Optional[str] = None,
+    *,
+    mastery_swap_buffers: dict | None = None,
 ):
     try:
         payload = json.dumps(
             {
                 "central_bonus": int(central_bonus),
                 "mastery_swap_buffer": int(mastery_swap_buffer),
+                "mastery_swap_buffers": (
+                    {**DEFAULT_SWAP_BUFFERS, **mastery_swap_buffers}
+                    if mastery_swap_buffers is not None
+                    else {key: int(mastery_swap_buffer) for key in DEFAULT_SWAP_BUFFERS}
+                ),
             },
             ensure_ascii=False,
         )

--- a/arknights_mower/utils/mastery_optimizer.py
+++ b/arknights_mower/utils/mastery_optimizer.py
@@ -1,11 +1,16 @@
 """Pure duration calculation and bounded search for consecutive mastery stages."""
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from itertools import product
 
 from .mastery_support_data import rate
-from .mastery_support_types import BASE_HOURS, StageSpec, SupportPlanError
+from .mastery_support_types import (
+    BASE_HOURS,
+    StageSpec,
+    SupportPlanError,
+    swap_buffer_minutes,
+)
 
 
 def _duration(first, reducer, spec):
@@ -26,6 +31,14 @@ def _duration(first, reducer, spec):
 
 
 def stage_route(first, reducer, spec):
+    configured_buffer = spec.buffer
+    inherited = spec.work <= BASE_HOURS[spec.level] / 2
+    spec = replace(
+        spec,
+        buffer=swap_buffer_minutes(
+            spec.level, spec.buffer, central=spec.central, inherited=inherited
+        ),
+    )
     duration = _duration(first, reducer, spec)
     if duration is None:
         return None
@@ -40,6 +53,8 @@ def stage_route(first, reducer, spec):
         "swap_efficiency": reducer["efficiency"] if reducer else 0,
         "central_bonus": spec.central,
         "mastery_swap_buffer": max(1, spec.buffer),
+        "configured_swap_buffer": configured_buffer,
+        "half_inherited": inherited,
         "hours": hours,
         "switch_after": switch_after,
     }
@@ -75,7 +90,7 @@ def _mark_carry(route, last, carry, step):
     earned = (
         step.level < step.target
         and last["halves"]
-        and last_hours >= (300 + max(1, step.buffer)) / 60
+        and last_hours >= (300 + route["mastery_swap_buffer"]) / 60
     )
     route.update(
         activate_with=carry,

--- a/arknights_mower/utils/mastery_support_types.py
+++ b/arknights_mower/utils/mastery_support_types.py
@@ -4,9 +4,48 @@ import json
 from dataclasses import dataclass
 
 BASE_HOURS = {1: 8, 2: 16, 3: 24}
+DEFAULT_SWAP_BUFFER_MINUTES = 10
+CENTRAL_SWAP_BUFFER_MINUTES = 15
+UNHALVED_M2_SWAP_BUFFER_MINUTES = 30
+DEFAULT_SWAP_BUFFERS = {
+    "no_central": DEFAULT_SWAP_BUFFER_MINUTES,
+    "central": CENTRAL_SWAP_BUFFER_MINUTES,
+    "central_unhalved_m2": UNHALVED_M2_SWAP_BUFFER_MINUTES,
+}
 REDUCERS = ("逻各斯", "艾丽妮")
 CONTROL_TRAINERS = frozenset(("阿斯卡纶", "烛煌", "斩业星熊"))
 IGNORED_NAMES = frozenset(("", "Free", "Current"))
+
+
+def swap_buffer_minutes(level, configured=None, *, central=0, inherited=False):
+    """A full sixteen-hour M2 needs more margin for changes in central staffing."""
+    if not central:
+        key = "no_central"
+    else:
+        key = "central_unhalved_m2" if level == 2 and not inherited else "central"
+    if isinstance(configured, dict):
+        return configured.get(key, DEFAULT_SWAP_BUFFERS[key])
+    return DEFAULT_SWAP_BUFFERS[key] if configured is None else configured
+
+
+def configured_swap_buffer(settings):
+    """Old saved numeric settings remain explicit user choices."""
+    return settings.get(
+        "mastery_swap_buffers",
+        settings.get("mastery_swap_buffer", DEFAULT_SWAP_BUFFER_MINUTES),
+    )
+
+
+def route_swap_buffer(route, level=None):
+    return swap_buffer_minutes(
+        route.get("level") if level is None else level,
+        route.get(
+            "configured_swap_buffer",
+            route.get("mastery_swap_buffer", DEFAULT_SWAP_BUFFER_MINUTES),
+        ),
+        central=route.get("central_bonus", 0),
+        inherited=route.get("half_inherited", False),
+    )
 
 
 class SupportPlanError(ValueError):
@@ -22,7 +61,7 @@ class TrainingInputs:
     roster: list | None = None
     metadata: dict | None = None
     schedule: tuple | None = None
-    buffer: int = 10
+    buffer: int | dict | None = None
 
 
 @dataclass(frozen=True)
@@ -30,7 +69,7 @@ class StageSpec:
     level: int
     work: float
     central: int = 0
-    buffer: int = 10
+    buffer: int | dict | None = None
     manual: bool = False
 
 
@@ -62,6 +101,11 @@ def stage_for(plan, level):
     runtime = decode_json(plan.get("support_runtime"))
     if stage and runtime and runtime.get("level") == level:
         stage.update(runtime)
+    if stage and (
+        stage.get("configured_swap_buffer", False) is None
+        or isinstance(stage.get("configured_swap_buffer"), dict)
+    ):
+        stage["mastery_swap_buffer"] = max(1, route_swap_buffer(stage, level))
     return stage
 
 

--- a/arknights_mower/views/mastery.py
+++ b/arknights_mower/views/mastery.py
@@ -24,7 +24,10 @@ from arknights_mower.utils.mastery_db import (
 )
 from arknights_mower.utils.mastery_recommendation import get_skill_data
 from arknights_mower.utils.mastery_support_types import (
+    DEFAULT_SWAP_BUFFER_MINUTES,
+    DEFAULT_SWAP_BUFFERS,
     TrainingInputs,
+    configured_swap_buffer,
     decode_json,
     decode_supports,
 )
@@ -452,7 +455,7 @@ class MasteryRouteView(MethodView):
                     inputs=TrainingInputs(
                         roster=roster,
                         metadata=metadata,
-                        buffer=settings["mastery_swap_buffer"],
+                        buffer=configured_swap_buffer(settings),
                     ),
                 )
             )
@@ -540,9 +543,21 @@ class MasteryRouteSettingsView(MethodView):
 
     def post(self):
         data = request.json or {}
+        buffers = data.get("mastery_swap_buffers")
+        if buffers is not None and (
+            not isinstance(buffers, dict)
+            or any(
+                key not in DEFAULT_SWAP_BUFFERS or type(value) is not int or value < 0
+                for key, value in buffers.items()
+            )
+        ):
+            return {"error": "换人缓冲时间必须为非负整数"}, 400
         save_route_settings(
             central_bonus=int(data.get("central_bonus", 0)),
-            mastery_swap_buffer=int(data.get("mastery_swap_buffer", 10)),
+            mastery_swap_buffer=int(
+                data.get("mastery_swap_buffer", DEFAULT_SWAP_BUFFER_MINUTES)
+            ),
+            mastery_swap_buffers=buffers,
         )
         return {"status": "ok"}
 

--- a/ui/src/pages/MasteryRecommendation.vue
+++ b/ui/src/pages/MasteryRecommendation.vue
@@ -353,15 +353,36 @@
         </n-text>
       </div>
       <n-text depth="2" style="margin-top: 10px">减半换人缓冲时间（分钟）</n-text>
-      <mower-input-number
-        v-model:value="masterySettings.mastery_swap_buffer"
-        :min="0"
-        :max="60"
-        size="small"
-        style="width: 120px; margin-top: 4px"
-      />
+      <div
+        v-for="item in masteryBufferFields"
+        :key="item.key"
+        style="
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+          margin-top: 8px;
+        "
+      >
+        <n-text depth="2">{{ item.label }}</n-text>
+        <mower-input-number
+          :value="masterySettings.mastery_swap_buffers[item.key]"
+          @update:value="
+            (value) =>
+              (masterySettings.mastery_swap_buffers[item.key] =
+                value ?? DEFAULT_MASTERY_SWAP_BUFFERS[item.key])
+          "
+          :min="0"
+          :max="60"
+          clearable
+          size="small"
+          style="width: 120px; flex-shrink: 0"
+        />
+      </div>
       <n-text depth="3" style="font-size: 11px; margin-top: 2px">
-        减半对象需在位时间 = 5小时 + 缓冲时间，缓冲越大越保守
+        默认{{
+          autoCentralBonus ? '分别为 15、30' : '为 10'
+        }}分钟，可自行调整；清空单项恢复该项默认值。
       </n-text>
       <template #footer>
         <n-space justify="end" align="center">
@@ -650,7 +671,9 @@ import {
   buildMasteryRoutePayload,
   prepareMasteryRoutes,
   completeMasterySupports,
-  syncMasteryRouteDefaults
+  syncMasteryRouteDefaults,
+  DEFAULT_MASTERY_SWAP_BUFFERS,
+  normalizeMasterySwapBuffers
 } from '@/utils/masteryRoute'
 import { render_op_label } from '@/utils/op_select'
 import { masteryLevelLabel } from '@/utils/masteryLevel'
@@ -1243,7 +1266,18 @@ const level_list = [
   { value: 3, label: '专三' }
 ]
 // 全局路线设置（#91 修订）：中枢加成（0/5）+ 换人缓冲时间，存路线配置设置行，不走 conf。
-const masterySettings = reactive({ central_bonus: 0, mastery_swap_buffer: 10 })
+const masterySettings = reactive({
+  central_bonus: 0,
+  mastery_swap_buffers: { ...DEFAULT_MASTERY_SWAP_BUFFERS }
+})
+const masteryBufferFields = computed(() =>
+  autoCentralBonus.value
+    ? [
+        { key: 'central', label: '中枢加成 +5%' },
+        { key: 'central_unhalved_m2', label: '中枢加成 +5%，专二未继承减半' }
+      ]
+    : [{ key: 'no_central', label: '无中枢加成' }]
+)
 
 const defaultsCache = ref(null)
 const bestTrainers = ref({})
@@ -1313,7 +1347,7 @@ for (const profession of profKeys) {
 
 // #115：modal 级中枢加成/缓冲与逐职业路线同源走草稿语义——改了不保存关掉要还原
 watch(
-  () => [masterySettings.central_bonus, masterySettings.mastery_swap_buffer],
+  () => [masterySettings.central_bonus, ...Object.values(masterySettings.mastery_swap_buffers)],
   () => {
     if (_autoSaveReady) _dirtyMasterySettings = true
   }
@@ -1340,7 +1374,7 @@ async function loadRoute() {
   const settings = r.data?.settings || {}
   _autoSaveReady = false
   masterySettings.central_bonus = settings.central_bonus ?? 0
-  masterySettings.mastery_swap_buffer = settings.mastery_swap_buffer ?? 10
+  masterySettings.mastery_swap_buffers = normalizeMasterySwapBuffers(settings)
   bestTrainers.value = r.data?.best_trainers || {}
   defaultsError.value = r.data?.defaults_error || ''
   const { routes: merged, suggestedProfessions } = prepareMasteryRoutes(
@@ -1391,7 +1425,7 @@ async function saveRouteAndClose() {
       flushRouteSettings(),
       axios.post(`${import.meta.env.VITE_HTTP_URL}/mastery-route/settings`, {
         central_bonus: autoCentralBonus.value,
-        mastery_swap_buffer: masterySettings.mastery_swap_buffer
+        mastery_swap_buffers: { ...masterySettings.mastery_swap_buffers }
       })
     ])
     _dirtyMasterySettings = false // 已落库，关弹窗不再触发「未保存还原」

--- a/ui/src/utils/masteryRoute.js
+++ b/ui/src/utils/masteryRoute.js
@@ -1,3 +1,20 @@
+export const DEFAULT_MASTERY_SWAP_BUFFERS = Object.freeze({
+  no_central: 10,
+  central: 15,
+  central_unhalved_m2: 30
+})
+
+export function normalizeMasterySwapBuffers(settings = {}) {
+  const configured = settings.mastery_swap_buffers
+  const legacy = settings.mastery_swap_buffer
+  return Object.fromEntries(
+    Object.entries(DEFAULT_MASTERY_SWAP_BUFFERS).map(([key, fallback]) => {
+      const value = configured && typeof configured === 'object' ? configured[key] : legacy
+      return [key, Number.isInteger(value) && value >= 0 ? value : fallback]
+    })
+  )
+}
+
 function normalizeMatch(value) {
   if (value === true) return 'yes'
   if (value === false) return 'no'

--- a/ui/src/utils/masteryRoute.test.js
+++ b/ui/src/utils/masteryRoute.test.js
@@ -2,11 +2,42 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   buildMasteryRoutePayload,
+  normalizeMasterySwapBuffers,
   normalizeMasteryRouteDefaults,
   parseMasteryRoute,
   prepareMasteryRoutes,
   syncMasteryRouteDefaults
 } from './masteryRoute.js'
+
+describe('mastery handoff buffers', () => {
+  it('uses separate defaults for the three conditions', () => {
+    expect(normalizeMasterySwapBuffers()).toEqual({
+      no_central: 10,
+      central: 15,
+      central_unhalved_m2: 30
+    })
+  })
+  it('retains a smaller legacy custom value for every condition', () => {
+    expect(normalizeMasterySwapBuffers({ mastery_swap_buffer: 5 })).toEqual({
+      no_central: 5,
+      central: 5,
+      central_unhalved_m2: 5
+    })
+  })
+  it('keeps independent custom values including zero', () => {
+    const values = { no_central: 0, central: 4, central_unhalved_m2: 9 }
+    expect(
+      normalizeMasterySwapBuffers({ mastery_swap_buffers: values, mastery_swap_buffer: 10 })
+    ).toEqual(values)
+  })
+  it('fills only missing conditions with defaults', () => {
+    expect(normalizeMasterySwapBuffers({ mastery_swap_buffers: { central: 6 } })).toEqual({
+      no_central: 10,
+      central: 6,
+      central_unhalved_m2: 30
+    })
+  })
+})
 
 describe('mastery route contracts', () => {
   it('waits for roster sync before asking for fresh defaults', async () => {


### PR DESCRIPTION
修复中枢 +5% 开启时，减半换人最后检查因两边加成口径不一致而误判、取消换人的问题。最后检查对当前协助者和减半干员都计入中枢加成；换人排期保留原保守算法，检查通过不会因此推迟已经到期的换人。

减半缓冲改为三档独立配置，并按排班表自动识别的中枢加成显示对应输入框：

- 无中枢加成：默认 10 分钟。
- 有中枢 +5%：默认 15 分钟。
- 有中枢 +5%，且专二未继承减半：默认 30 分钟。

默认值不作为用户自定义值的下限；清空单项恢复该档默认。旧版单值配置兼容应用到三档，隐藏档位保留原值。开训时依据实际减半继承状态选档，避免预览与实际不一致时用错缓冲。本次不调整调度器优先级，也不加入操作预算。

验证包含旧配置兼容、分档保存、实际继承与预览不一致、换人最后检查边界及日志案例回归；已运行 Python 回归、前端测试、生产构建和代码格式检查。
