### PR TITLE
fix(base): 修复确认弹窗期间房间名单滚动无法退出

### DIFF
--- a/arknights_mower/solvers/base_schedule.py
+++ b/arknights_mower/solvers/base_schedule.py
@@ -3556,6 +3556,28 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         self.reset_room_time(room)
         raise Exception("未成功进入房间")
 
+    def scroll_room_operators(self, *, bottom):
+        """滚动房间详情名单；弹窗或滚动不生效时交回原有房间重试。"""
+        point = (1800, 930 if bottom else 138)
+        direction = -1 if bottom else 1
+        self.recog.update()
+        for attempt in range(7):
+            if self.find("confirm") or self.find("double_confirm/main"):
+                raise RecognizeError("读取房间名单时出现确认弹窗，返回场景导航处理")
+            if not self.find("room_detail"):
+                raise RecognizeError("读取房间名单时已离开房间详情，重新定位")
+            if self.get_color(point)[0] <= 51:
+                return
+            if attempt == 6:
+                break
+            self.swipe(
+                (self.recog.w * 0.8, self.recog.h * 0.5),
+                (0, direction * self.recog.h * 0.45),
+                duration=500,
+                interval=1,
+            )
+        raise RecognizeError("房间名单滚动六次仍未到达边界，返回房间重试")
+
     def get_agent_from_room(self, room, read_time_index=None):
         if read_time_index is None:
             read_time_index = []
@@ -3584,13 +3606,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         else:
             length = len(self.op_data.plan[room])
         if length > 3:
-            while self.get_color((1800, 138))[0] > 51:
-                self.swipe(
-                    (self.recog.w * 0.8, self.recog.h * 0.5),
-                    (0, self.recog.h * 0.45),
-                    duration=500,
-                    interval=1,
-                )
+            self.scroll_room_operators(bottom=False)
         name_x = (1288, 1869)
         name_y = [(135, 326), (344, 535), (553, 744), (532, 723), (741, 932)]
         name_p = [tuple(zip(name_x, y)) for y in name_y]
@@ -3605,13 +3621,7 @@ class BaseSchedulerSolver(SceneGraphSolver, BaseMixin):
         swiped = False
         for i in range(0, length):
             if i >= 3 and not swiped:
-                while self.get_color((1800, 930))[0] > 51:
-                    self.swipe(
-                        (self.recog.w * 0.8, self.recog.h * 0.5),
-                        (0, -self.recog.h * 0.45),
-                        duration=500,
-                        interval=1,
-                    )
+                self.scroll_room_operators(bottom=True)
                 swiped = True
             data = {}
             if self.find("infra_no_operator", scope=name_p[i]):

--- a/arknights_mower/tests/confirm_dialog_tests.py
+++ b/arknights_mower/tests/confirm_dialog_tests.py
@@ -1,0 +1,78 @@
+"""确认按钮不应因半透明栏后面的游戏背景不同而失去识别。"""
+
+from datetime import datetime
+from unittest.mock import Mock
+
+import cv2
+import numpy as np
+import pytest
+
+from arknights_mower.utils.image import cmatch, loadres
+from arknights_mower.utils.recognize import Recognizer
+from arknights_mower.utils.scene import Scene
+
+
+def recognizer(image):
+    result = object.__new__(Recognizer)
+    result._img = image
+    result._gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+    result.scene = Scene.UNDEFINED
+    result.last_scene = None
+    result.last_scene_time = datetime.now()
+    return result
+
+
+def sample(background=(120, 75, 30)):
+    image = np.empty((1080, 1920, 3), dtype=np.uint8)
+    image[:] = background
+    reference = loadres("confirm")
+    image[708:772, 928:992] = reference[25:89, 928:992]
+    return image
+
+
+def test_changed_backdrop_preserves_confirm_recognition():
+    image = sample()
+    assert not cmatch(image[683:797], loadres("confirm"))
+    result = recognizer(image)
+    assert result.find("confirm") == ((928, 708), (992, 772))
+    actual_find = result.find
+    result.find = lambda name, **kwargs: (
+        actual_find(name, **kwargs) if name == "confirm" else None
+    )
+    assert result.get_scene() == Scene.CONFIRM
+
+
+def test_existing_full_bar_keeps_original_scope():
+    image = np.zeros((1080, 1920, 3), dtype=np.uint8)
+    image[683:797] = loadres("confirm")
+    assert recognizer(image).find("confirm") == ((0, 683), (1920, 797))
+
+
+@pytest.mark.parametrize("kind", ["empty", "white", "circle", "shifted", "inverted"])
+def test_no_click_for_missing_or_different_icon(kind):
+    image = sample()
+    if kind == "shifted":
+        image[708:772, 1040:1104] = image[708:772, 928:992]
+    if kind == "inverted":
+        image[708:772, 928:992] = 255 - image[708:772, 928:992]
+    else:
+        image[708:772, 928:992] = 255 if kind == "white" else 0
+        if kind == "circle":
+            cv2.circle(image, (960, 738), 29, (255, 255, 255), -1)
+    assert recognizer(image).find("confirm") is None
+
+
+def test_confirmation_uses_existing_navigation_without_game_exit():
+    from arknights_mower.utils.graph import confirm
+
+    solver = Mock()
+    confirm(solver)
+    solver.tap_element.assert_called_once_with("confirm")
+    solver.device.exit.assert_not_called()
+
+
+def test_small_frame_does_not_raise():
+    assert (
+        recognizer(np.zeros((100, 100, 3), dtype=np.uint8)).find_confirm_button()
+        is None
+    )

--- a/arknights_mower/tests/room_scroll_recovery_tests.py
+++ b/arknights_mower/tests/room_scroll_recovery_tests.py
@@ -1,0 +1,72 @@
+"""断线弹窗或无效滚动不能把房间读取困在固定像素 while 循环中。"""
+
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.modules.setdefault("arknights_mower.utils.skland", Mock())
+
+from arknights_mower.solvers.base_schedule import BaseSchedulerSolver  # noqa: E402
+from arknights_mower.utils.csleep import MowerExit  # noqa: E402
+from arknights_mower.utils.recognize import RecognizeError  # noqa: E402
+
+
+def solver():
+    result = object.__new__(BaseSchedulerSolver)
+    result.recog = Mock(w=1920, h=1080)
+    result.find = Mock(side_effect=lambda name: name == "room_detail")
+    result.get_color = Mock(return_value=(255, 255, 255))
+    result.swipe = Mock()
+    return result
+
+
+@pytest.mark.parametrize("bottom", [False, True])
+def test_unchanged_scroll_has_bounded_room_recovery(bottom):
+    result = solver()
+    with pytest.raises(RecognizeError, match="六次"):
+        result.scroll_room_operators(bottom=bottom)
+    assert result.swipe.call_count == 6
+
+
+@pytest.mark.parametrize("dialog", ["confirm", "double_confirm/main"])
+def test_popup_interrupts_scroll_before_another_gesture(dialog):
+    result = solver()
+    result.find.side_effect = lambda name: (
+        name == "room_detail" or (result.swipe.call_count == 1 and name == dialog)
+    )
+    with pytest.raises(RecognizeError, match="确认弹窗"):
+        result.scroll_room_operators(bottom=True)
+    result.swipe.assert_called_once()
+
+
+def test_left_room_is_not_read_as_scroll_boundary():
+    result = solver()
+    result.find.return_value = None
+    result.find.side_effect = None
+    result.get_color.return_value = (0, 0, 0)
+    with pytest.raises(RecognizeError, match="离开房间"):
+        result.scroll_room_operators(bottom=True)
+    result.swipe.assert_not_called()
+
+
+def test_last_gesture_result_is_checked_before_failure():
+    result = solver()
+    result.get_color.side_effect = [(255, 255, 255)] * 6 + [(0, 0, 0)]
+    result.scroll_room_operators(bottom=True)
+    assert result.swipe.call_count == 6
+
+
+def test_already_at_boundary_does_not_swipe():
+    result = solver()
+    result.get_color.return_value = (0, 0, 0)
+    result.scroll_room_operators(bottom=False)
+    result.swipe.assert_not_called()
+
+
+def test_user_stop_is_not_converted_to_recovery():
+    result = solver()
+    result.recog.update.side_effect = MowerExit
+    with pytest.raises(MowerExit):
+        result.scroll_room_operators(bottom=True)
+    result.swipe.assert_not_called()

--- a/arknights_mower/utils/recognize.py
+++ b/arknights_mower/utils/recognize.py
@@ -849,6 +849,10 @@ class Recognizer:
                         logger.debug(f"find: {res} {scope=} {ssim=}")
                         return scope
 
+            if res == "confirm":
+                # 背景透出会改变整条按钮栏的颜色/纹理；保留原匹配，失败时
+                # 只复核固定位置的完整勾选图标，不扩大搜索区域或降低阈值。
+                return self.find_confirm_button()
             return None
 
         template_matching = {
@@ -1010,6 +1014,24 @@ class Recognizer:
         if strict and ret is None:
             raise RecognizeError(f"Can't find '{res}'")
         return ret
+
+    def find_confirm_button(self):
+        reference = loadres("confirm")
+        # 原按钮栏位于 (0, 683)，中央图标包含完整白圆、黑勾和窄边缘。
+        local_scope = ((928, 25), (992, 89))
+        scope = ((928, 708), (992, 772))
+        expected = cropimg(reference, local_scope)
+        actual = cropimg(self.img, scope)
+        if actual.shape != expected.shape or not cmatch(actual, expected):
+            return None
+        score = vision_np.ssim(
+            cv2.cvtColor(actual, cv2.COLOR_RGB2GRAY),
+            cv2.cvtColor(expected, cv2.COLOR_RGB2GRAY),
+        )
+        if score >= 0.9:
+            logger.debug(f"find: confirm foreground {scope=} {score=}")
+            return scope
+        return None
 
     def score(
         self,


### PR DESCRIPTION
房间详情名单读取用两个没有次数上限的固定像素 while 循环滚动到顶/底，过程中不检查确认弹窗或房间是否仍在前台。断线等弹窗出现后，边界像素可能始终不满足条件，排班会持续截图/滑动，无法回到原有场景恢复。

改为每次滚动前检查确认弹窗与房间详情，最多发送六次原有手势并检查最后一次结果；未到达边界或离开房间时抛出 RecognizeError，沿用调用者已有的房间重试和场景导航。保留手势距离、等待和五人房间读取顺序；用户停止立即传播，不新增关闭游戏或终止排班逻辑。

同时保留确认栏原有整条匹配，失败时用既有素材复核固定位置的完整白圆勾选图标，保持颜色检查及 0.9 SSIM 阈值。避免半透明栏背景变化导致确认按钮漏识别，不扩大搜索区域；仍使用原 Scene.CONFIRM 导航。

诊断依据：用户提供的 23:43:32 日志最后停在宿舍第三位计时读取，之后至 00:17:44 手动停止前持续截图，没有继续房间读取；代码下一步正进入第四/第五位前的无界滚动。更早 23:42 的等待超时已重启游戏，23:43:14 曾恢复基建，不能将整个问题都归为同一次未知场景。日志与无界滚动路径吻合，但没有该时刻的原始游戏截图，不能断言错误 400 的网络原因或此次按钮漏识别的具体像素原因。

验证：确认按钮、滚动中断及相关基建/宿舍/训练/设备/场景交还回归 524 项、24 项子测试通过；其中新增 17 项覆盖原确认栏、改变背景、无勾白圆、错位图标、离房、弹窗中断、最后一次滚动成功及停止传播。Ruff、格式和差异检查通过；[GitHub CI](https://github.com/ArkMowers/arknights-mower/actions/runs/34705491325) 的完整 Python 回归、识别等价性和静态检查均通过。保持草稿，尚未在用户原始故障画面/实机上验证；本 PR 不更改 Android APK。
