### PR TITLE
ci(android): 添加 ARM64 更新兼容检测及发行归档校验

### DIFF
--- a/.github/workflows/format-check-and-test.yml
+++ b/.github/workflows/format-check-and-test.yml
@@ -56,6 +56,7 @@ jobs:
               - 'ui/{package.json,package-lock.json,vite.config.*,copy.js,.npmrc}'
               - 'scripts/{check_*,compile_requirements,inject_version,prepare_macos_adb,prune_opencv,bundled_linux_adb,package_android,sync_android_release}.py'
               - 'scripts/tests/**'
+              - 'arknights_mower/tests/android*_tests.py'
               - '.github/{workflows,actions}/**'
             frontend:
               # Shared components and build inputs can affect update/drop flows.
@@ -147,9 +148,6 @@ jobs:
           ./venv/bin/pip install pytest
       - name: Compile all Python sources
         run: ./venv/bin/python3 -m compileall -q arknights_mower scripts
-      - name: Android host compatibility
-        # Android embeds Linux CPython; test its host contract without APK signing.
-        run: ./venv/bin/python3 -m unittest -v arknights_mower.tests.android_distribution_tests arknights_mower.tests.android_component_tests
       - name: 自动发现全部 Python 回归测试（兼容 unittest 和 pytest）
         run: ./venv/bin/python3 -m pytest -v -o faulthandler_timeout=60
 
@@ -241,3 +239,47 @@ jobs:
             arknights_mower.tests.software_update_progress_tests \
             arknights_mower.tests.process_control_tests \
             arknights_mower.tests.software_update_transaction_tests
+
+  android-compatibility:
+    name: Android update compatibility (ARM64)
+    needs: changes
+    # Android embeds Linux ARM64 CPython; this checks the host contract, not an APK.
+    # Include frontend changes because this job builds the actual update archive.
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' && (needs.changes.outputs.update != 'false' || needs.changes.outputs.frontend != 'false') }}
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    env:
+      MOWER_DATA_DIR: ${{ github.workspace }}/.cache/android-tests
+      PYTHONIOENCODING: utf-8
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - name: Install system libraries and Python dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libzbar0 libgl1 libglib2.0-0
+          python -m pip install -r requirements.txt
+          python -c "import os, platform; from pathlib import Path; assert platform.machine() == 'aarch64'; Path(os.environ['MOWER_DATA_DIR']).mkdir(parents=True, exist_ok=True)"
+      - name: Test Android update routes, official MAA assets and packaging
+        run: |
+          python -m unittest -v \
+            arknights_mower.tests.android_distribution_tests \
+            arknights_mower.tests.android_component_tests \
+            scripts.tests.android_release_tests
+      - name: Build shared WebUI
+        working-directory: ui
+        run: npm ci && npm run build
+      - name: Package and validate Android update
+        run: |
+          python scripts/inject_version.py 0.0.0-alpha.0
+          python scripts/package_android.py 0.0.0-alpha.0
+          python scripts/check_android_package.py dist/arknights-mower_0.0.0-alpha.0_android_arm64.zip --version 0.0.0-alpha.0 --revision "$(git rev-parse HEAD)"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -579,6 +579,8 @@ jobs:
         run: npm ci && npm run build
       - name: Package Mower without the Android host
         run: python scripts/package_android.py "${{ needs.prepare.outputs.version }}"
+      - name: Validate Android update archive
+        run: python scripts/check_android_package.py "dist/arknights-mower_${{ needs.prepare.outputs.version }}_android_arm64.zip" --version "${{ needs.prepare.outputs.version }}" --revision "$(git rev-parse HEAD)"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/check_android_package.py
+++ b/scripts/check_android_package.py
@@ -1,0 +1,67 @@
+"""Validate the application update archive before publishing it to Android hosts."""
+
+import argparse
+import json
+import sys
+import zipfile
+from pathlib import Path, PurePosixPath
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.package_android import REQUIRED, RUNTIME_API  # noqa: E402
+
+
+def check(package: Path, version: str, revision: str) -> None:
+    with zipfile.ZipFile(package) as archive:
+        names = archive.namelist()
+        if len(names) != len(set(names)) or archive.testzip() is not None:
+            raise ValueError("duplicate entries or damaged Android archive")
+        for name in names:
+            path = PurePosixPath(name)
+            if path.is_absolute() or ".." in path.parts or "\\" in name:
+                raise ValueError(f"unsafe archive path: {name}")
+            if name != "mower-android.json" and not name.startswith("mower/"):
+                raise ValueError(f"unexpected archive root: {name}")
+            if any(p in ("mower_android", "__pycache__", "tests") for p in path.parts):
+                raise ValueError(f"host or development files in update: {name}")
+        meta = json.loads(archive.read("mower-android.json"))
+        expected = {
+            "kind": "mower-android",
+            "format": 1,
+            "version": version,
+            "revision": revision,
+            "runtime_api": RUNTIME_API,
+            "python": "3.12",
+            "platform": "android",
+            "arch": "arm64",
+        }
+        if meta != expected:
+            raise ValueError("Android update manifest differs from expected release")
+        for name in REQUIRED:
+            if not archive.read("mower/" + name).strip():
+                raise ValueError(f"empty required file: {name}")
+        if (
+            archive.read("mower/arknights_mower/utils/git_revision").decode()
+            != revision
+        ):
+            raise ValueError("embedded revision differs from release")
+        source = archive.read("mower/arknights_mower/__init__.py").decode()
+        if f'__version__ = "{version}"' not in source:
+            raise ValueError("embedded version differs from release")
+        for name in names:
+            if name.endswith(".py"):
+                compile(archive.read(name), name, "exec")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package", type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--revision", required=True)
+    args = parser.parse_args()
+    check(args.package, args.version, args.revision)
+    print("Android update manifest, payload and Python syntax verified")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/android_release_tests.py
+++ b/scripts/tests/android_release_tests.py
@@ -9,6 +9,7 @@ import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
+from scripts.check_android_package import check
 from scripts.package_android import REQUIRED, package
 from scripts.sync_android_release import REPO, candidates, download, sync
 
@@ -183,3 +184,45 @@ class AndroidReleaseSyncTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AndroidArchiveValidationTests(unittest.TestCase):
+    def fixture(self, root, changes=None):
+        for name in REQUIRED:
+            target = root / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("payload")
+        (root / "arknights_mower/__init__.py").write_text('__version__ = "4.2.0"\n')
+        original = package(root, root / "out", "4.2.0", "a" * 40)
+        if not changes:
+            return original
+        edited = root / "edited.zip"
+        with zipfile.ZipFile(original) as source, zipfile.ZipFile(edited, "w") as dest:
+            files = {name: source.read(name) for name in source.namelist()}
+            files.update(changes)
+            for name, contents in files.items():
+                dest.writestr(name, contents)
+        return edited
+
+    def test_real_package_passes_validation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            check(self.fixture(Path(temp)), "4.2.0", "a" * 40)
+
+    def test_bad_payload_cannot_be_published(self):
+        cases = [
+            {"mower/CHANGELOG.md": " "},
+            {"mower/server.py": "def invalid("},
+            {"mower/arknights_mower/utils/git_revision": "b" * 40},
+            {"mower/arknights_mower/__init__.py": '__version__ = "4.2.1"'},
+            {"mower/mower_android/host.py": "payload"},
+            {"../outside": "payload"},
+            {"mower-android.json": "{}"},
+        ]
+        for changes in cases:
+            with (
+                self.subTest(changes=list(changes)),
+                tempfile.TemporaryDirectory() as temp,
+            ):
+                archive = self.fixture(Path(temp), changes)
+                with self.assertRaises((ValueError, SyntaxError)):
+                    check(archive, "4.2.0", "a" * 40)


### PR DESCRIPTION
Android 更新兼容检查原本只嵌在通用 Python 测试步骤中，PR 没有独立 ARM64 检测结果，正式更新包也缺少打包后的内容校验。新增 Android update compatibility (ARM64) 任务，参照桌面更新矩阵的依赖安装与改动范围控制，在 Linux ARM64 CPython 3.12 上检查 Android 宿主契约，并构建共享 WebUI 和真实 Android Mower 更新包。

更新相关路径、Android 回归、前端和 CI 改动触发任务；手动运行或范围判定失败仍执行。测试官方 Android MAA 资源选择、更新路由及发行包复用。新增归档检查器，核对 manifest、版本、提交、必需文件、非空 changelog、Python 语法及宿主文件隔离；正式发行在上传 Android 更新包前运行同一检查器。

APK 继续由 Android 仓库构建，这个任务不模拟 Android 系统权限、虚拟显示或厂商保活。

验证：本地 Android 接口/组件/打包与发行 workflow 回归 49 项通过，真实 WebUI 构建及 Android 更新包校验通过，actionlint、Ruff、格式和差异检查通过。新增 ARM64 任务已在 [GitHub CI](https://github.com/ArkMowers/arknights-mower/actions/runs/34705437236) 通过，包含真实更新包构建与校验。
