### PR TITLE
fix(solver): 修复场景识别缓存不刷新导致的空转

### DIFF
--- a/arknights_mower/tests/solver_tests.py
+++ b/arknights_mower/tests/solver_tests.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from arknights_mower.utils.csleep import MowerExit
+from arknights_mower.utils.scene import Scene
 from arknights_mower.utils.solver import BaseSolver
 
 
@@ -67,6 +68,47 @@ class TestTapElement(unittest.TestCase):
         result = self.solver.tap_element("confirm_blue")
         self.assertTrue(result)
         self.tap_mock.assert_called_once_with([[100, 200], [300, 400]], 0.5, 0.5, 1)
+
+
+class TestRunClearsStaleScene(unittest.TestCase):
+    """run：每圈结束清一次场景缓存，转移静默失败时不会拿陈旧场景一直空转。"""
+
+    class _StaleSceneSolver(BaseSolver):
+        """转移在陈旧场景上静默失败，画面刷新之后才认出正确场景。"""
+
+        def __init__(self, recog):
+            self.recog = recog
+            self.iterations = 0
+
+        def transition(self):
+            self.iterations += 1
+            if self.iterations > 3:
+                raise AssertionError("run 未在刷新画面后退出，仍在陈旧场景上空转")
+            if self.scene() == Scene.OPERATOR_ELIMINATE_AGENCY:
+                return None  # 找不到要点的元素，静默失败
+            return True
+
+    class _StaleRecog:
+        """get_scene 返回缓存场景，update 之后才看得到新画面。"""
+
+        def __init__(self, scene, refreshed):
+            self.scene = scene
+            self.refreshed = refreshed
+
+        def get_scene(self):
+            return self.scene
+
+        def update(self):
+            self.scene = self.refreshed
+
+        def check_current_focus(self):
+            pass
+
+    def test_stale_scene_does_not_spin_forever(self):
+        recog = self._StaleRecog(Scene.OPERATOR_ELIMINATE_AGENCY, Scene.INFRA_MAIN)
+        solver = self._StaleSceneSolver(recog)
+        self.assertTrue(solver.run())
+        self.assertEqual(solver.iterations, 2)
 
 
 if __name__ == "__main__":

--- a/arknights_mower/utils/solver.py
+++ b/arknights_mower/utils/solver.py
@@ -86,6 +86,10 @@ class BaseSolver:
                 logger.exception(e)
                 raise e
             retry_times = config.MAX_RETRYTIME
+            # transition() 既没点屏幕也没等待就返回时，缓存不会被清掉（清理写在
+            # sleep 里）。下一次 get_scene 仍返回旧场景，比如 tap_element 找不到
+            # 元素直接返回 False，while 就会一直空转下去。这里补上清理。
+            self.recog.update()
 
     @abstractmethod
     def transition(self) -> bool:


### PR DESCRIPTION
BaseSolver.run 的循环里，transition() 可能静默失败：tap_element 找不到元素时只返回 False，这一次既不点屏幕也不等待。场景识别读到场景后会一直复用这个结论，缓存只在 sleep 里的 recog.update() 时才清掉，于是 get_scene 每一圈都返回同一张旧画面的结论，循环以每秒数千次空转并连续写调试日志；空转期间 stop_mower 检查不到，停止请求要等到下一次设备操作或等待才会生效。

在 run 循环末尾补上一次 recog.update()，清掉场景缓存，下一次 get_scene 重新截图识别，循环在一两圈内恢复。正常路径上 transition() 的点屏幕与等待已经走到 sleep 清过缓存，这里只是重复清一次已经为空的缓存，截图频率与识别行为不变。用 update() 而不是 clear()，是顺带让空转期间的停止请求也生效；导航循环在 #941 已经采用同样处理。改动落在 BaseSolver.run，作战、排班、信用、招募、邮件、仓库、隐秘战线、生息演算等解算器都走这个循环，覆盖面比导航循环大——如果有哪个解算器依赖连续复用同一帧画面判断，这里会改变它的行为，现有代码里没有这种用法。

验证：solver_tests.py 8 项通过。去掉这一行时新增的 TestRunClearsStaleScene::test_stale_scene_does_not_spin_forever 失败，加回后通过；该用例用假识别器与假解算器构造陈旧场景，断言 run 在刷新画面后退出、不刷新时以断言失败结束而不是挂死。Ruff 检查与格式化检查通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
