### PR TITLE
revert(solver): 恢复 swipe_noinertia 的滑动参数

### DIFF
--- a/arknights_mower/utils/solver.py
+++ b/arknights_mower/utils/solver.py
@@ -339,26 +339,22 @@ class BaseSolver:
         self,
         start: tp.Coordinate,
         movement: tp.Coordinate,
-        duration: int = 80,
+        duration: int = 20,
         interval: float = 0.2,
     ) -> None:
-        """swipe with no inertia (movement should be vertical)。
-
-        duration 调大、偏置调小：主轴太快会甩过头弹回（画面抖动、稳定不下来），
-        回放会拿着没停稳的画面继续走而错位；改成受控拖动。
-        """
+        """swipe with no inertia (movement should be vertical)"""
         if config.stop_mower.is_set():
             raise MowerExit
         points = [start]
         if movement[0] == 0:
             dis = abs(movement[1])
-            points.append((start[0] + 40, start[1]))
-            points.append((start[0] + 40, start[1] + movement[1]))
+            points.append((start[0] + 100, start[1]))
+            points.append((start[0] + 100, start[1] + movement[1]))
             points.append((start[0], start[1] + movement[1]))
         else:
             dis = abs(movement[0])
-            points.append((start[0], start[1] + 40))
-            points.append((start[0] + movement[0], start[1] + 40))
+            points.append((start[0], start[1] + 100))
+            points.append((start[0] + movement[0], start[1] + 100))
             points.append((start[0] + movement[0], start[1]))
         self.device.swipe_ext(points, durations=[200, dis * duration // 100, 200])
         if interval > 0:


### PR DESCRIPTION
#923 为了让回放的画面停稳，把 `BaseSolver.swipe_noinertia` 的默认参数从 `duration=20`、偏置 `100` 改成了 `duration=80`、偏置 `40`。这个函数是滑动的统一入口，导航定位、基建换班、仓库识别都调用它，参数一动，全部滑动场景的手感跟着变。

这次把这组参数恢复成 #923 之前的取值：`duration` 回到 20，垂直与水平两个方向的偏置都回到 100，随参数一起加上去的那段函数说明也一并去掉。函数内部的点位分段与 `durations` 计算方式没有变，改动与 `d3e48613^` 中该函数逐行一致。

回退之后，#923 提到的画面甩过头弹回、回放拿着没停稳的画面继续走，会回到改动前的表现，这是这次回退的代价。

#923 里另一处与滑动有关的地方（回放验证阶段的定位滑动不进入录制结果）没有回退，那属于录制功能，不是滑动参数。

验证：测试里 `swipe_noinertia` 都是 mock 掉的，没有任何用例断言这组默认值，回退不需要改动测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
